### PR TITLE
fix: remove h1 titles from uref class and namespace templates

### DIFF
--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -1,0 +1,48 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<div class="markdown level0 summary">{{{summary}}}</div>
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{#inheritance.0}}
+<div class="inheritance">
+  <h5>{{__global.inheritance}}</h5>
+{{/inheritance.0}}
+{{#inheritance.0.value}}
+    {{>partials/uref/inheritance}}
+{{/inheritance.0.value}}
+{{#inheritance.0}}
+    <div class="level{{level}}"><span class="xref">{{name.0.value}}</span></div>
+</div>
+{{/inheritance.0}}
+{{#inheritedMembers.0}}
+<div class="inheritedMembers">
+  <h5>{{__global.inheritedMembers}}</h5>
+{{/inheritedMembers.0}}
+{{#inheritedMembers}}
+  <div>
+  {{#definition}}
+    <xref uid="{{definition}}" altProperty="fullName" displayProperty="name"/>
+  {{/definition}}
+  {{^definition}}
+    <xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/>
+  {{/definition}}
+  </div>
+{{/inheritedMembers}}
+{{#inheritedMembers.0}}
+</div>
+{{/inheritedMembers.0}}
+{{#namespace.0}}
+<h6><strong>{{__global.namespace}}</strong>: {{{value.specName.0.value}}}</h6>
+{{/namespace.0}}
+{{#package.0}}
+<h6><strong>{{__global.package}}</strong>: {{{value.specName.0.value}}}</h6>
+{{/package.0}}
+{{#remarks}}
+<h5 id="{{id}}_remarks"><strong>{{__global.remarks}}</strong></h5>
+<div class="markdown level0 remarks">{{{remarks}}}</div>
+{{/remarks}}
+{{#example.0}}
+<h5 id="{{id}}_examples"><strong>{{__global.examples}}</strong></h5>
+{{/example.0}}
+{{#example}}
+{{{.}}}
+{{/example}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -1,0 +1,220 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+
+<div class="markdown level0 summary">{{{summary}}}</div>
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{#package.0}}
+<h6><strong>{{__global.package}}</strong>: {{{value.specName.0.value}}}</h6>
+{{/package.0}}
+<div class="markdown level0 remarks">{{{remarks}}}</div>
+{{#children}}
+  <h3 id="{{id}}">{{>partials/namespaceSubtitle}}</h3>
+  {{^isEmbedded}}
+    {{#children}}
+      <h4><xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/></h4>
+      <section>{{{summary}}}</section>
+    {{/children}}
+  {{/isEmbedded}}
+  {{#isEmbedded}}
+    {{#children}}
+      {{^_disableContribution}}
+      {{#docurl}}
+      <span class="small pull-right mobile-hide">
+        <span class="divider">|</span>
+        <a href="{{docurl}}">{{__global.improveThisDoc}}</a>
+      </span>{{/docurl}}
+      {{#sourceurl}}
+      <span class="small pull-right mobile-hide">
+        <a href="{{sourceurl}}">{{__global.viewSource}}</a>
+      </span>{{/sourceurl}}
+      {{/_disableContribution}}
+      {{#overload}}
+      <a id="{{id}}" data-uid="{{uid}}"></a>
+      {{/overload}}
+      <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+      <div class="markdown level1 summary">{{{summary}}}</div>
+      <div class="markdown level1 conceptual">{{{conceptual}}}</div>
+      <h5 class="decalaration">{{__global.declaration}}</h5>
+      {{#syntax}}
+      <div class="codewrapper">
+        <pre><code class="lang-{{syntax.content.0.lang}} hljs">{{syntax.content.0.value}}</code></pre>
+      </div>
+      {{#parameters.0}}
+      <h5 class="parameters">{{__global.parameters}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.name}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+      {{/parameters.0}}
+      {{#parameters}}
+          <tr>
+            <td>{{{type.specName.0.value}}}</td>
+            <td><em>{{{id}}}</em></td>
+            <td>
+              {{{description}}}
+              {{>partials/uref/parameters}}
+            </td>
+          </tr>
+      {{/parameters}}
+      {{#parameters.0}}
+        </tbody>
+      </table>
+      {{/parameters.0}}
+      {{#return}}
+      <h5 class="returns">{{__global.returns}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{{value.type.0.specName.0.value}}}</td>
+            <td>{{{value.description}}}</td>
+          </tr>
+        </tbody>
+      </table>
+      {{/return}}
+      {{#typeParameters.0}}
+      <h5 class="typeParameters">{{__global.typeParameters}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.name}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+      {{/typeParameters.0}}
+      {{#typeParameters}}
+          <tr>
+            <td><em>{{{id}}}</em></td>
+            <td>{{{description}}}</td>
+          </tr>
+      {{/typeParameters}}
+      {{#typeParameters.0}}
+        </tbody>
+      </table>
+      {{/typeParameters.0}}
+      {{#fieldValue}}
+      <h5 class="fieldValue">{{__global.fieldValue}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{{value.type.0.specName.0.value}}}</td>
+            <td>{{{value.description}}}</td>
+          </tr>
+        </tbody>
+      </table>
+      {{/fieldValue}}
+      {{#propertyValue}}
+      <h5 class="propertyValue">{{__global.propertyValue}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{{value.type.0.specName.0.value}}}</td>
+            <td>{{{value.description}}}</td>
+          </tr>
+        </tbody>
+      </table>
+      {{/propertyValue}}
+      {{#eventType}}
+      <h5 class="eventType">{{__global.eventType}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.description}}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>{{{type.specName.0.value}}}</td>
+            <td>{{{description}}}</td>
+          </tr>
+        </tbody>
+      </table>
+      {{/eventType}}
+      {{/syntax}}
+      {{#overridden}}
+      <h5 class="overrides">{{__global.overrides}}</h5>
+      <div><xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+      {{/overridden}}
+      {{#implements.0}}
+      <h5 class="implements">{{__global.implements}}</h5>
+      {{/implements.0}}
+      {{#implements}}
+        {{#definition}}
+          <div><xref href="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+        {{/definition}}
+        {{^definition}}
+          <div><xref href="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/></div>
+        {{/definition}}
+      {{/implements}}
+      {{#remarks}}
+      <h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
+      <div class="markdown level1 remarks">{{{remarks}}}</div>
+      {{/remarks}}
+      {{#example.0}}
+      <h5 id="{{id}}_examples">{{__global.examples}}</h5>
+      {{/example.0}}
+      {{#example}}
+      {{{.}}}
+      {{/example}}
+      {{#exceptions.0}}
+      <h5 class="exceptions">{{__global.exceptions}}</h5>
+      <table class="table table-bordered table-striped table-condensed">
+        <thead>
+          <tr>
+            <th>{{__global.type}}</th>
+            <th>{{__global.condition}}</th>
+          </tr>
+        </thead>
+        <tbody>
+      {{/exceptions.0}}
+      {{#exceptions.0.value}}
+          <tr>
+            <td>{{{type.specName.0.value}}}</td>
+            <td>{{{description}}}</td>
+          </tr>
+      {{/exceptions.0.value}}
+      {{#exceptions.0}}
+        </tbody>
+      </table>
+      {{/exceptions.0}}
+      {{#seealso.0}}
+      <h5 id="{{id}}_seealso">{{__global.seealso}}</h5>
+      <div class="seealso">
+      {{/seealso.0}}
+      {{#seealso}}
+        {{#isCref}}
+          <div>{{{type.specName.0.value}}}</div>
+        {{/isCref}}
+        {{^isCref}}
+          <div>{{{url}}}</div>
+        {{/isCref}}
+      {{/seealso}}
+      {{#seealso.0}}
+      </div>
+      {{/seealso.0}}
+    {{/children}}
+  {{/isEmbedded}}
+{{/children}}


### PR DESCRIPTION
I found the `uref` templates were causing the issue by modifying the default template and inspecting the output.

Here are the steps I took to generate these files:

1. `docfx template export default`
2. `mkdir devsite/partials/uref`
3. `cp _exported_templates/partials/uref/class.header.tmpl.partial _exported_templates/partials/uref/namespace.tmpl.partial devsite/partials/uref/`
4. Delete the `h1` elements. They are automatically handled by Devsite.