### PR TITLE
feat!: add constants & types, update namespace order & headers

### DIFF
--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -283,8 +283,10 @@ function getDefinitions(category) {
     "interface":    { inInterface: true,    typePropertyName: "inInterface",    id: "interfaces" },
     "enum":         { inEnum: true,         typePropertyName: "inEnum",         id: "enums" },
     "delegate":     { inDelegate: true,     typePropertyName: "inDelegate",     id: "delegates" },
-    "function":     { inFunction: true,     typePropertyName: "inFunction",     id: "functions",    isEmbedded: true },
+    "const":        { inConst: true,        typePropertyName: "inConst",        id: "consts",       isEmbedded: true },
     "variable":     { inVariable: true,     typePropertyName: "inVariable",     id: "variables",    isEmbedded: true },
+    "type":         { inTypes: true,        typePropertyName: "inTypes",        id: "types",        isEmbedded: true },
+    "function":     { inFunction: true,     typePropertyName: "inFunction",     id: "functions",    isEmbedded: true },
     "typealias":    { inTypeAlias: true,    typePropertyName: "inTypeAlias",    id: "typealiases",  isEmbedded: true },
   };
   var classItems = {
@@ -298,7 +300,7 @@ function getDefinitions(category) {
     "member":       { inMember: true,       typePropertyName: "inMember",       id: "members"},
     "function":     { inFunction: true,     typePropertyName: "inFunction",     id: "functions" }
   };
-  if (category === 'class') {
+  if (category === 'class' || category === 'type') {
     return classItems;
   }
   if (category === 'ns') {

--- a/third_party/docfx/templates/devsite/partials/namespaceSubtitle.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/namespaceSubtitle.tmpl.partial
@@ -28,3 +28,10 @@
 {{#inTypeAlias}}
 {{__global.typeAliasesInSubtitle}}
 {{/inTypeAlias}}
+
+{{#inTypes}}
+{{__global.typesInSubtitle}}
+{{/inTypes}}
+{{#inConst}}
+{{__global.constsInSubtitle}}
+{{/inConst}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -7,10 +7,10 @@
 {{/package.0}}
 <div class="markdown level0 remarks">{{{remarks}}}</div>
 {{#children}}
-  <h3 id="{{id}}">{{>partials/namespaceSubtitle}}</h3>
+  <h2 id="{{id}}">{{>partials/namespaceSubtitle}}</h2>
   {{^isEmbedded}}
     {{#children}}
-      <h4><xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/></h4>
+      <h3><xref uid="{{uid}}" altProperty="fullName" displayProperty="name"/></h3>
       <section>{{{summary}}}</section>
     {{/children}}
   {{/isEmbedded}}
@@ -30,11 +30,11 @@
       {{#overload}}
       <a id="{{id}}" data-uid="{{uid}}"></a>
       {{/overload}}
-      <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+      <h3 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h3>
       <div class="markdown level1 summary">{{{summary}}}</div>
       <div class="markdown level1 conceptual">{{{conceptual}}}</div>
-      <h5 class="decalaration">{{__global.declaration}}</h5>
       {{#syntax}}
+      <h5 class="decalaration">{{__global.declaration}}</h5>
       <div class="codewrapper">
         <pre><code class="lang-{{syntax.content.0.lang}} hljs">{{syntax.content.0.value}}</code></pre>
       </div>

--- a/third_party/docfx/templates/devsite/token.json
+++ b/third_party/docfx/templates/devsite/token.json
@@ -1,4 +1,7 @@
 {
+  "typesInSubtitle": "Types",
+  "constsInSubtitle": "Constants",
+
   "namespacesInSubtitle": "Namespaces",
   "classesInSubtitle": "Classes",
   "structsInSubtitle": "Structs",


### PR DESCRIPTION
These updates (especially `type` and `constant`) will be used for Go.

I _think_ reordering the namespace sections is OK for other languages? I adjusted it a bit to make it match pkg.go.dev for Go.