### PR TITLE
fix: avoid template delimiter collision

### DIFF
--- a/third_party/docfx/templates/devsite/partials/head.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/head.tmpl.partial
@@ -9,8 +9,11 @@
   <meta name="generator" content="docfx {{_docfxVersion}}">
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
+  {{!Temporarily change delimiter to avoid interpreting root_path.}}
+  {{=<% %>=}}
   <meta name="project_path" value="{{ root_path }}_project.yaml" />
   <meta name="book_path" value="{{ root_path }}_book.yaml" />
+  <%={{ }}=%>
   <meta property="docfx:navrel" content="{{_navRel}}">
   <meta property="docfx:tocrel" content="{{_tocRel}}">
   {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}


### PR DESCRIPTION
Without this change, these lines render as:

```
    <meta name="project_path" value="_project.yaml">
    <meta name="book_path" value="_book.yaml">
```