### PR TITLE
fix: use project path variable

### DIFF
--- a/third_party/docfx/templates/devsite/README.md
+++ b/third_party/docfx/templates/devsite/README.md
@@ -16,7 +16,8 @@ The `docfx.json` file needs some extra config:
     "_disableSideFilter": true,
     "_disableAffix": true,
     "_disableFooter": true,
-    "_rootPath": "/dotnet/reference/dialogflow"
+    "_rootPath": "/dotnet/reference/dialogflow",
+    "_projectPath": "/dotnet/"
 },
 "template": [
     "default",

--- a/third_party/docfx/templates/devsite/partials/head.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/head.tmpl.partial
@@ -9,11 +9,8 @@
   <meta name="generator" content="docfx {{_docfxVersion}}">
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
-  {{!Temporarily change delimiter to avoid interpreting root_path.}}
-  {{=<% %>=}}
-  <meta name="project_path" value="{{ root_path }}_project.yaml" />
-  <meta name="book_path" value="{{ root_path }}_book.yaml" />
-  <%={{ }}=%>
+  <meta name="project_path" value="{{_projectPath}}_project.yaml" />
+  <meta name="book_path" value="{{_projectPath}}_book.yaml" />
   <meta property="docfx:navrel" content="{{_navRel}}">
   <meta property="docfx:tocrel" content="{{_tocRel}}">
   {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}


### PR DESCRIPTION
The pages don't include the normal template variables, so root_path is
undefined.