### PR TITLE
feat: support Go types with methods/functions/consts/vars

### DIFF
--- a/testdata/go/obj/api/docs.metadata
+++ b/testdata/go/obj/api/docs.metadata
@@ -1,6 +1,6 @@
 update_time {
-  seconds: 1600449129
-  nanos: 590872326
+  seconds: 1600974930
+  nanos: 453023776
 }
 name: "cloud.google.com/go/storage"
 version: "v1.11.0"

--- a/testdata/go/obj/api/index.yml
+++ b/testdata/go/obj/api/index.yml
@@ -237,7 +237,7 @@ items:
   summary: |
     Delete permanently deletes the ACL entry for the given entity.
   parent: cloud.google.com/go/storage.ACLHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -251,7 +251,7 @@ items:
   summary: |
     List retrieves ACL entries.
   parent: cloud.google.com/go/storage.ACLHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -265,7 +265,7 @@ items:
   summary: |
     Set sets the role for the given entity.
   parent: cloud.google.com/go/storage.ACLHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -335,7 +335,7 @@ items:
     DeleteLabel causes a label to be deleted when ua is used in a
     call to Bucket.Update.
   parent: cloud.google.com/go/storage.BucketAttrsToUpdate
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -348,7 +348,7 @@ items:
     SetLabel causes a label to be added or modified when ua is used
     in a call to Bucket.Update.
   parent: cloud.google.com/go/storage.BucketAttrsToUpdate
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -401,7 +401,7 @@ items:
     This controls who can list, create or overwrite the objects in a bucket.
     This call does not perform any network operations.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -415,7 +415,7 @@ items:
     and PayloadFormat, and must not set its ID. The other fields are all optional. The
     returned Notification's ID can be used to refer to it.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -429,7 +429,7 @@ items:
   summary: |
     Attrs returns the metadata for the bucket.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -444,7 +444,7 @@ items:
     Create creates the Bucket in the project.
     If attrs is nil the API defaults will be used.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -460,7 +460,7 @@ items:
     These ACLs are applied to newly created objects in this bucket that do not have a defined ACL.
     This call does not perform any network operations.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -472,7 +472,7 @@ items:
   summary: |
     Delete deletes the Bucket.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -486,7 +486,7 @@ items:
   summary: |
     DeleteNotification deletes the notification with the given ID.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -500,7 +500,7 @@ items:
   summary: |
     IAM provides access to IAM access control for the bucket.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -516,7 +516,7 @@ items:
     satisfied. The only valid preconditions for buckets are MetagenerationMatch
     and MetagenerationNotMatch.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -536,7 +536,7 @@ items:
     most customers. It might be changed in backwards-incompatible ways and is not
     subject to any SLA or deprecation policy.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -551,7 +551,7 @@ items:
     Notifications returns all the Notifications configured for this bucket, as a map
     indexed by notification ID.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -570,7 +570,7 @@ items:
     for valid object names can be found at:
       https://cloud.google.com/storage/docs/bucket-naming
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -585,7 +585,7 @@ items:
 
     Note: The returned iterator is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -599,7 +599,7 @@ items:
   summary: |
     Update updates a bucket's attributes.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -619,7 +619,7 @@ items:
 
     A user project is required for all operations on Requester Pays buckets.
   parent: cloud.google.com/go/storage.BucketHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -648,7 +648,7 @@ items:
 
     Note: This method is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.BucketIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -664,7 +664,7 @@ items:
 
     Note: This method is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.BucketIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -766,7 +766,7 @@ items:
     found at:
       https://cloud.google.com/storage/docs/bucket-naming
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -783,7 +783,7 @@ items:
 
     Note: The returned iterator is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -799,7 +799,7 @@ items:
 
     Close need not be called at program exit.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -813,7 +813,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -829,7 +829,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -845,7 +845,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -863,7 +863,7 @@ items:
   summary: |
     ServiceAccount fetches the email address of the given project's Google Cloud Storage service account.
   parent: cloud.google.com/go/storage.Client
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -888,7 +888,7 @@ items:
   summary: |
     Run performs the compose operation.
   parent: cloud.google.com/go/storage.Composer
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -930,7 +930,7 @@ items:
   summary: |
     Run performs the copy.
   parent: cloud.google.com/go/storage.Copier
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -992,7 +992,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.HMACKeyHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1012,7 +1012,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.HMACKeyHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1028,7 +1028,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.HMACKeyHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1125,7 +1125,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.HMACKeysIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1141,7 +1141,7 @@ items:
 
     This method is EXPERIMENTAL and subject to change or removal without notice.
   parent: cloud.google.com/go/storage.HMACKeysIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1306,7 +1306,7 @@ items:
     This controls who can read and write this object.
     This call does not perform any network operations.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1319,7 +1319,7 @@ items:
     Attrs returns meta information about the object.
     ErrObjectNotExist will be returned if the object is not found.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1335,7 +1335,7 @@ items:
   summary: |
     BucketName returns the name of the bucket.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1353,7 +1353,7 @@ items:
     source objects and encrypt the destination object. It is an error
     to specify an encryption key for any of the source objects.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1370,7 +1370,7 @@ items:
     For Requester Pays buckets, the user project of dst is billed, unless it is empty,
     in which case the user project of src is billed.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1385,7 +1385,7 @@ items:
   summary: |
     Delete deletes the single specified object.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1403,7 +1403,7 @@ items:
     all operations work when given a specific generation; check the API
     endpoints at https://cloud.google.com/storage/docs/json_api/ for details.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1421,7 +1421,7 @@ items:
     satisfied. See https://cloud.google.com/storage/docs/generations-preconditions
     for more details.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1439,7 +1439,7 @@ items:
     Encryption key must be a 32-byte AES-256 key.
     See https://cloud.google.com/storage/docs/encryption for details.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1462,7 +1462,7 @@ items:
     that file will be served back whole, regardless of the requested range as
     Google Cloud Storage dictates.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1484,7 +1484,7 @@ items:
 
     The caller must call Close on the returned Reader when done reading.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1512,7 +1512,7 @@ items:
     It is the caller's responsibility to call Close when writing is done. To
     stop writing without saving the data, cancel the context.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1526,7 +1526,7 @@ items:
   summary: |
     ObjectName returns the name of the object.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1538,7 +1538,7 @@ items:
   summary: |
     ReadCompressed when true causes the read to happen without decompressing.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1552,7 +1552,7 @@ items:
     All zero-value attributes are ignored.
     ErrObjectNotExist will be returned if the object is not found.
   parent: cloud.google.com/go/storage.ObjectHandle
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1587,7 +1587,7 @@ items:
 
     Note: This method is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.ObjectIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1603,7 +1603,7 @@ items:
 
     Note: This method is not safe for concurrent operations without explicit synchronization.
   parent: cloud.google.com/go/storage.ObjectIterator
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1731,7 +1731,7 @@ items:
     optimization; for more information, see
     https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance
   parent: cloud.google.com/go/storage.Query
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1761,7 +1761,7 @@ items:
 
     Deprecated: use Reader.Attrs.CacheControl.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1773,7 +1773,7 @@ items:
   summary: |
     Close closes the Reader. It must be called when done reading.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1787,7 +1787,7 @@ items:
 
     Deprecated: use Reader.Attrs.ContentEncoding.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1801,7 +1801,7 @@ items:
 
     Deprecated: use Reader.Attrs.ContentType.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1815,7 +1815,7 @@ items:
 
     Deprecated: use Reader.Attrs.LastModified.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1825,7 +1825,7 @@ items:
     func (*Reader) Read
   id: Read
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1837,7 +1837,7 @@ items:
   summary: |
     Remain returns the number of bytes left to read, or -1 if unknown.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -1853,7 +1853,7 @@ items:
 
     Deprecated: use Reader.Attrs.Size.
   parent: cloud.google.com/go/storage.Reader
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -2015,7 +2015,7 @@ items:
     Attrs returns metadata about a successfully-written object.
     It's only valid to call it after Close returns nil.
   parent: cloud.google.com/go/storage.Writer
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -2029,7 +2029,7 @@ items:
     If Close doesn't return an error, metadata about the written object
     can be retrieved by calling Attrs.
   parent: cloud.google.com/go/storage.Writer
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -2044,7 +2044,7 @@ items:
 
     Deprecated: cancel the context passed to NewWriter instead.
   parent: cloud.google.com/go/storage.Writer
-  type: function
+  type: method
   langs:
   - go
   syntax:
@@ -2064,7 +2064,7 @@ items:
     Writes will be retried on transient errors from the server, unless
     Writer.ChunkSize has been set to zero.
   parent: cloud.google.com/go/storage.Writer
-  type: function
+  type: method
   langs:
   - go
   syntax:

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -208,6 +208,7 @@ These errors can be introspected for more information by type asserting to the r
 	SetStorageClassAction = &quot;SetStorageClass&quot;
 )</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload">NoPayload, JSONPayload</h3>
         <div class="markdown level1 summary"><p>Values for Notification.PayloadFormat.</p>
 </div>
@@ -222,6 +223,7 @@ These errors can be introspected for more information by type asserting to the r
 	JSONPayload = &quot;JSON_API_V1&quot;
 )</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
         <div class="markdown level1 summary"><p>Values for Notification.EventTypes.</p>
 </div>
@@ -243,6 +245,7 @@ These errors can be introspected for more information by type asserting to the r
 	ObjectArchiveEvent = &quot;OBJECT_ARCHIVE&quot;
 )</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
         <div class="markdown level1 summary"></div>
         <div class="markdown level1 conceptual"></div>
@@ -262,78 +265,7 @@ These errors can be introspected for more information by type asserting to the r
 	ScopeReadWrite = raw.DevstorageReadWriteScope
 )</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers">AllUsers, AllAuthenticatedUsers</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">const (
-	AllUsers              ACLEntity = &quot;allUsers&quot;
-	AllAuthenticatedUsers ACLEntity = &quot;allAuthenticatedUsers&quot;
-)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter">RoleOwner, RoleReader, RoleWriter</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">const (
-	RoleOwner  ACLRole = &quot;OWNER&quot;
-	RoleReader ACLRole = &quot;READER&quot;
-	RoleWriter ACLRole = &quot;WRITER&quot;
-)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted">Active, Inactive, Deleted</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">const (
-	// Active is the status for an active key that can be used to sign
-	// requests.
-	Active HMACState = &quot;ACTIVE&quot;
-
-	// Inactive is the status for an inactive key thus requests signed by
-	// this key will be denied.
-	Inactive HMACState = &quot;INACTIVE&quot;
-
-	// Deleted is the status for a key that is deleted.
-	// Once in this state the key cannot key cannot be recovered
-	// and does not count towards key limits. Deleted keys will be cleaned
-	// up later.
-	Deleted HMACState = &quot;DELETED&quot;
-)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived">LiveAndArchived, Live, Archived</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">const (
-	// LiveAndArchived includes both live and archived objects.
-	LiveAndArchived Liveness = iota
-	// Live specifies that the object is still live.
-	Live
-	// Archived specifies that the object is archived.
-	Archived
-)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">const (
-	// SigningSchemeDefault is presently V2 and will change to V4 in the future.
-	SigningSchemeDefault SigningScheme = iota
-
-	// SigningSchemeV2 uses the V2 scheme to sign URLs.
-	SigningSchemeV2
-
-	// SigningSchemeV4 uses the V4 scheme to sign URLs.
-	SigningSchemeV4
-)</code></pre>
-        </div>
+        
     <h2 id="variables">Variables
   
   </h2>
@@ -349,6 +281,7 @@ These errors can be introspected for more information by type asserting to the r
 	ErrObjectNotExist = errors.New(&quot;storage: object doesn't exist&quot;)
 )</code></pre>
         </div>
+        
     <h2 id="types">
   Types
   </h2>
@@ -365,7 +298,18 @@ They are sometimes referred to as grantees.</p>
         <div class="codewrapper">
           <pre><code class="lang-go hljs">type ACLEntity string</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle">ACLHandle</h3>
+        
+            <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers">AllUsers, AllAuthenticatedUsers</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">const (
+	AllUsers              ACLEntity = &quot;allUsers&quot;
+	AllAuthenticatedUsers ACLEntity = &quot;allAuthenticatedUsers&quot;
+)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle">ACLHandle</h3>
         <div class="markdown level1 summary"><p>ACLHandle provides operations on an access control list for a Google Cloud Storage bucket or object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
@@ -375,6 +319,104 @@ They are sometimes referred to as grantees.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete">func (*ACLHandle) Delete
+</h4>
+            <div class="markdown level1 summary"><p>Delete permanently deletes the ACL entry for the given entity.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (a *ACLHandle) Delete(ctx context.Context, entity ACLEntity) (err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ACLHandle_Delete_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// No longer grant access to the bucket to everyone on the Internet.
+	if err := client.Bucket(&quot;my-bucket&quot;).ACL().Delete(ctx, storage.AllUsers); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List">func (*ACLHandle) List
+</h4>
+            <div class="markdown level1 summary"><p>List retrieves ACL entries.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (a *ACLHandle) List(ctx context.Context) (rules []ACLRule, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ACLHandle_List_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// List the default object ACLs for my-bucket.
+	aclRules, err := client.Bucket(&quot;my-bucket&quot;).DefaultObjectACL().List(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(aclRules)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set">func (*ACLHandle) Set
+</h4>
+            <div class="markdown level1 summary"><p>Set sets the role for the given entity.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (a *ACLHandle) Set(ctx context.Context, entity ACLEntity, role ACLRole) (err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ACLHandle_Set_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Let any authenticated user read my-bucket/my-object.
+	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
+	if err := obj.ACL().Set(ctx, storage.AllAuthenticatedUsers, storage.RoleReader); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole">ACLRole</h3>
         <div class="markdown level1 summary"><p>ACLRole is the level of access to grant.</p>
 </div>
@@ -383,7 +425,19 @@ They are sometimes referred to as grantees.</p>
         <div class="codewrapper">
           <pre><code class="lang-go hljs">type ACLRole string</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule">ACLRule</h3>
+        
+            <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter">RoleOwner, RoleReader, RoleWriter</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">const (
+	RoleOwner  ACLRole = &quot;OWNER&quot;
+	RoleReader ACLRole = &quot;READER&quot;
+	RoleWriter ACLRole = &quot;WRITER&quot;
+)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule">ACLRule</h3>
         <div class="markdown level1 summary"><p>ACLRule represents a grant for a role to an entity (user, group or team) for a
 Google Cloud Storage object or bucket.</p>
 </div>
@@ -399,6 +453,7 @@ Google Cloud Storage object or bucket.</p>
 	ProjectTeam *ProjectTeam
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs">BucketAttrs</h3>
         <div class="markdown level1 summary"><p>BucketAttrs represents the metadata for a Google Cloud Storage bucket.
 Read-only fields are ignored by BucketHandle.Create.</p>
@@ -513,6 +568,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	LocationType string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate">BucketAttrsToUpdate</h3>
         <div class="markdown level1 summary"><p>BucketAttrsToUpdate define the attributes to update during an Update call.</p>
 </div>
@@ -580,7 +636,28 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions">BucketConditions</h3>
+        
+            <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel">func (*BucketAttrsToUpdate) DeleteLabel
+</h4>
+            <div class="markdown level1 summary"><p>DeleteLabel causes a label to be deleted when ua is used in a
+call to Bucket.Update.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (ua *BucketAttrsToUpdate) DeleteLabel(name string)</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel">func (*BucketAttrsToUpdate) SetLabel
+</h4>
+            <div class="markdown level1 summary"><p>SetLabel causes a label to be added or modified when ua is used
+in a call to Bucket.Update.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (ua *BucketAttrsToUpdate) SetLabel(name, value string)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions">BucketConditions</h3>
         <div class="markdown level1 summary"><p>BucketConditions constrain bucket methods to act on specific metagenerations.</p>
 <p>The zero value is an empty set of constraints.</p>
 </div>
@@ -599,6 +676,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	MetagenerationNotMatch int64
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption">BucketEncryption</h3>
         <div class="markdown level1 summary"><p>BucketEncryption is a bucket&#39;s encryption configuration.</p>
 </div>
@@ -613,6 +691,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	DefaultKMSKeyName string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle">BucketHandle</h3>
         <div class="markdown level1 summary"><p>BucketHandle provides operations on a Google Cloud Storage bucket.
 Use Client.Bucket to get a handle.</p>
@@ -627,7 +706,7 @@ Use Client.Bucket to get a handle.</p>
         <h5 id="cloud_google_com_go_storage_BucketHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
-          <pre><code>package main
+        <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -654,6 +733,610 @@ func main() {
 }
 </code></pre>
         </div>
+  
+            <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL">func (*BucketHandle) ACL
+</h4>
+            <div class="markdown level1 summary"><p>ACL returns an ACLHandle, which provides access to the bucket&#39;s access control list.
+This controls who can list, create or overwrite the objects in a bucket.
+This call does not perform any network operations.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) ACL() *ACLHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_ACL_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification">func (*BucketHandle) AddNotification
+</h4>
+            <div class="markdown level1 summary"><p>AddNotification adds a notification to b. You must set n&#39;s TopicProjectID, TopicID
+and PayloadFormat, and must not set its ID. The other fields are all optional. The
+returned Notification&#39;s ID can be used to refer to it.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) AddNotification(ctx context.Context, n *Notification) (ret *Notification, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_AddNotification_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	b := client.Bucket(&quot;my-bucket&quot;)
+	n, err := b.AddNotification(ctx, &amp;storage.Notification{
+		TopicProjectID: &quot;my-project&quot;,
+		TopicID:        &quot;my-topic&quot;,
+		PayloadFormat:  storage.JSONPayload,
+	})
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(n.ID)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs">func (*BucketHandle) Attrs
+</h4>
+            <div class="markdown level1 summary"><p>Attrs returns the metadata for the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Attrs(ctx context.Context) (attrs *BucketAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Attrs_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create">func (*BucketHandle) Create
+</h4>
+            <div class="markdown level1 summary"><p>Create creates the Bucket in the project.
+If attrs is nil the API defaults will be used.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Create(ctx context.Context, projectID string, attrs *BucketAttrs) (err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Create_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	if err := client.Bucket(&quot;my-bucket&quot;).Create(ctx, &quot;my-project&quot;, nil); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL">func (*BucketHandle) DefaultObjectACL
+</h4>
+            <div class="markdown level1 summary"><p>DefaultObjectACL returns an ACLHandle, which provides access to the bucket&#39;s default object ACLs.
+These ACLs are applied to newly created objects in this bucket that do not have a defined ACL.
+This call does not perform any network operations.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) DefaultObjectACL() *ACLHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete">func (*BucketHandle) Delete
+</h4>
+            <div class="markdown level1 summary"><p>Delete deletes the Bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Delete(ctx context.Context) (err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Delete_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	if err := client.Bucket(&quot;my-bucket&quot;).Delete(ctx); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification">func (*BucketHandle) DeleteNotification
+</h4>
+            <div class="markdown level1 summary"><p>DeleteNotification deletes the notification with the given ID.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) DeleteNotification(ctx context.Context, id string) (err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+var notificationID string
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	b := client.Bucket(&quot;my-bucket&quot;)
+	// TODO: Obtain notificationID from BucketHandle.AddNotification
+	// or BucketHandle.Notifications.
+	err = b.DeleteNotification(ctx, notificationID)
+	if err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM">func (*BucketHandle) IAM
+</h4>
+            <div class="markdown level1 summary"><p>IAM provides access to IAM access control for the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) IAM() *iam.Handle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_IAM_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If">func (*BucketHandle) If
+</h4>
+            <div class="markdown level1 summary"><p>If returns a new BucketHandle that applies a set of preconditions.
+Preconditions already set on the BucketHandle are ignored.
+Operations on the new handle will return an error if the preconditions are not
+satisfied. The only valid preconditions for buckets are MetagenerationMatch
+and MetagenerationNotMatch.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) If(conds BucketConditions) *BucketHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_If_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy">func (*BucketHandle) LockRetentionPolicy
+</h4>
+            <div class="markdown level1 summary"><p>LockRetentionPolicy locks a bucket&#39;s retention policy until a previously-configured
+RetentionPeriod past the EffectiveTime. Note that if RetentionPeriod is set to less
+than a day, the retention policy is treated as a development configuration and locking
+will have no effect. The BucketHandle must have a metageneration condition that
+matches the bucket&#39;s metageneration. See BucketHandle.If.</p>
+<p>This feature is in private alpha release. It is not currently available to
+most customers. It might be changed in backwards-incompatible ways and is not
+subject to any SLA or deprecation policy.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) error</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	b := client.Bucket(&quot;my-bucket&quot;)
+	attrs, err := b.Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Note that locking the bucket without first attaching a RetentionPolicy
+	// that's at least 1 day is a no-op
+	err = b.If(storage.BucketConditions{MetagenerationMatch: attrs.MetaGeneration}).LockRetentionPolicy(ctx)
+	if err != nil {
+		// TODO: handle err
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications">func (*BucketHandle) Notifications
+</h4>
+            <div class="markdown level1 summary"><p>Notifications returns all the Notifications configured for this bucket, as a map
+indexed by notification ID.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Notifications(ctx context.Context) (n map[string]*Notification, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Notifications_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	b := client.Bucket(&quot;my-bucket&quot;)
+	ns, err := b.Notifications(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	for id, n := range ns {
+		fmt.Printf(&quot;%s: %+v\n&quot;, id, n)
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object">func (*BucketHandle) Object
+</h4>
+            <div class="markdown level1 summary"><p>Object returns an ObjectHandle, which provides operations on the named object.
+This call does not perform any network operations.</p>
+<p>name must consist entirely of valid UTF-8-encoded runes. The full specification
+for valid object names can be found at:
+  <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Object(name string) *ObjectHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Object_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects">func (*BucketHandle) Objects
+</h4>
+            <div class="markdown level1 summary"><p>Objects returns an iterator over the objects in the bucket that match the Query q.
+If q is nil, no filtering is done.</p>
+<p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Objects(ctx context.Context, q *Query) *ObjectIterator</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Objects_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	it := client.Bucket(&quot;my-bucket&quot;).Objects(ctx, nil)
+	_ = it // TODO: iterate using Next or iterator.Pager.
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update">func (*BucketHandle) Update
+</h4>
+            <div class="markdown level1 summary"><p>Update updates a bucket&#39;s attributes.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) Update(ctx context.Context, uattrs BucketAttrsToUpdate) (attrs *BucketAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_Update_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Enable versioning in the bucket, regardless of its previous value.
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Update(ctx,
+		storage.BucketAttrsToUpdate{VersioningEnabled: true})
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(attrs)
+}
+</code></pre>
+            </div>
+            <h6 translate="no">readModifyWrite</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	b := client.Bucket(&quot;my-bucket&quot;)
+	attrs, err := b.Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	var au storage.BucketAttrsToUpdate
+	au.SetLabel(&quot;lab&quot;, attrs.Labels[&quot;lab&quot;]+&quot;-more&quot;)
+	if attrs.Labels[&quot;delete-me&quot;] == &quot;yes&quot; {
+		au.DeleteLabel(&quot;delete-me&quot;)
+	}
+	attrs, err = b.
+		If(storage.BucketConditions{MetagenerationMatch: attrs.MetaGeneration}).
+		Update(ctx, au)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject">func (*BucketHandle) UserProject
+</h4>
+            <div class="markdown level1 summary"><p>UserProject returns a new BucketHandle that passes the project ID as the user
+project for all subsequent calls. Calls with a user project will be billed to that
+project rather than to the bucket&#39;s owning project.</p>
+<p>A user project is required for all operations on Requester Pays buckets.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (b *BucketHandle) UserProject(projectID string) *BucketHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketHandle_UserProject_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
+	if err == storage.ErrBucketNotExist {
+		fmt.Println(&quot;The bucket does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator">BucketIterator</h3>
         <div class="markdown level1 summary"><p>A BucketIterator is an iterator over BucketAttrs.</p>
 <p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
@@ -667,7 +1350,61 @@ func main() {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging">BucketLogging</h3>
+        
+            <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next">func (*BucketIterator) Next
+</h4>
+            <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
+there are no more results. Once Next returns iterator.Done, all subsequent
+calls will return iterator.Done.</p>
+<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *BucketIterator) Next() (*BucketAttrs, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_BucketIterator_Next_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	it := client.Buckets(ctx, &quot;my-project&quot;)
+	for {
+		bucketAttrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Println(bucketAttrs)
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo">func (*BucketIterator) PageInfo
+</h4>
+            <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
+<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *BucketIterator) PageInfo() *iterator.PageInfo</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging">BucketLogging</h3>
         <div class="markdown level1 summary"><p>BucketLogging holds the bucket&#39;s logging configuration, which defines the
 destination bucket and optional name prefix for the current bucket&#39;s
 logs.</p>
@@ -684,6 +1421,7 @@ logs.</p>
 	LogObjectPrefix string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly">BucketPolicyOnly</h3>
         <div class="markdown level1 summary"><p>BucketPolicyOnly is an alias for UniformBucketLevelAccess.
 Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
@@ -700,6 +1438,7 @@ Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
 	LockedTime time.Time
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite">BucketWebsite</h3>
         <div class="markdown level1 summary"><p>BucketWebsite holds the bucket&#39;s website configuration, controlling how the
 service behaves when accessing bucket contents as a web site. See
@@ -721,6 +1460,7 @@ service behaves when accessing bucket contents as a web site. See
 	NotFoundPage string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS">CORS</h3>
         <div class="markdown level1 summary"><p>CORS is the bucket&#39;s Cross-Origin Resource Sharing (CORS) configuration.</p>
 </div>
@@ -748,6 +1488,7 @@ service behaves when accessing bucket contents as a web site. See
 	ResponseHeaders []string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client">Client</h3>
         <div class="markdown level1 summary"><p>Client is a client for interacting with Google Cloud Storage.</p>
 <p>Clients should be reused instead of created as needed.
@@ -760,7 +1501,287 @@ The methods of Client are safe for concurrent use by multiple goroutines.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer">Composer</h3>
+        
+            <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient">func NewClient
+</h4>
+            <div class="markdown level1 summary"><p>NewClient creates a new Google Cloud Storage client.
+The default scope is ScopeFullControl. To use a different scope, like
+ScopeReadOnly, use option.WithScopes.</p>
+<p>Clients should be reused instead of created as needed. The methods of Client
+are safe for concurrent use by multiple goroutines.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Client_NewClient_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	// Use Google Application Default Credentials to authorize and authenticate the client.
+	// More information about Application Default Credentials and how to enable is at
+	// https://developers.google.com/identity/protocols/application-default-credentials.
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Use the client.
+
+	// Close the client when finished.
+	if err := client.Close(); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h6 translate="no">unauthenticated</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;google.golang.org/api/option&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Use the client.
+
+	// Close the client when finished.
+	if err := client.Close(); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket">func (*Client) Bucket
+</h4>
+            <div class="markdown level1 summary"><p>Bucket returns a BucketHandle, which provides operations on the named bucket.
+This call does not perform any network operations.</p>
+<p>The supplied name must contain only lowercase letters, numbers, dashes,
+underscores, and dots. The full specification for valid bucket names can be
+found at:
+  <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) Bucket(name string) *BucketHandle</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets">func (*Client) Buckets
+</h4>
+            <div class="markdown level1 summary"><p>Buckets returns an iterator over the buckets in the project. You may
+optionally set the iterator&#39;s Prefix field to restrict the list to buckets
+whose names begin with the prefix. By default, all buckets in the project
+are returned.</p>
+<p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) Buckets(ctx context.Context, projectID string) *BucketIterator</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Client_Buckets_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	it := client.Buckets(ctx, &quot;my-bucket&quot;)
+	_ = it // TODO: iterate using Next or iterator.Pager.
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close">func (*Client) Close
+</h4>
+            <div class="markdown level1 summary"><p>Close closes the Client.</p>
+<p>Close need not be called at program exit.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) Close() error</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey">func (*Client) CreateHMACKey
+</h4>
+            <div class="markdown level1 summary"><p>CreateHMACKey invokes an RPC for Google Cloud Storage to create a new HMACKey.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) CreateHMACKey(ctx context.Context, projectID, serviceAccountEmail string, ...) (*HMACKey, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Client_CreateHMACKey_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	hkey, err := client.CreateHMACKey(ctx, &quot;project-id&quot;, &quot;service-account-email&quot;)
+	if err != nil {
+		// TODO: handle error.
+	}
+	_ = hkey // TODO: Use the HMAC Key.
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle">func (*Client) HMACKeyHandle
+</h4>
+            <div class="markdown level1 summary"><p>HMACKeyHandle creates a handle that will be used for HMACKey operations.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) HMACKeyHandle(projectID, accessID string) *HMACKeyHandle</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys">func (*Client) ListHMACKeys
+</h4>
+            <div class="markdown level1 summary"><p>ListHMACKeys returns an iterator for listing HMACKeys.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) ListHMACKeys(ctx context.Context, projectID string, opts ...HMACKeyOption) *HMACKeysIterator</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Client_ListHMACKeys_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;)
+	for {
+		key, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: handle error.
+		}
+		_ = key // TODO: Use the key.
+	}
+}
+</code></pre>
+            </div>
+            <h6 translate="no">forServiceAccountEmail</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;, storage.ForHMACKeyServiceAccountEmail(&quot;service@account.email&quot;))
+	for {
+		key, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: handle error.
+		}
+		_ = key // TODO: Use the key.
+	}
+}
+</code></pre>
+            </div>
+            <h6 translate="no">showDeletedKeys</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;, storage.ShowDeletedHMACKeys())
+	for {
+		key, err := iter.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: handle error.
+		}
+		_ = key // TODO: Use the key.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount">func (*Client) ServiceAccount
+</h4>
+            <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Client) ServiceAccount(ctx context.Context, projectID string) (string, error)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer">Composer</h3>
         <div class="markdown level1 summary"><p>A Composer composes source objects into a destination object.</p>
 <p>For Requester Pays buckets, the user project of dst is billed.</p>
 </div>
@@ -782,6 +1803,60 @@ The methods of Client are safe for concurrent use by multiple goroutines.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        
+            <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run">func (*Composer) Run
+</h4>
+            <div class="markdown level1 summary"><p>Run performs the compose operation.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Composer) Run(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Composer_Run_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	bkt := client.Bucket(&quot;bucketname&quot;)
+	src1 := bkt.Object(&quot;o1&quot;)
+	src2 := bkt.Object(&quot;o2&quot;)
+	dst := bkt.Object(&quot;o3&quot;)
+
+	// Compose and modify metadata.
+	c := dst.ComposerFrom(src1, src2)
+	c.ContentType = &quot;text/plain&quot;
+
+	// Set the expected checksum for the destination object to be validated by
+	// the backend (if desired).
+	c.CRC32C = 42
+	c.SendCRC32C = true
+
+	attrs, err := c.Run(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	fmt.Println(attrs)
+	// Just compose.
+	attrs, err = dst.ComposerFrom(src1, src2).Run(ctx)
+	if err != nil {
+		// TODO: Handle error.
+	}
+	fmt.Println(attrs)
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions">Conditions</h3>
         <div class="markdown level1 summary"><p>Conditions constrain methods to act on specific generations of
 objects.</p>
@@ -822,6 +1897,7 @@ for details on how these operate.</p>
 	MetagenerationNotMatch int64
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier">Copier</h3>
         <div class="markdown level1 summary"><p>A Copier copies a source object to a destination.</p>
 </div>
@@ -865,6 +1941,83 @@ for details on how these operate.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        
+            <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run">func (*Copier) Run
+</h4>
+            <div class="markdown level1 summary"><p>Run performs the copy.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (c *Copier) Run(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Copier_Run_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	src := client.Bucket(&quot;bucketname&quot;).Object(&quot;file1&quot;)
+	dst := client.Bucket(&quot;another-bucketname&quot;).Object(&quot;file2&quot;)
+
+	// Copy content and modify metadata.
+	copier := dst.CopierFrom(src)
+	copier.ContentType = &quot;text/plain&quot;
+	attrs, err := copier.Run(ctx)
+	if err != nil {
+		// TODO: Handle error, possibly resuming with copier.RewriteToken.
+	}
+	fmt.Println(attrs)
+
+	// Just copy content.
+	attrs, err = dst.CopierFrom(src).Run(ctx)
+	if err != nil {
+		// TODO: Handle error. No way to resume.
+	}
+	fmt.Println(attrs)
+}
+</code></pre>
+            </div>
+            <h6 translate="no">progress</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;log&quot;
+)
+
+func main() {
+	// Display progress across multiple rewrite RPCs.
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	src := client.Bucket(&quot;bucketname&quot;).Object(&quot;file1&quot;)
+	dst := client.Bucket(&quot;another-bucketname&quot;).Object(&quot;file2&quot;)
+
+	copier := dst.CopierFrom(src)
+	copier.ProgressFunc = func(copiedBytes, totalBytes uint64) {
+		log.Printf(&quot;copy %.1f%% done&quot;, float64(copiedBytes)/float64(totalBytes)*100)
+	}
+	if _, err := copier.Run(ctx); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey">HMACKey</h3>
         <div class="markdown level1 summary"><p>HMACKey is the representation of a Google Cloud Storage HMAC key.</p>
 <p>HMAC keys are used to authenticate signed access to objects. To enable HMAC key
@@ -906,6 +2059,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	State HMACState
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate">HMACKeyAttrsToUpdate</h3>
         <div class="markdown level1 summary"><p>HMACKeyAttrsToUpdate defines the attributes of an HMACKey that will be updated.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
@@ -921,6 +2075,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	Etag string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle">HMACKeyHandle</h3>
         <div class="markdown level1 summary"><p>HMACKeyHandle helps provide access and management for HMAC keys.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
@@ -932,6 +2087,118 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete">func (*HMACKeyHandle) Delete
+</h4>
+            <div class="markdown level1 summary"><p>Delete invokes an RPC to delete the key referenced by accessID, on Google Cloud Storage.
+Only inactive HMAC keys can be deleted.
+After deletion, a key cannot be used to authenticate requests.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (hkh *HMACKeyHandle) Delete(ctx context.Context, opts ...HMACKeyOption) error</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Delete_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
+	// Make sure that the HMACKey being deleted has a status of inactive.
+	if err := hkh.Delete(ctx); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get">func (*HMACKeyHandle) Get
+</h4>
+            <div class="markdown level1 summary"><p>Get invokes an RPC to retrieve the HMAC key referenced by the
+HMACKeyHandle&#39;s accessID.</p>
+<p>Options such as UserProjectForHMACKeys can be used to set the
+userProject to be billed against for operations.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (hkh *HMACKeyHandle) Get(ctx context.Context, opts ...HMACKeyOption) (*HMACKey, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Get_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
+	hkey, err := hkh.Get(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	_ = hkey // TODO: Use the HMAC Key.
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update">func (*HMACKeyHandle) Update
+</h4>
+            <div class="markdown level1 summary"><p>Update mutates the HMACKey referred to by accessID.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (h *HMACKeyHandle) Update(ctx context.Context, au HMACKeyAttrsToUpdate, opts ...HMACKeyOption) (*HMACKey, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Update_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
+	ukey, err := hkh.Update(ctx, storage.HMACKeyAttrsToUpdate{
+		State: storage.Inactive,
+	})
+	if err != nil {
+		// TODO: handle error.
+	}
+	_ = ukey // TODO: Use the HMAC Key.
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption">HMACKeyOption</h3>
         <div class="markdown level1 summary"><p>HMACKeyOption configures the behavior of HMACKey related methods and actions.</p>
 <p>This interface is EXPERIMENTAL and subject to change or removal without notice.</p>
@@ -943,7 +2210,43 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator">HMACKeysIterator</h3>
+        
+            <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail">func ForHMACKeyServiceAccountEmail
+</h4>
+            <div class="markdown level1 summary"><p>ForHMACKeyServiceAccountEmail returns HMAC Keys that are
+associated with the email address of a service account in the project.</p>
+<p>Only one service account email can be used as a filter, so if multiple
+of these options are applied, the last email to be set will be used.</p>
+<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func ForHMACKeyServiceAccountEmail(serviceAccountEmail string) HMACKeyOption</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys">func ShowDeletedHMACKeys
+</h4>
+            <div class="markdown level1 summary"><p>ShowDeletedHMACKeys will also list keys whose state is &quot;DELETED&quot;.</p>
+<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func ShowDeletedHMACKeys() HMACKeyOption</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys">func UserProjectForHMACKeys
+</h4>
+            <div class="markdown level1 summary"><p>UserProjectForHMACKeys will bill the request against userProjectID
+if userProjectID is non-empty.</p>
+<p>Note: This is a noop right now and only provided for API compatibility.</p>
+<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func UserProjectForHMACKeys(userProjectID string) HMACKeyOption</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator">HMACKeysIterator</h3>
         <div class="markdown level1 summary"><p>An HMACKeysIterator is an iterator over HMACKeys.</p>
 <p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
@@ -955,7 +2258,32 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState">HMACState</h3>
+        
+            <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next">func (*HMACKeysIterator) Next
+</h4>
+            <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
+there are no more results. Once Next returns iterator.Done, all subsequent
+calls will return iterator.Done.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *HMACKeysIterator) Next() (*HMACKey, error)</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo">func (*HMACKeysIterator) PageInfo
+</h4>
+            <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *HMACKeysIterator) PageInfo() *iterator.PageInfo</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState">HMACState</h3>
         <div class="markdown level1 summary"><p>HMACState is the state of the HMAC key.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
@@ -964,7 +2292,29 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
         <div class="codewrapper">
           <pre><code class="lang-go hljs">type HMACState string</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle">Lifecycle</h3>
+        
+            <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted">Active, Inactive, Deleted</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">const (
+	// Active is the status for an active key that can be used to sign
+	// requests.
+	Active HMACState = &quot;ACTIVE&quot;
+
+	// Inactive is the status for an inactive key thus requests signed by
+	// this key will be denied.
+	Inactive HMACState = &quot;INACTIVE&quot;
+
+	// Deleted is the status for a key that is deleted.
+	// Once in this state the key cannot key cannot be recovered
+	// and does not count towards key limits. Deleted keys will be cleaned
+	// up later.
+	Deleted HMACState = &quot;DELETED&quot;
+)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle">Lifecycle</h3>
         <div class="markdown level1 summary"><p>Lifecycle is the lifecycle configuration for objects in the bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
@@ -974,6 +2324,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	Rules []LifecycleRule
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction">LifecycleAction</h3>
         <div class="markdown level1 summary"><p>LifecycleAction is a lifecycle configuration action.</p>
 </div>
@@ -993,6 +2344,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	StorageClass string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition">LifecycleCondition</h3>
         <div class="markdown level1 summary"><p>LifecycleCondition is a set of conditions used to match objects and take an
 action automatically.</p>
@@ -1050,6 +2402,7 @@ action automatically.</p>
 	NumNewerVersions int64
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule">LifecycleRule</h3>
         <div class="markdown level1 summary"><p>LifecycleRule is a lifecycle configuration rule.</p>
 <p>When all the configured conditions are met by an object in the bucket, the
@@ -1068,6 +2421,7 @@ configured action will automatically be taken on that object.</p>
 	Condition LifecycleCondition
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness">Liveness</h3>
         <div class="markdown level1 summary"><p>Liveness specifies whether the object is live or not.</p>
 </div>
@@ -1076,7 +2430,22 @@ configured action will automatically be taken on that object.</p>
         <div class="codewrapper">
           <pre><code class="lang-go hljs">type Liveness int</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification">Notification</h3>
+        
+            <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived">LiveAndArchived, Live, Archived</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">const (
+	// LiveAndArchived includes both live and archived objects.
+	LiveAndArchived Liveness = iota
+	// Live specifies that the object is still live.
+	Live
+	// Archived specifies that the object is archived.
+	Archived
+)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification">Notification</h3>
         <div class="markdown level1 summary"><p>A Notification describes how to send Cloud PubSub messages when certain
 events occur in a bucket.</p>
 </div>
@@ -1111,6 +2480,7 @@ events occur in a bucket.</p>
 	PayloadFormat string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs">ObjectAttrs</h3>
         <div class="markdown level1 summary"><p>ObjectAttrs represents the metadata for a Google Cloud Storage (GCS) object.</p>
 </div>
@@ -1261,6 +2631,7 @@ events occur in a bucket.</p>
 	CustomTime time.Time
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate">ObjectAttrsToUpdate</h3>
         <div class="markdown level1 summary"><p>ObjectAttrsToUpdate is used to update the attributes of an object.
 Only fields set to non-nil values will be updated.
@@ -1293,6 +2664,7 @@ Metadata, use
 	PredefinedACL string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle">ObjectHandle</h3>
         <div class="markdown level1 summary"><p>ObjectHandle provides operations on an object in a Google Cloud Storage bucket.
 Use BucketHandle.Object to get a handle.</p>
@@ -1307,7 +2679,7 @@ Use BucketHandle.Object to get a handle.</p>
         <h5 id="cloud_google_com_go_storage_ObjectHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
-          <pre><code>package main
+        <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1334,6 +2706,750 @@ func main() {
 }
 </code></pre>
         </div>
+  
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL">func (*ObjectHandle) ACL
+</h4>
+            <div class="markdown level1 summary"><p>ACL provides access to the object&#39;s access control list.
+This controls who can read and write this object.
+This call does not perform any network operations.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) ACL() *ACLHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_ACL_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err == storage.ErrObjectNotExist {
+		fmt.Println(&quot;The object does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs">func (*ObjectHandle) Attrs
+</h4>
+            <div class="markdown level1 summary"><p>Attrs returns meta information about the object.
+ErrObjectNotExist will be returned if the object is not found.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_Attrs_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	objAttrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(objAttrs)
+}
+</code></pre>
+            </div>
+            <h6 translate="no">withConditions</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;time&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
+	// Read the object.
+	objAttrs1, err := obj.Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Do something else for a while.
+	time.Sleep(5 * time.Minute)
+	// Now read the same contents, even if the object has been written since the last read.
+	objAttrs2, err := obj.Generation(objAttrs1.Generation).Attrs(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(objAttrs1, objAttrs2)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName">func (*ObjectHandle) BucketName
+</h4>
+            <div class="markdown level1 summary"><p>BucketName returns the name of the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) BucketName() string</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_BucketName_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err == storage.ErrObjectNotExist {
+		fmt.Println(&quot;The object does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom">func (*ObjectHandle) ComposerFrom
+</h4>
+            <div class="markdown level1 summary"><p>ComposerFrom creates a Composer that can compose srcs into dst.
+You can immediately call Run on the returned Composer, or you can
+configure it first.</p>
+<p>The encryption key for the destination object will be used to decrypt all
+source objects and encrypt the destination object. It is an error
+to specify an encryption key for any of the source objects.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err == storage.ErrObjectNotExist {
+		fmt.Println(&quot;The object does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom">func (*ObjectHandle) CopierFrom
+</h4>
+            <div class="markdown level1 summary"><p>CopierFrom creates a Copier that can copy src to dst.
+You can immediately call Run on the returned Copier, or
+you can configure it first.</p>
+<p>For Requester Pays buckets, the user project of dst is billed, unless it is empty,
+in which case the user project of src is billed.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (dst *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom_examples">Examples</h5>
+            <h6 translate="no">rotateEncryptionKeys</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+var key1, key2 []byte
+
+func main() {
+	// To rotate the encryption key on an object, copy it onto itself.
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	obj := client.Bucket(&quot;bucketname&quot;).Object(&quot;obj&quot;)
+	// Assume obj is encrypted with key1, and we want to change to key2.
+	_, err = obj.Key(key2).CopierFrom(obj.Key(key1)).Run(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete">func (*ObjectHandle) Delete
+</h4>
+            <div class="markdown level1 summary"><p>Delete deletes the single specified object.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) Delete(ctx context.Context) error</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_Delete_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// To delete multiple objects in a bucket, list them with an
+	// ObjectIterator, then Delete them.
+
+	// If you are using this package on the App Engine Flex runtime,
+	// you can init a bucket client with your app's default bucket name.
+	// See http://godoc.org/google.golang.org/appengine/file#DefaultBucketName.
+	bucket := client.Bucket(&quot;my-bucket&quot;)
+	it := bucket.Objects(ctx, nil)
+	for {
+		objAttrs, err := it.Next()
+		if err != nil &amp;&amp; err != iterator.Done {
+			// TODO: Handle error.
+		}
+		if err == iterator.Done {
+			break
+		}
+		if err := bucket.Object(objAttrs.Name).Delete(ctx); err != nil {
+			// TODO: Handle error.
+		}
+	}
+	fmt.Println(&quot;deleted all object items in the bucket specified.&quot;)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation">func (*ObjectHandle) Generation
+</h4>
+            <div class="markdown level1 summary"><p>Generation returns a new ObjectHandle that operates on a specific generation
+of the object.
+By default, the handle operates on the latest generation. Not
+all operations work when given a specific generation; check the API
+endpoints at <a href="https://cloud.google.com/storage/docs/json_api/">https://cloud.google.com/storage/docs/json_api/</a> for details.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) Generation(gen int64) *ObjectHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_Generation_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;io&quot;
+	&quot;os&quot;
+)
+
+var gen int64
+
+func main() {
+	// Read an object's contents from generation gen, regardless of the
+	// current generation of the object.
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
+	rc, err := obj.Generation(gen).NewReader(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	defer rc.Close()
+	if _, err := io.Copy(os.Stdout, rc); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If">func (*ObjectHandle) If
+</h4>
+            <div class="markdown level1 summary"><p>If returns a new ObjectHandle that applies a set of preconditions.
+Preconditions already set on the ObjectHandle are ignored.
+Operations on the new handle will return an error if the preconditions are not
+satisfied. See <a href="https://cloud.google.com/storage/docs/generations-preconditions">https://cloud.google.com/storage/docs/generations-preconditions</a>
+for more details.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) If(conds Conditions) *ObjectHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_If_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;google.golang.org/api/googleapi&quot;
+	&quot;io&quot;
+	&quot;net/http&quot;
+	&quot;os&quot;
+)
+
+var gen int64
+
+func main() {
+	// Read from an object only if the current generation is gen.
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
+	rc, err := obj.If(storage.Conditions{GenerationMatch: gen}).NewReader(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	if _, err := io.Copy(os.Stdout, rc); err != nil {
+		// TODO: handle error.
+	}
+	if err := rc.Close(); err != nil {
+		switch ee := err.(type) {
+		case *googleapi.Error:
+			if ee.Code == http.StatusPreconditionFailed {
+				// The condition presented in the If failed.
+				// TODO: handle error.
+			}
+
+			// TODO: handle other status codes here.
+
+		default:
+			// TODO: handle error.
+		}
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key">func (*ObjectHandle) Key
+</h4>
+            <div class="markdown level1 summary"><p>Key returns a new ObjectHandle that uses the supplied encryption
+key to encrypt and decrypt the object&#39;s contents.</p>
+<p>Encryption key must be a 32-byte AES-256 key.
+See <a href="https://cloud.google.com/storage/docs/encryption">https://cloud.google.com/storage/docs/encryption</a> for details.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_Key_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+var secretKey []byte
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
+	// Encrypt the object's contents.
+	w := obj.Key(secretKey).NewWriter(ctx)
+	if _, err := w.Write([]byte(&quot;top secret&quot;)); err != nil {
+		// TODO: handle error.
+	}
+	if err := w.Close(); err != nil {
+		// TODO: handle error.
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader">func (*ObjectHandle) NewRangeReader
+</h4>
+            <div class="markdown level1 summary"><p>NewRangeReader reads part of an object, reading at most length bytes
+starting at the given offset. If length is negative, the object is read
+until the end. If offset is negative, the object is read abs(offset) bytes
+from the end, and length must also be negative to indicate all remaining
+bytes will be read.</p>
+<p>If the object&#39;s metadata property &quot;Content-Encoding&quot; is set to &quot;gzip&quot; or satisfies
+decompressive transcoding per <a href="https://cloud.google.com/storage/docs/transcoding">https://cloud.google.com/storage/docs/transcoding</a>
+that file will be served back whole, regardless of the requested range as
+Google Cloud Storage dictates.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64) (r *Reader, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;io/ioutil&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Read only the first 64K.
+	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, 0, 64*1024)
+	if err != nil {
+		// TODO: handle error.
+	}
+	defer rc.Close()
+
+	slurp, err := ioutil.ReadAll(rc)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;first 64K of file contents:\n%s\n&quot;, slurp)
+}
+</code></pre>
+            </div>
+            <h6 translate="no">lastNBytes</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;io/ioutil&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Read only the last 10 bytes until the end of the file.
+	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, -10, -1)
+	if err != nil {
+		// TODO: handle error.
+	}
+	defer rc.Close()
+
+	slurp, err := ioutil.ReadAll(rc)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;Last 10 bytes from the end of the file:\n%s\n&quot;, slurp)
+}
+</code></pre>
+            </div>
+            <h6 translate="no">untilEnd</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;io/ioutil&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Read from the 101st byte until the end of the file.
+	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, 100, -1)
+	if err != nil {
+		// TODO: handle error.
+	}
+	defer rc.Close()
+
+	slurp, err := ioutil.ReadAll(rc)
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;From 101st byte until the end:\n%s\n&quot;, slurp)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader">func (*ObjectHandle) NewReader
+</h4>
+            <div class="markdown level1 summary"><p>NewReader creates a new Reader to read the contents of the
+object.
+ErrObjectNotExist will be returned if the object is not found.</p>
+<p>The caller must call Close on the returned Reader when done reading.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) NewReader(ctx context.Context) (*Reader, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_NewReader_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;io/ioutil&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	rc, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).NewReader(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	slurp, err := ioutil.ReadAll(rc)
+	rc.Close()
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(&quot;file contents:&quot;, slurp)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter">func (*ObjectHandle) NewWriter
+</h4>
+            <div class="markdown level1 summary"><p>NewWriter returns a storage Writer that writes to the GCS object
+associated with this ObjectHandle.</p>
+<p>A new object will be created unless an object with this name already exists.
+Otherwise any previous object with the same name will be replaced.
+The object will not be available (and any previous object will remain)
+until Close has been called.</p>
+<p>Attributes can be set on the object by modifying the returned Writer&#39;s
+ObjectAttrs field before the first call to Write. If no ContentType
+attribute is specified, the content type will be automatically sniffed
+using net/http.DetectContentType.</p>
+<p>It is the caller&#39;s responsibility to call Close when writing is done. To
+stop writing without saving the data, cancel the context.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) NewWriter(ctx context.Context) *Writer</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_NewWriter_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	wc := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewWriter(ctx)
+	_ = wc // TODO: Use the Writer.
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName">func (*ObjectHandle) ObjectName
+</h4>
+            <div class="markdown level1 summary"><p>ObjectName returns the name of the object.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) ObjectName() string</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_ObjectName_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err == storage.ErrObjectNotExist {
+		fmt.Println(&quot;The object does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed">func (*ObjectHandle) ReadCompressed
+</h4>
+            <div class="markdown level1 summary"><p>ReadCompressed when true causes the read to happen without decompressing.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) ReadCompressed(compressed bool) *ObjectHandle</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed_examples">Examples</h5>
+            <h6 translate="no">exists</h6>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	attrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
+	if err == storage.ErrObjectNotExist {
+		fmt.Println(&quot;The object does not exist&quot;)
+		return
+	}
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update">func (*ObjectHandle) Update
+</h4>
+            <div class="markdown level1 summary"><p>Update updates an object with the provided attributes.
+All zero-value attributes are ignored.
+ErrObjectNotExist will be returned if the object is not found.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (o *ObjectHandle) Update(ctx context.Context, uattrs ObjectAttrsToUpdate) (oa *ObjectAttrs, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectHandle_Update_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Change only the content type of the object.
+	objAttrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Update(ctx, storage.ObjectAttrsToUpdate{
+		ContentType:        &quot;text/html&quot;,
+		ContentDisposition: &quot;&quot;, // delete ContentDisposition
+	})
+	if err != nil {
+		// TODO: handle error.
+	}
+	fmt.Println(objAttrs)
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator">ObjectIterator</h3>
         <div class="markdown level1 summary"><p>An ObjectIterator is an iterator over ObjectAttrs.</p>
 <p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
@@ -1345,7 +3461,64 @@ func main() {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields">PolicyV4Fields</h3>
+        
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next">func (*ObjectIterator) Next
+</h4>
+            <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
+there are no more results. Once Next returns iterator.Done, all subsequent
+calls will return iterator.Done.</p>
+<p>If Query.Delimiter is non-empty, some of the ObjectAttrs returned by Next will
+have a non-empty Prefix field, and a zero value for all other fields. These
+represent prefixes.</p>
+<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *ObjectIterator) Next() (*ObjectAttrs, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_ObjectIterator_Next_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;context&quot;
+	&quot;fmt&quot;
+	&quot;google.golang.org/api/iterator&quot;
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		// TODO: handle error.
+	}
+	it := client.Bucket(&quot;my-bucket&quot;).Objects(ctx, nil)
+	for {
+		objAttrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			// TODO: Handle error.
+		}
+		fmt.Println(objAttrs)
+	}
+}
+</code></pre>
+            </div>
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo">func (*ObjectIterator) PageInfo
+</h4>
+            <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
+<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (it *ObjectIterator) PageInfo() *iterator.PageInfo</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields">PolicyV4Fields</h3>
         <div class="markdown level1 summary"><p>PolicyV4Fields describes the attributes for a PostPolicyV4 request.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
@@ -1383,6 +3556,7 @@ func main() {
 	RedirectToURLOnSuccess string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4">PostPolicyV4</h3>
         <div class="markdown level1 summary"><p>PostPolicyV4 describes the URL and respective form fields for a generated PostPolicyV4 request.</p>
 </div>
@@ -1397,6 +3571,92 @@ func main() {
 	Fields map[string]string
 }</code></pre>
         </div>
+        
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4">func GenerateSignedPostPolicyV4
+</h4>
+            <div class="markdown level1 summary"><p>GenerateSignedPostPolicyV4 generates a PostPolicyV4 value from bucket, object and opts.
+The generated URL and fields will then allow an unauthenticated client to perform multipart uploads.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func GenerateSignedPostPolicyV4(bucket, object string, opts *PostPolicyV4Options) (*PostPolicyV4, error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
+
+import (
+	&quot;bytes&quot;
+	&quot;cloud.google.com/go/storage&quot;
+	&quot;io&quot;
+	&quot;mime/multipart&quot;
+	&quot;net/http&quot;
+	&quot;time&quot;
+)
+
+func main() {
+	pv4, err := storage.GenerateSignedPostPolicyV4(&quot;my-bucket&quot;, &quot;my-object.txt&quot;, &amp;storage.PostPolicyV4Options{
+		GoogleAccessID: &quot;my-access-id&quot;,
+		PrivateKey:     []byte(&quot;my-private-key&quot;),
+
+		// The upload expires in 2hours.
+		Expires: time.Now().Add(2 * time.Hour),
+
+		Fields: &amp;storage.PolicyV4Fields{
+			StatusCodeOnSuccess:    200,
+			RedirectToURLOnSuccess: &quot;https://example.org/&quot;,
+			// It MUST only be a text file.
+			ContentType: &quot;text/plain&quot;,
+		},
+
+		// The conditions that the uploaded file will be expected to conform to.
+		Conditions: []storage.PostPolicyV4Condition{
+			// Make the file a maximum of 10mB.
+			storage.ConditionContentLengthRange(0, 10&lt;&lt;20),
+		},
+	})
+	if err != nil {
+		// TODO: handle error.
+	}
+
+	// Now you can upload your file using the generated post policy
+	// with a plain HTTP client or even the browser.
+	formBuf := new(bytes.Buffer)
+	mw := multipart.NewWriter(formBuf)
+	for fieldName, value := range pv4.Fields {
+		if err := mw.WriteField(fieldName, value); err != nil {
+			// TODO: handle error.
+		}
+	}
+	file := bytes.NewReader(bytes.Repeat([]byte(&quot;a&quot;), 100))
+
+	mf, err := mw.CreateFormFile(&quot;file&quot;, &quot;myfile.txt&quot;)
+	if err != nil {
+		// TODO: handle error.
+	}
+	if _, err := io.Copy(mf, file); err != nil {
+		// TODO: handle error.
+	}
+	if err := mw.Close(); err != nil {
+		// TODO: handle error.
+	}
+
+	// Compose the request.
+	req, err := http.NewRequest(&quot;POST&quot;, pv4.URL, formBuf)
+	if err != nil {
+		// TODO: handle error.
+	}
+	// Ensure the Content-Type is derived from the multipart writer.
+	req.Header.Set(&quot;Content-Type&quot;, mw.FormDataContentType())
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		// TODO: handle error.
+	}
+	_ = res
+}
+</code></pre>
+            </div>
         <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition">PostPolicyV4Condition</h3>
         <div class="markdown level1 summary"><p>PostPolicyV4Condition describes the constraints that the subsequent
 object upload&#39;s multipart form fields will be expected to conform to.</p>
@@ -1409,7 +3669,28 @@ object upload&#39;s multipart form fields will be expected to conform to.</p>
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options">PostPolicyV4Options</h3>
+        
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange">func ConditionContentLengthRange
+</h4>
+            <div class="markdown level1 summary"><p>ConditionContentLengthRange constraints the limits that the
+multipart upload&#39;s range header will be expected to be within.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func ConditionContentLengthRange(start, end uint64) PostPolicyV4Condition</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith">func ConditionStartsWith
+</h4>
+            <div class="markdown level1 summary"><p>ConditionStartsWith checks that an attributes starts with value.
+An empty value will cause this condition to be ignored.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func ConditionStartsWith(key, value string) PostPolicyV4Condition</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options">PostPolicyV4Options</h3>
         <div class="markdown level1 summary"><p>PostPolicyV4Options are used to construct a signed post policy.
 Please see <a href="https://cloud.google.com/storage/docs/xml-api/post-object">https://cloud.google.com/storage/docs/xml-api/post-object</a>
 for reference about the fields.</p>
@@ -1484,6 +3765,7 @@ for reference about the fields.</p>
 	Conditions []PostPolicyV4Condition
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam">ProjectTeam</h3>
         <div class="markdown level1 summary"><p>ProjectTeam is the project team associated with the entity, if any.</p>
 </div>
@@ -1495,6 +3777,7 @@ for reference about the fields.</p>
 	Team          string
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query">Query</h3>
         <div class="markdown level1 summary"><p>Query represents a query to filter objects from a bucket.</p>
 </div>
@@ -1533,7 +3816,23 @@ for reference about the fields.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader">Reader</h3>
+        
+            <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection">func (*Query) SetAttrSelection
+</h4>
+            <div class="markdown level1 summary"><p>SetAttrSelection makes the query populate only specific attributes of
+objects. When iterating over objects, if you only need each object&#39;s name
+and size, pass []string{&quot;Name&quot;, &quot;Size&quot;} to this method. Only these fields
+will be fetched for each object across the network; the other fields of
+ObjectAttr will remain at their default values. This is a performance
+optimization; for more information, see
+<a href="https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance">https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance</a></p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (q *Query) SetAttrSelection(attrs []string) error</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader">Reader</h3>
         <div class="markdown level1 summary"><p>Reader reads a Cloud Storage object.
 It implements io.Reader.</p>
 <p>Typically, a Reader computes the CRC of the downloaded content and compares it to
@@ -1548,7 +3847,86 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs">ReaderObjectAttrs</h3>
+        
+            <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl">func (*Reader) CacheControl
+</h4>
+            <div class="markdown level1 summary"><p>CacheControl returns the cache control of the object.</p>
+<p>Deprecated: use Reader.Attrs.CacheControl.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) CacheControl() string</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close">func (*Reader) Close
+</h4>
+            <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) Close() error</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding">func (*Reader) ContentEncoding
+</h4>
+            <div class="markdown level1 summary"><p>ContentEncoding returns the content encoding of the object.</p>
+<p>Deprecated: use Reader.Attrs.ContentEncoding.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) ContentEncoding() string</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType">func (*Reader) ContentType
+</h4>
+            <div class="markdown level1 summary"><p>ContentType returns the content type of the object.</p>
+<p>Deprecated: use Reader.Attrs.ContentType.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) ContentType() string</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified">func (*Reader) LastModified
+</h4>
+            <div class="markdown level1 summary"><p>LastModified returns the value of the Last-Modified header.</p>
+<p>Deprecated: use Reader.Attrs.LastModified.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) LastModified() (time.Time, error)</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read">func (*Reader) Read
+</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) Read(p []byte) (int, error)</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain">func (*Reader) Remain
+</h4>
+            <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) Remain() int64</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size">func (*Reader) Size
+</h4>
+            <div class="markdown level1 summary"><p>Size returns the size of the object in bytes.
+The returned value is always the same and is not affected by
+calls to Read or Close.</p>
+<p>Deprecated: use Reader.Attrs.Size.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (r *Reader) Size() int64</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs">ReaderObjectAttrs</h3>
         <div class="markdown level1 summary"><p>ReaderObjectAttrs are attributes about the object being read. These are populated
 during the New call. This struct only holds a subset of object attributes: to
 get the full set of attributes, use ObjectHandle.Attrs.</p>
@@ -1590,6 +3968,7 @@ get the full set of attributes, use ObjectHandle.Attrs.</p>
 	Metageneration int64
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy">RetentionPolicy</h3>
         <div class="markdown level1 summary"><p>RetentionPolicy enforces a minimum retention time for all objects
 contained in the bucket.</p>
@@ -1623,6 +4002,7 @@ subject to any SLA or deprecation policy.</p>
 	IsLocked bool
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions">SignedURLOptions</h3>
         <div class="markdown level1 summary"><p>SignedURLOptions allows you to restrict the access to the signed URL.</p>
 </div>
@@ -1720,6 +4100,7 @@ subject to any SLA or deprecation policy.</p>
 	Scheme SigningScheme
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme">SigningScheme</h3>
         <div class="markdown level1 summary"><p>SigningScheme determines the API version to use when signing URLs.</p>
 </div>
@@ -1728,7 +4109,24 @@ subject to any SLA or deprecation policy.</p>
         <div class="codewrapper">
           <pre><code class="lang-go hljs">type SigningScheme int</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle">URLStyle</h3>
+        
+            <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">const (
+	// SigningSchemeDefault is presently V2 and will change to V4 in the future.
+	SigningSchemeDefault SigningScheme = iota
+
+	// SigningSchemeV2 uses the V2 scheme to sign URLs.
+	SigningSchemeV2
+
+	// SigningSchemeV4 uses the V4 scheme to sign URLs.
+	SigningSchemeV4
+)</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle">URLStyle</h3>
         <div class="markdown level1 summary"><p>URLStyle determines the style to use for the signed URL. pathStyle is the
 default. All non-default options work with V4 scheme only. See
 <a href="https://cloud.google.com/storage/docs/request-endpoints">https://cloud.google.com/storage/docs/request-endpoints</a> for details.</p>
@@ -1740,7 +4138,44 @@ default. All non-default options work with V4 scheme only. See
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
-        <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess">UniformBucketLevelAccess</h3>
+        
+            <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname">func BucketBoundHostname
+</h4>
+            <div class="markdown level1 summary"><p>BucketBoundHostname generates a URL with a custom hostname tied to a
+specific GCS bucket. The desired hostname should be passed in using the
+hostname argument. Generated urls will be of the form
+&quot;<bucket-bound-hostname>/<object-name>&quot;. See
+<a href="https://cloud.google.com/storage/docs/request-endpoints#cname">https://cloud.google.com/storage/docs/request-endpoints#cname</a> and
+<a href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers</a>
+for details. Note that for CNAMEs, only HTTP is supported, so Insecure must
+be set to true.<p>
+</object-name></bucket-bound-hostname></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func BucketBoundHostname(hostname string) URLStyle</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle">func PathStyle
+</h4>
+            <div class="markdown level1 summary"><p>PathStyle is the default style, and will generate a URL of the form
+&quot;storage.googleapis.com/<bucket-name>/<object-name>&quot;.<p>
+</object-name></bucket-name></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func PathStyle() URLStyle</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle">func VirtualHostedStyle
+</h4>
+            <div class="markdown level1 summary"><p>VirtualHostedStyle generates a URL relative to the bucket&#39;s virtual
+hostname, e.g. &quot;<bucket-name>.storage.googleapis.com/<object-name>&quot;.<p>
+</object-name></bucket-name></div>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func VirtualHostedStyle() URLStyle</code></pre>
+            </div>
+                  <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess">UniformBucketLevelAccess</h3>
         <div class="markdown level1 summary"><p>UniformBucketLevelAccess configures access checks to use only bucket-level IAM
 policies.</p>
 </div>
@@ -1756,6 +4191,7 @@ policies.</p>
 	LockedTime time.Time
 }</code></pre>
         </div>
+        
         <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer">Writer</h3>
         <div class="markdown level1 summary"><p>A Writer writes a Cloud Storage object.</p>
 </div>
@@ -1809,2098 +4245,42 @@ policies.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
-    <h2 id="functions">Functions
-  
-  </h2>
-        <h3 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete">func (*ACLHandle) Delete
-</h3>
-        <div class="markdown level1 summary"><p>Delete permanently deletes the ACL entry for the given entity.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (a *ACLHandle) Delete(ctx context.Context, entity ACLEntity) (err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ACLHandle_Delete_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// No longer grant access to the bucket to everyone on the Internet.
-	if err := client.Bucket(&quot;my-bucket&quot;).ACL().Delete(ctx, storage.AllUsers); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List">func (*ACLHandle) List
-</h3>
-        <div class="markdown level1 summary"><p>List retrieves ACL entries.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (a *ACLHandle) List(ctx context.Context) (rules []ACLRule, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ACLHandle_List_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// List the default object ACLs for my-bucket.
-	aclRules, err := client.Bucket(&quot;my-bucket&quot;).DefaultObjectACL().List(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(aclRules)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set">func (*ACLHandle) Set
-</h3>
-        <div class="markdown level1 summary"><p>Set sets the role for the given entity.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (a *ACLHandle) Set(ctx context.Context, entity ACLEntity, role ACLRole) (err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ACLHandle_Set_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Let any authenticated user read my-bucket/my-object.
-	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
-	if err := obj.ACL().Set(ctx, storage.AllAuthenticatedUsers, storage.RoleReader); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel">func (*BucketAttrsToUpdate) DeleteLabel
-</h3>
-        <div class="markdown level1 summary"><p>DeleteLabel causes a label to be deleted when ua is used in a
-call to Bucket.Update.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (ua *BucketAttrsToUpdate) DeleteLabel(name string)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel">func (*BucketAttrsToUpdate) SetLabel
-</h3>
-        <div class="markdown level1 summary"><p>SetLabel causes a label to be added or modified when ua is used
-in a call to Bucket.Update.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (ua *BucketAttrsToUpdate) SetLabel(name, value string)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL">func (*BucketHandle) ACL
-</h3>
-        <div class="markdown level1 summary"><p>ACL returns an ACLHandle, which provides access to the bucket&#39;s access control list.
-This controls who can list, create or overwrite the objects in a bucket.
-This call does not perform any network operations.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) ACL() *ACLHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification">func (*BucketHandle) AddNotification
-</h3>
-        <div class="markdown level1 summary"><p>AddNotification adds a notification to b. You must set n&#39;s TopicProjectID, TopicID
-and PayloadFormat, and must not set its ID. The other fields are all optional. The
-returned Notification&#39;s ID can be used to refer to it.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) AddNotification(ctx context.Context, n *Notification) (ret *Notification, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_AddNotification_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	b := client.Bucket(&quot;my-bucket&quot;)
-	n, err := b.AddNotification(ctx, &amp;storage.Notification{
-		TopicProjectID: &quot;my-project&quot;,
-		TopicID:        &quot;my-topic&quot;,
-		PayloadFormat:  storage.JSONPayload,
-	})
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(n.ID)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs">func (*BucketHandle) Attrs
-</h3>
-        <div class="markdown level1 summary"><p>Attrs returns the metadata for the bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Attrs(ctx context.Context) (attrs *BucketAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Attrs_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	attrs, err := client.Bucket(&quot;my-bucket&quot;).Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(attrs)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create">func (*BucketHandle) Create
-</h3>
-        <div class="markdown level1 summary"><p>Create creates the Bucket in the project.
-If attrs is nil the API defaults will be used.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Create(ctx context.Context, projectID string, attrs *BucketAttrs) (err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Create_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	if err := client.Bucket(&quot;my-bucket&quot;).Create(ctx, &quot;my-project&quot;, nil); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL">func (*BucketHandle) DefaultObjectACL
-</h3>
-        <div class="markdown level1 summary"><p>DefaultObjectACL returns an ACLHandle, which provides access to the bucket&#39;s default object ACLs.
-These ACLs are applied to newly created objects in this bucket that do not have a defined ACL.
-This call does not perform any network operations.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) DefaultObjectACL() *ACLHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete">func (*BucketHandle) Delete
-</h3>
-        <div class="markdown level1 summary"><p>Delete deletes the Bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Delete(ctx context.Context) (err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Delete_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	if err := client.Bucket(&quot;my-bucket&quot;).Delete(ctx); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification">func (*BucketHandle) DeleteNotification
-</h3>
-        <div class="markdown level1 summary"><p>DeleteNotification deletes the notification with the given ID.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) DeleteNotification(ctx context.Context, id string) (err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-var notificationID string
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	b := client.Bucket(&quot;my-bucket&quot;)
-	// TODO: Obtain notificationID from BucketHandle.AddNotification
-	// or BucketHandle.Notifications.
-	err = b.DeleteNotification(ctx, notificationID)
-	if err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM">func (*BucketHandle) IAM
-</h3>
-        <div class="markdown level1 summary"><p>IAM provides access to IAM access control for the bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) IAM() *iam.Handle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If">func (*BucketHandle) If
-</h3>
-        <div class="markdown level1 summary"><p>If returns a new BucketHandle that applies a set of preconditions.
-Preconditions already set on the BucketHandle are ignored.
-Operations on the new handle will return an error if the preconditions are not
-satisfied. The only valid preconditions for buckets are MetagenerationMatch
-and MetagenerationNotMatch.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) If(conds BucketConditions) *BucketHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy">func (*BucketHandle) LockRetentionPolicy
-</h3>
-        <div class="markdown level1 summary"><p>LockRetentionPolicy locks a bucket&#39;s retention policy until a previously-configured
-RetentionPeriod past the EffectiveTime. Note that if RetentionPeriod is set to less
-than a day, the retention policy is treated as a development configuration and locking
-will have no effect. The BucketHandle must have a metageneration condition that
-matches the bucket&#39;s metageneration. See BucketHandle.If.</p>
-<p>This feature is in private alpha release. It is not currently available to
-most customers. It might be changed in backwards-incompatible ways and is not
-subject to any SLA or deprecation policy.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) LockRetentionPolicy(ctx context.Context) error</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	b := client.Bucket(&quot;my-bucket&quot;)
-	attrs, err := b.Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Note that locking the bucket without first attaching a RetentionPolicy
-	// that's at least 1 day is a no-op
-	err = b.If(storage.BucketConditions{MetagenerationMatch: attrs.MetaGeneration}).LockRetentionPolicy(ctx)
-	if err != nil {
-		// TODO: handle err
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications">func (*BucketHandle) Notifications
-</h3>
-        <div class="markdown level1 summary"><p>Notifications returns all the Notifications configured for this bucket, as a map
-indexed by notification ID.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Notifications(ctx context.Context) (n map[string]*Notification, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Notifications_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	b := client.Bucket(&quot;my-bucket&quot;)
-	ns, err := b.Notifications(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	for id, n := range ns {
-		fmt.Printf(&quot;%s: %+v\n&quot;, id, n)
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object">func (*BucketHandle) Object
-</h3>
-        <div class="markdown level1 summary"><p>Object returns an ObjectHandle, which provides operations on the named object.
-This call does not perform any network operations.</p>
-<p>name must consist entirely of valid UTF-8-encoded runes. The full specification
-for valid object names can be found at:
-  <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Object(name string) *ObjectHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects">func (*BucketHandle) Objects
-</h3>
-        <div class="markdown level1 summary"><p>Objects returns an iterator over the objects in the bucket that match the Query q.
-If q is nil, no filtering is done.</p>
-<p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Objects(ctx context.Context, q *Query) *ObjectIterator</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Objects_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	it := client.Bucket(&quot;my-bucket&quot;).Objects(ctx, nil)
-	_ = it // TODO: iterate using Next or iterator.Pager.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update">func (*BucketHandle) Update
-</h3>
-        <div class="markdown level1 summary"><p>Update updates a bucket&#39;s attributes.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) Update(ctx context.Context, uattrs BucketAttrsToUpdate) (attrs *BucketAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketHandle_Update_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Enable versioning in the bucket, regardless of its previous value.
-	attrs, err := client.Bucket(&quot;my-bucket&quot;).Update(ctx,
-		storage.BucketAttrsToUpdate{VersioningEnabled: true})
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(attrs)
-}
-</code></pre>
-        </div>
-        <h6 translate="no">readModifyWrite</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	b := client.Bucket(&quot;my-bucket&quot;)
-	attrs, err := b.Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	var au storage.BucketAttrsToUpdate
-	au.SetLabel(&quot;lab&quot;, attrs.Labels[&quot;lab&quot;]+&quot;-more&quot;)
-	if attrs.Labels[&quot;delete-me&quot;] == &quot;yes&quot; {
-		au.DeleteLabel(&quot;delete-me&quot;)
-	}
-	attrs, err = b.
-		If(storage.BucketConditions{MetagenerationMatch: attrs.MetaGeneration}).
-		Update(ctx, au)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(attrs)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject">func (*BucketHandle) UserProject
-</h3>
-        <div class="markdown level1 summary"><p>UserProject returns a new BucketHandle that passes the project ID as the user
-project for all subsequent calls. Calls with a user project will be billed to that
-project rather than to the bucket&#39;s owning project.</p>
-<p>A user project is required for all operations on Requester Pays buckets.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (b *BucketHandle) UserProject(projectID string) *BucketHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next">func (*BucketIterator) Next
-</h3>
-        <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
-there are no more results. Once Next returns iterator.Done, all subsequent
-calls will return iterator.Done.</p>
-<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *BucketIterator) Next() (*BucketAttrs, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_BucketIterator_Next_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	it := client.Buckets(ctx, &quot;my-project&quot;)
-	for {
-		bucketAttrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			// TODO: Handle error.
-		}
-		fmt.Println(bucketAttrs)
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo">func (*BucketIterator) PageInfo
-</h3>
-        <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
-<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *BucketIterator) PageInfo() *iterator.PageInfo</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient">func NewClient
-</h3>
-        <div class="markdown level1 summary"><p>NewClient creates a new Google Cloud Storage client.
-The default scope is ScopeFullControl. To use a different scope, like
-ScopeReadOnly, use option.WithScopes.</p>
-<p>Clients should be reused instead of created as needed. The methods of Client
-are safe for concurrent use by multiple goroutines.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func NewClient(ctx context.Context, opts ...option.ClientOption) (*Client, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Client_NewClient_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	// Use Google Application Default Credentials to authorize and authenticate the client.
-	// More information about Application Default Credentials and how to enable is at
-	// https://developers.google.com/identity/protocols/application-default-credentials.
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Use the client.
-
-	// Close the client when finished.
-	if err := client.Close(); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h6 translate="no">unauthenticated</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;google.golang.org/api/option&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx, option.WithoutAuthentication())
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Use the client.
-
-	// Close the client when finished.
-	if err := client.Close(); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket">func (*Client) Bucket
-</h3>
-        <div class="markdown level1 summary"><p>Bucket returns a BucketHandle, which provides operations on the named bucket.
-This call does not perform any network operations.</p>
-<p>The supplied name must contain only lowercase letters, numbers, dashes,
-underscores, and dots. The full specification for valid bucket names can be
-found at:
-  <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) Bucket(name string) *BucketHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets">func (*Client) Buckets
-</h3>
-        <div class="markdown level1 summary"><p>Buckets returns an iterator over the buckets in the project. You may
-optionally set the iterator&#39;s Prefix field to restrict the list to buckets
-whose names begin with the prefix. By default, all buckets in the project
-are returned.</p>
-<p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) Buckets(ctx context.Context, projectID string) *BucketIterator</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Client_Buckets_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	it := client.Buckets(ctx, &quot;my-bucket&quot;)
-	_ = it // TODO: iterate using Next or iterator.Pager.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close">func (*Client) Close
-</h3>
-        <div class="markdown level1 summary"><p>Close closes the Client.</p>
-<p>Close need not be called at program exit.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) Close() error</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey">func (*Client) CreateHMACKey
-</h3>
-        <div class="markdown level1 summary"><p>CreateHMACKey invokes an RPC for Google Cloud Storage to create a new HMACKey.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) CreateHMACKey(ctx context.Context, projectID, serviceAccountEmail string, ...) (*HMACKey, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Client_CreateHMACKey_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	hkey, err := client.CreateHMACKey(ctx, &quot;project-id&quot;, &quot;service-account-email&quot;)
-	if err != nil {
-		// TODO: handle error.
-	}
-	_ = hkey // TODO: Use the HMAC Key.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle">func (*Client) HMACKeyHandle
-</h3>
-        <div class="markdown level1 summary"><p>HMACKeyHandle creates a handle that will be used for HMACKey operations.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) HMACKeyHandle(projectID, accessID string) *HMACKeyHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys">func (*Client) ListHMACKeys
-</h3>
-        <div class="markdown level1 summary"><p>ListHMACKeys returns an iterator for listing HMACKeys.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) ListHMACKeys(ctx context.Context, projectID string, opts ...HMACKeyOption) *HMACKeysIterator</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Client_ListHMACKeys_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;)
-	for {
-		key, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			// TODO: handle error.
-		}
-		_ = key // TODO: Use the key.
-	}
-}
-</code></pre>
-        </div>
-        <h6 translate="no">forServiceAccountEmail</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;, storage.ForHMACKeyServiceAccountEmail(&quot;service@account.email&quot;))
-	for {
-		key, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			// TODO: handle error.
-		}
-		_ = key // TODO: Use the key.
-	}
-}
-</code></pre>
-        </div>
-        <h6 translate="no">showDeletedKeys</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	iter := client.ListHMACKeys(ctx, &quot;project-id&quot;, storage.ShowDeletedHMACKeys())
-	for {
-		key, err := iter.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			// TODO: handle error.
-		}
-		_ = key // TODO: Use the key.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount">func (*Client) ServiceAccount
-</h3>
-        <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Client) ServiceAccount(ctx context.Context, projectID string) (string, error)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run">func (*Composer) Run
-</h3>
-        <div class="markdown level1 summary"><p>Run performs the compose operation.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Composer) Run(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Composer_Run_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	bkt := client.Bucket(&quot;bucketname&quot;)
-	src1 := bkt.Object(&quot;o1&quot;)
-	src2 := bkt.Object(&quot;o2&quot;)
-	dst := bkt.Object(&quot;o3&quot;)
-
-	// Compose and modify metadata.
-	c := dst.ComposerFrom(src1, src2)
-	c.ContentType = &quot;text/plain&quot;
-
-	// Set the expected checksum for the destination object to be validated by
-	// the backend (if desired).
-	c.CRC32C = 42
-	c.SendCRC32C = true
-
-	attrs, err := c.Run(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	fmt.Println(attrs)
-	// Just compose.
-	attrs, err = dst.ComposerFrom(src1, src2).Run(ctx)
-	if err != nil {
-		// TODO: Handle error.
-	}
-	fmt.Println(attrs)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run">func (*Copier) Run
-</h3>
-        <div class="markdown level1 summary"><p>Run performs the copy.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (c *Copier) Run(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Copier_Run_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	src := client.Bucket(&quot;bucketname&quot;).Object(&quot;file1&quot;)
-	dst := client.Bucket(&quot;another-bucketname&quot;).Object(&quot;file2&quot;)
-
-	// Copy content and modify metadata.
-	copier := dst.CopierFrom(src)
-	copier.ContentType = &quot;text/plain&quot;
-	attrs, err := copier.Run(ctx)
-	if err != nil {
-		// TODO: Handle error, possibly resuming with copier.RewriteToken.
-	}
-	fmt.Println(attrs)
-
-	// Just copy content.
-	attrs, err = dst.CopierFrom(src).Run(ctx)
-	if err != nil {
-		// TODO: Handle error. No way to resume.
-	}
-	fmt.Println(attrs)
-}
-</code></pre>
-        </div>
-        <h6 translate="no">progress</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;log&quot;
-)
-
-func main() {
-	// Display progress across multiple rewrite RPCs.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	src := client.Bucket(&quot;bucketname&quot;).Object(&quot;file1&quot;)
-	dst := client.Bucket(&quot;another-bucketname&quot;).Object(&quot;file2&quot;)
-
-	copier := dst.CopierFrom(src)
-	copier.ProgressFunc = func(copiedBytes, totalBytes uint64) {
-		log.Printf(&quot;copy %.1f%% done&quot;, float64(copiedBytes)/float64(totalBytes)*100)
-	}
-	if _, err := copier.Run(ctx); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete">func (*HMACKeyHandle) Delete
-</h3>
-        <div class="markdown level1 summary"><p>Delete invokes an RPC to delete the key referenced by accessID, on Google Cloud Storage.
-Only inactive HMAC keys can be deleted.
-After deletion, a key cannot be used to authenticate requests.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (hkh *HMACKeyHandle) Delete(ctx context.Context, opts ...HMACKeyOption) error</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Delete_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
-	// Make sure that the HMACKey being deleted has a status of inactive.
-	if err := hkh.Delete(ctx); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get">func (*HMACKeyHandle) Get
-</h3>
-        <div class="markdown level1 summary"><p>Get invokes an RPC to retrieve the HMAC key referenced by the
-HMACKeyHandle&#39;s accessID.</p>
-<p>Options such as UserProjectForHMACKeys can be used to set the
-userProject to be billed against for operations.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (hkh *HMACKeyHandle) Get(ctx context.Context, opts ...HMACKeyOption) (*HMACKey, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Get_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
-	hkey, err := hkh.Get(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	_ = hkey // TODO: Use the HMAC Key.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update">func (*HMACKeyHandle) Update
-</h3>
-        <div class="markdown level1 summary"><p>Update mutates the HMACKey referred to by accessID.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (h *HMACKeyHandle) Update(ctx context.Context, au HMACKeyAttrsToUpdate, opts ...HMACKeyOption) (*HMACKey, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Update_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	hkh := client.HMACKeyHandle(&quot;project-id&quot;, &quot;access-key-id&quot;)
-	ukey, err := hkh.Update(ctx, storage.HMACKeyAttrsToUpdate{
-		State: storage.Inactive,
-	})
-	if err != nil {
-		// TODO: handle error.
-	}
-	_ = ukey // TODO: Use the HMAC Key.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail">func ForHMACKeyServiceAccountEmail
-</h3>
-        <div class="markdown level1 summary"><p>ForHMACKeyServiceAccountEmail returns HMAC Keys that are
-associated with the email address of a service account in the project.</p>
-<p>Only one service account email can be used as a filter, so if multiple
-of these options are applied, the last email to be set will be used.</p>
-<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func ForHMACKeyServiceAccountEmail(serviceAccountEmail string) HMACKeyOption</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys">func ShowDeletedHMACKeys
-</h3>
-        <div class="markdown level1 summary"><p>ShowDeletedHMACKeys will also list keys whose state is &quot;DELETED&quot;.</p>
-<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func ShowDeletedHMACKeys() HMACKeyOption</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys">func UserProjectForHMACKeys
-</h3>
-        <div class="markdown level1 summary"><p>UserProjectForHMACKeys will bill the request against userProjectID
-if userProjectID is non-empty.</p>
-<p>Note: This is a noop right now and only provided for API compatibility.</p>
-<p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func UserProjectForHMACKeys(userProjectID string) HMACKeyOption</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next">func (*HMACKeysIterator) Next
-</h3>
-        <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
-there are no more results. Once Next returns iterator.Done, all subsequent
-calls will return iterator.Done.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *HMACKeysIterator) Next() (*HMACKey, error)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo">func (*HMACKeysIterator) PageInfo
-</h3>
-        <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-<p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *HMACKeysIterator) PageInfo() *iterator.PageInfo</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL">func (*ObjectHandle) ACL
-</h3>
-        <div class="markdown level1 summary"><p>ACL provides access to the object&#39;s access control list.
-This controls who can read and write this object.
-This call does not perform any network operations.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) ACL() *ACLHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs">func (*ObjectHandle) Attrs
-</h3>
-        <div class="markdown level1 summary"><p>Attrs returns meta information about the object.
-ErrObjectNotExist will be returned if the object is not found.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) Attrs(ctx context.Context) (attrs *ObjectAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_Attrs_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	objAttrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(objAttrs)
-}
-</code></pre>
-        </div>
-        <h6 translate="no">withConditions</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;time&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
-	// Read the object.
-	objAttrs1, err := obj.Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Do something else for a while.
-	time.Sleep(5 * time.Minute)
-	// Now read the same contents, even if the object has been written since the last read.
-	objAttrs2, err := obj.Generation(objAttrs1.Generation).Attrs(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(objAttrs1, objAttrs2)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName">func (*ObjectHandle) BucketName
-</h3>
-        <div class="markdown level1 summary"><p>BucketName returns the name of the bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) BucketName() string</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom">func (*ObjectHandle) ComposerFrom
-</h3>
-        <div class="markdown level1 summary"><p>ComposerFrom creates a Composer that can compose srcs into dst.
-You can immediately call Run on the returned Composer, or you can
-configure it first.</p>
-<p>The encryption key for the destination object will be used to decrypt all
-source objects and encrypt the destination object. It is an error
-to specify an encryption key for any of the source objects.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (dst *ObjectHandle) ComposerFrom(srcs ...*ObjectHandle) *Composer</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom">func (*ObjectHandle) CopierFrom
-</h3>
-        <div class="markdown level1 summary"><p>CopierFrom creates a Copier that can copy src to dst.
-You can immediately call Run on the returned Copier, or
-you can configure it first.</p>
-<p>For Requester Pays buckets, the user project of dst is billed, unless it is empty,
-in which case the user project of src is billed.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (dst *ObjectHandle) CopierFrom(src *ObjectHandle) *Copier</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom_examples">Examples</h5>
-        <h6 translate="no">rotateEncryptionKeys</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-var key1, key2 []byte
-
-func main() {
-	// To rotate the encryption key on an object, copy it onto itself.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	obj := client.Bucket(&quot;bucketname&quot;).Object(&quot;obj&quot;)
-	// Assume obj is encrypted with key1, and we want to change to key2.
-	_, err = obj.Key(key2).CopierFrom(obj.Key(key1)).Run(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete">func (*ObjectHandle) Delete
-</h3>
-        <div class="markdown level1 summary"><p>Delete deletes the single specified object.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) Delete(ctx context.Context) error</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_Delete_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// To delete multiple objects in a bucket, list them with an
-	// ObjectIterator, then Delete them.
-
-	// If you are using this package on the App Engine Flex runtime,
-	// you can init a bucket client with your app's default bucket name.
-	// See http://godoc.org/google.golang.org/appengine/file#DefaultBucketName.
-	bucket := client.Bucket(&quot;my-bucket&quot;)
-	it := bucket.Objects(ctx, nil)
-	for {
-		objAttrs, err := it.Next()
-		if err != nil &amp;&amp; err != iterator.Done {
-			// TODO: Handle error.
-		}
-		if err == iterator.Done {
-			break
-		}
-		if err := bucket.Object(objAttrs.Name).Delete(ctx); err != nil {
-			// TODO: Handle error.
-		}
-	}
-	fmt.Println(&quot;deleted all object items in the bucket specified.&quot;)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation">func (*ObjectHandle) Generation
-</h3>
-        <div class="markdown level1 summary"><p>Generation returns a new ObjectHandle that operates on a specific generation
-of the object.
-By default, the handle operates on the latest generation. Not
-all operations work when given a specific generation; check the API
-endpoints at <a href="https://cloud.google.com/storage/docs/json_api/">https://cloud.google.com/storage/docs/json_api/</a> for details.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) Generation(gen int64) *ObjectHandle</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_Generation_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;io&quot;
-	&quot;os&quot;
-)
-
-var gen int64
-
-func main() {
-	// Read an object's contents from generation gen, regardless of the
-	// current generation of the object.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
-	rc, err := obj.Generation(gen).NewReader(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	defer rc.Close()
-	if _, err := io.Copy(os.Stdout, rc); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If">func (*ObjectHandle) If
-</h3>
-        <div class="markdown level1 summary"><p>If returns a new ObjectHandle that applies a set of preconditions.
-Preconditions already set on the ObjectHandle are ignored.
-Operations on the new handle will return an error if the preconditions are not
-satisfied. See <a href="https://cloud.google.com/storage/docs/generations-preconditions">https://cloud.google.com/storage/docs/generations-preconditions</a>
-for more details.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) If(conds Conditions) *ObjectHandle</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_If_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;google.golang.org/api/googleapi&quot;
-	&quot;io&quot;
-	&quot;net/http&quot;
-	&quot;os&quot;
-)
-
-var gen int64
-
-func main() {
-	// Read from an object only if the current generation is gen.
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
-	rc, err := obj.If(storage.Conditions{GenerationMatch: gen}).NewReader(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	if _, err := io.Copy(os.Stdout, rc); err != nil {
-		// TODO: handle error.
-	}
-	if err := rc.Close(); err != nil {
-		switch ee := err.(type) {
-		case *googleapi.Error:
-			if ee.Code == http.StatusPreconditionFailed {
-				// The condition presented in the If failed.
-				// TODO: handle error.
-			}
-
-			// TODO: handle other status codes here.
-
-		default:
-			// TODO: handle error.
-		}
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key">func (*ObjectHandle) Key
-</h3>
-        <div class="markdown level1 summary"><p>Key returns a new ObjectHandle that uses the supplied encryption
-key to encrypt and decrypt the object&#39;s contents.</p>
-<p>Encryption key must be a 32-byte AES-256 key.
-See <a href="https://cloud.google.com/storage/docs/encryption">https://cloud.google.com/storage/docs/encryption</a> for details.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) Key(encryptionKey []byte) *ObjectHandle</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_Key_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-var secretKey []byte
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	obj := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;)
-	// Encrypt the object's contents.
-	w := obj.Key(secretKey).NewWriter(ctx)
-	if _, err := w.Write([]byte(&quot;top secret&quot;)); err != nil {
-		// TODO: handle error.
-	}
-	if err := w.Close(); err != nil {
-		// TODO: handle error.
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader">func (*ObjectHandle) NewRangeReader
-</h3>
-        <div class="markdown level1 summary"><p>NewRangeReader reads part of an object, reading at most length bytes
-starting at the given offset. If length is negative, the object is read
-until the end. If offset is negative, the object is read abs(offset) bytes
-from the end, and length must also be negative to indicate all remaining
-bytes will be read.</p>
-<p>If the object&#39;s metadata property &quot;Content-Encoding&quot; is set to &quot;gzip&quot; or satisfies
-decompressive transcoding per <a href="https://cloud.google.com/storage/docs/transcoding">https://cloud.google.com/storage/docs/transcoding</a>
-that file will be served back whole, regardless of the requested range as
-Google Cloud Storage dictates.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) NewRangeReader(ctx context.Context, offset, length int64) (r *Reader, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;io/ioutil&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Read only the first 64K.
-	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, 0, 64*1024)
-	if err != nil {
-		// TODO: handle error.
-	}
-	defer rc.Close()
-
-	slurp, err := ioutil.ReadAll(rc)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Printf(&quot;first 64K of file contents:\n%s\n&quot;, slurp)
-}
-</code></pre>
-        </div>
-        <h6 translate="no">lastNBytes</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;io/ioutil&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Read only the last 10 bytes until the end of the file.
-	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, -10, -1)
-	if err != nil {
-		// TODO: handle error.
-	}
-	defer rc.Close()
-
-	slurp, err := ioutil.ReadAll(rc)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Printf(&quot;Last 10 bytes from the end of the file:\n%s\n&quot;, slurp)
-}
-</code></pre>
-        </div>
-        <h6 translate="no">untilEnd</h6>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;io/ioutil&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Read from the 101st byte until the end of the file.
-	rc, err := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewRangeReader(ctx, 100, -1)
-	if err != nil {
-		// TODO: handle error.
-	}
-	defer rc.Close()
-
-	slurp, err := ioutil.ReadAll(rc)
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Printf(&quot;From 101st byte until the end:\n%s\n&quot;, slurp)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader">func (*ObjectHandle) NewReader
-</h3>
-        <div class="markdown level1 summary"><p>NewReader creates a new Reader to read the contents of the
-object.
-ErrObjectNotExist will be returned if the object is not found.</p>
-<p>The caller must call Close on the returned Reader when done reading.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) NewReader(ctx context.Context) (*Reader, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_NewReader_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;io/ioutil&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	rc, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).NewReader(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	slurp, err := ioutil.ReadAll(rc)
-	rc.Close()
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(&quot;file contents:&quot;, slurp)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter">func (*ObjectHandle) NewWriter
-</h3>
-        <div class="markdown level1 summary"><p>NewWriter returns a storage Writer that writes to the GCS object
-associated with this ObjectHandle.</p>
-<p>A new object will be created unless an object with this name already exists.
-Otherwise any previous object with the same name will be replaced.
-The object will not be available (and any previous object will remain)
-until Close has been called.</p>
-<p>Attributes can be set on the object by modifying the returned Writer&#39;s
-ObjectAttrs field before the first call to Write. If no ContentType
-attribute is specified, the content type will be automatically sniffed
-using net/http.DetectContentType.</p>
-<p>It is the caller&#39;s responsibility to call Close when writing is done. To
-stop writing without saving the data, cancel the context.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) NewWriter(ctx context.Context) *Writer</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_NewWriter_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	wc := client.Bucket(&quot;bucketname&quot;).Object(&quot;filename1&quot;).NewWriter(ctx)
-	_ = wc // TODO: Use the Writer.
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName">func (*ObjectHandle) ObjectName
-</h3>
-        <div class="markdown level1 summary"><p>ObjectName returns the name of the object.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) ObjectName() string</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed">func (*ObjectHandle) ReadCompressed
-</h3>
-        <div class="markdown level1 summary"><p>ReadCompressed when true causes the read to happen without decompressing.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) ReadCompressed(compressed bool) *ObjectHandle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update">func (*ObjectHandle) Update
-</h3>
-        <div class="markdown level1 summary"><p>Update updates an object with the provided attributes.
-All zero-value attributes are ignored.
-ErrObjectNotExist will be returned if the object is not found.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (o *ObjectHandle) Update(ctx context.Context, uattrs ObjectAttrsToUpdate) (oa *ObjectAttrs, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectHandle_Update_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Change only the content type of the object.
-	objAttrs, err := client.Bucket(&quot;my-bucket&quot;).Object(&quot;my-object&quot;).Update(ctx, storage.ObjectAttrsToUpdate{
-		ContentType:        &quot;text/html&quot;,
-		ContentDisposition: &quot;&quot;, // delete ContentDisposition
-	})
-	if err != nil {
-		// TODO: handle error.
-	}
-	fmt.Println(objAttrs)
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next">func (*ObjectIterator) Next
-</h3>
-        <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
-there are no more results. Once Next returns iterator.Done, all subsequent
-calls will return iterator.Done.</p>
-<p>If Query.Delimiter is non-empty, some of the ObjectAttrs returned by Next will
-have a non-empty Prefix field, and a zero value for all other fields. These
-represent prefixes.</p>
-<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *ObjectIterator) Next() (*ObjectAttrs, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_ObjectIterator_Next_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;context&quot;
-	&quot;fmt&quot;
-	&quot;google.golang.org/api/iterator&quot;
-)
-
-func main() {
-	ctx := context.Background()
-	client, err := storage.NewClient(ctx)
-	if err != nil {
-		// TODO: handle error.
-	}
-	it := client.Bucket(&quot;my-bucket&quot;).Objects(ctx, nil)
-	for {
-		objAttrs, err := it.Next()
-		if err == iterator.Done {
-			break
-		}
-		if err != nil {
-			// TODO: Handle error.
-		}
-		fmt.Println(objAttrs)
-	}
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo">func (*ObjectIterator) PageInfo
-</h3>
-        <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
-<p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (it *ObjectIterator) PageInfo() *iterator.PageInfo</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4">func GenerateSignedPostPolicyV4
-</h3>
-        <div class="markdown level1 summary"><p>GenerateSignedPostPolicyV4 generates a PostPolicyV4 value from bucket, object and opts.
-The generated URL and fields will then allow an unauthenticated client to perform multipart uploads.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func GenerateSignedPostPolicyV4(bucket, object string, opts *PostPolicyV4Options) (*PostPolicyV4, error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
-
-import (
-	&quot;bytes&quot;
-	&quot;cloud.google.com/go/storage&quot;
-	&quot;io&quot;
-	&quot;mime/multipart&quot;
-	&quot;net/http&quot;
-	&quot;time&quot;
-)
-
-func main() {
-	pv4, err := storage.GenerateSignedPostPolicyV4(&quot;my-bucket&quot;, &quot;my-object.txt&quot;, &amp;storage.PostPolicyV4Options{
-		GoogleAccessID: &quot;my-access-id&quot;,
-		PrivateKey:     []byte(&quot;my-private-key&quot;),
-
-		// The upload expires in 2hours.
-		Expires: time.Now().Add(2 * time.Hour),
-
-		Fields: &amp;storage.PolicyV4Fields{
-			StatusCodeOnSuccess:    200,
-			RedirectToURLOnSuccess: &quot;https://example.org/&quot;,
-			// It MUST only be a text file.
-			ContentType: &quot;text/plain&quot;,
-		},
-
-		// The conditions that the uploaded file will be expected to conform to.
-		Conditions: []storage.PostPolicyV4Condition{
-			// Make the file a maximum of 10mB.
-			storage.ConditionContentLengthRange(0, 10&lt;&lt;20),
-		},
-	})
-	if err != nil {
-		// TODO: handle error.
-	}
-
-	// Now you can upload your file using the generated post policy
-	// with a plain HTTP client or even the browser.
-	formBuf := new(bytes.Buffer)
-	mw := multipart.NewWriter(formBuf)
-	for fieldName, value := range pv4.Fields {
-		if err := mw.WriteField(fieldName, value); err != nil {
-			// TODO: handle error.
-		}
-	}
-	file := bytes.NewReader(bytes.Repeat([]byte(&quot;a&quot;), 100))
-
-	mf, err := mw.CreateFormFile(&quot;file&quot;, &quot;myfile.txt&quot;)
-	if err != nil {
-		// TODO: handle error.
-	}
-	if _, err := io.Copy(mf, file); err != nil {
-		// TODO: handle error.
-	}
-	if err := mw.Close(); err != nil {
-		// TODO: handle error.
-	}
-
-	// Compose the request.
-	req, err := http.NewRequest(&quot;POST&quot;, pv4.URL, formBuf)
-	if err != nil {
-		// TODO: handle error.
-	}
-	// Ensure the Content-Type is derived from the multipart writer.
-	req.Header.Set(&quot;Content-Type&quot;, mw.FormDataContentType())
-	res, err := http.DefaultClient.Do(req)
-	if err != nil {
-		// TODO: handle error.
-	}
-	_ = res
-}
-</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange">func ConditionContentLengthRange
-</h3>
-        <div class="markdown level1 summary"><p>ConditionContentLengthRange constraints the limits that the
-multipart upload&#39;s range header will be expected to be within.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func ConditionContentLengthRange(start, end uint64) PostPolicyV4Condition</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith">func ConditionStartsWith
-</h3>
-        <div class="markdown level1 summary"><p>ConditionStartsWith checks that an attributes starts with value.
-An empty value will cause this condition to be ignored.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func ConditionStartsWith(key, value string) PostPolicyV4Condition</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection">func (*Query) SetAttrSelection
-</h3>
-        <div class="markdown level1 summary"><p>SetAttrSelection makes the query populate only specific attributes of
-objects. When iterating over objects, if you only need each object&#39;s name
-and size, pass []string{&quot;Name&quot;, &quot;Size&quot;} to this method. Only these fields
-will be fetched for each object across the network; the other fields of
-ObjectAttr will remain at their default values. This is a performance
-optimization; for more information, see
-<a href="https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance">https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance</a></p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (q *Query) SetAttrSelection(attrs []string) error</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl">func (*Reader) CacheControl
-</h3>
-        <div class="markdown level1 summary"><p>CacheControl returns the cache control of the object.</p>
-<p>Deprecated: use Reader.Attrs.CacheControl.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) CacheControl() string</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close">func (*Reader) Close
-</h3>
-        <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) Close() error</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding">func (*Reader) ContentEncoding
-</h3>
-        <div class="markdown level1 summary"><p>ContentEncoding returns the content encoding of the object.</p>
-<p>Deprecated: use Reader.Attrs.ContentEncoding.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) ContentEncoding() string</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType">func (*Reader) ContentType
-</h3>
-        <div class="markdown level1 summary"><p>ContentType returns the content type of the object.</p>
-<p>Deprecated: use Reader.Attrs.ContentType.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) ContentType() string</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified">func (*Reader) LastModified
-</h3>
-        <div class="markdown level1 summary"><p>LastModified returns the value of the Last-Modified header.</p>
-<p>Deprecated: use Reader.Attrs.LastModified.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) LastModified() (time.Time, error)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read">func (*Reader) Read
-</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) Read(p []byte) (int, error)</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain">func (*Reader) Remain
-</h3>
-        <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) Remain() int64</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size">func (*Reader) Size
-</h3>
-        <div class="markdown level1 summary"><p>Size returns the size of the object in bytes.
-The returned value is always the same and is not affected by
-calls to Read or Close.</p>
-<p>Deprecated: use Reader.Attrs.Size.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (r *Reader) Size() int64</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname">func BucketBoundHostname
-</h3>
-        <div class="markdown level1 summary"><p>BucketBoundHostname generates a URL with a custom hostname tied to a
-specific GCS bucket. The desired hostname should be passed in using the
-hostname argument. Generated urls will be of the form
-&quot;<bucket-bound-hostname>/<object-name>&quot;. See
-<a href="https://cloud.google.com/storage/docs/request-endpoints#cname">https://cloud.google.com/storage/docs/request-endpoints#cname</a> and
-<a href="https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers">https://cloud.google.com/load-balancing/docs/https/adding-backend-buckets-to-load-balancers</a>
-for details. Note that for CNAMEs, only HTTP is supported, so Insecure must
-be set to true.<p>
-</object-name></bucket-bound-hostname></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func BucketBoundHostname(hostname string) URLStyle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle">func PathStyle
-</h3>
-        <div class="markdown level1 summary"><p>PathStyle is the default style, and will generate a URL of the form
-&quot;storage.googleapis.com/<bucket-name>/<object-name>&quot;.<p>
-</object-name></bucket-name></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func PathStyle() URLStyle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle">func VirtualHostedStyle
-</h3>
-        <div class="markdown level1 summary"><p>VirtualHostedStyle generates a URL relative to the bucket&#39;s virtual
-hostname, e.g. &quot;<bucket-name>.storage.googleapis.com/<object-name>&quot;.<p>
-</object-name></bucket-name></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func VirtualHostedStyle() URLStyle</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs">func (*Writer) Attrs
-</h3>
-        <div class="markdown level1 summary"><p>Attrs returns metadata about a successfully-written object.
+        
+            <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs">func (*Writer) Attrs
+</h4>
+            <div class="markdown level1 summary"><p>Attrs returns metadata about a successfully-written object.
 It&#39;s only valid to call it after Close returns nil.</p>
 </div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (w *Writer) Attrs() *ObjectAttrs</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close">func (*Writer) Close
-</h3>
-        <div class="markdown level1 summary"><p>Close completes the write operation and flushes any buffered data.
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (w *Writer) Attrs() *ObjectAttrs</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close">func (*Writer) Close
+</h4>
+            <div class="markdown level1 summary"><p>Close completes the write operation and flushes any buffered data.
 If Close doesn&#39;t return an error, metadata about the written object
 can be retrieved by calling Attrs.</p>
 </div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (w *Writer) Close() error</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError">func (*Writer) CloseWithError
-</h3>
-        <div class="markdown level1 summary"><p>CloseWithError aborts the write operation with the provided error.
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (w *Writer) Close() error</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError">func (*Writer) CloseWithError
+</h4>
+            <div class="markdown level1 summary"><p>CloseWithError aborts the write operation with the provided error.
 CloseWithError always returns nil.</p>
 <p>Deprecated: cancel the context passed to NewWriter instead.</p>
 </div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (w *Writer) CloseWithError(err error) error</code></pre>
-        </div>
-        <h3 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write">func (*Writer) Write
-</h3>
-        <div class="markdown level1 summary"><p>Write appends to w. It implements the io.Writer interface.</p>
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (w *Writer) CloseWithError(err error) error</code></pre>
+            </div>
+                      <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write">func (*Writer) Write
+</h4>
+            <div class="markdown level1 summary"><p>Write appends to w. It implements the io.Writer interface.</p>
 <p>Since writes happen asynchronously, Write may return a nil
 error even though the write failed (or will fail). Always
 use the error returned from Writer.Close to determine if
@@ -3908,14 +4288,14 @@ the upload was successful.</p>
 <p>Writes will be retried on transient errors from the server, unless
 Writer.ChunkSize has been set to zero.</p>
 </div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="lang-go hljs">func (w *Writer) Write(p []byte) (n int, err error)</code></pre>
-        </div>
-        <h5 id="cloud_google_com_go_storage_Writer_Write_examples">Examples</h5>
-        <div class="codewrapper">
-          <pre><code>package main
+            <div class="markdown level1 conceptual"></div>
+            <h5 class="decalaration">Declaration</h5>
+            <div class="codewrapper">
+              <pre><code class="lang-go hljs">func (w *Writer) Write(p []byte) (n int, err error)</code></pre>
+            </div>
+            <h5 id="cloud_google_com_go_storage_Writer_Write_examples">Examples</h5>
+            <div class="codewrapper">
+            <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3943,10 +4323,10 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 </code></pre>
-        </div>
-        <h6 translate="no">checksum</h6>
-        <div class="codewrapper">
-          <pre><code>package main
+            </div>
+            <h6 translate="no">checksum</h6>
+            <div class="codewrapper">
+            <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3976,10 +4356,10 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 </code></pre>
-        </div>
-        <h6 translate="no">timeout</h6>
-        <div class="codewrapper">
-          <pre><code>package main
+            </div>
+            <h6 translate="no">timeout</h6>
+            <div class="codewrapper">
+            <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4010,7 +4390,10 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 </code></pre>
-        </div>
+            </div>
+    <h2 id="functions">Functions
+  
+  </h2>
         <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL">func SignedURL
 </h3>
         <div class="markdown level1 summary"><p>SignedURL returns a URL for the specified object. Signed URLs allow
@@ -4025,7 +4408,7 @@ URLs, see <a href="https://cloud.google.com/storage/docs/accesscontrol#Signed-UR
         </div>
         <h5 id="cloud_google_com_go_storage_SignedURL_examples">Examples</h5>
         <div class="codewrapper">
-          <pre><code>package main
+        <pre><code>package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4052,6 +4435,7 @@ func main() {
 }
 </code></pre>
         </div>
+  
 </article>
           </div>
         </div>

--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -41,6 +41,8 @@ exports.transform = function (model) {
     }
   }
 
+  console.log(JSON.stringify(model, null, "  "));
+
   return model;
 }
 
@@ -171,16 +173,27 @@ function groupParameters(parameters) {
   return groupedParameters;
 }
 
-function groupChildren(model, category, typeChildrenItems) {
+function groupChildren(model, category, typeChildrenItems, itemToModify) {
   if (!model || !model.type) {
     return;
   }
+  if (!itemToModify) itemToModify = model;
   if (!typeChildrenItems) {
     var typeChildrenItems = getDefinitions(category);
   }
   var grouped = {};
 
   normalizeLanguageValuePairs(model.children).forEach(function (c) {
+    if (c.langs && c.langs[0] === "go") {
+      // Skip if this child has a different parent.
+      if (c.parent && c.parent[0].value.uid != itemToModify.uid) return;
+
+      // Group all of this child's children.
+      if (c.uid !== model.uid) {
+        groupChildren(model, category, typeChildrenItem, c);
+      }
+    }
+
     if (c.isEii) {
       var type = "eii";
     } else {
@@ -233,7 +246,7 @@ function groupChildren(model, category, typeChildrenItems) {
     }
   }
 
-  model.children = children;
+  itemToModify.children = children;
 }
 
 function getTypePropertyName(type) {
@@ -287,6 +300,7 @@ function getDefinitions(category) {
     "variable":     { inVariable: true,     typePropertyName: "inVariable",     id: "variables",    isEmbedded: true },
     "type":         { inTypes: true,        typePropertyName: "inTypes",        id: "types",        isEmbedded: true },
     "function":     { inFunction: true,     typePropertyName: "inFunction",     id: "functions",    isEmbedded: true },
+    "method":       { inMethod: true,       typePropertyName: "inMethod",       id: "methods",      isEmbedded: true },
     "typealias":    { inTypeAlias: true,    typePropertyName: "inTypeAlias",    id: "typealiases",  isEmbedded: true },
   };
   var classItems = {

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
@@ -1,0 +1,22 @@
+{{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
+{{#example.0}}
+<h5 id="{{id}}_examples">{{__global.examples}}</h5>
+{{/example.0}}
+{{^example.0}}
+{{#codeexamples.0}}
+<h5 id="{{id}}_examples">{{__global.examples}}</h5>
+{{/codeexamples.0}}
+{{/example.0}}
+{{#codeexamples}}
+{{#name}}
+{{^name.0}}
+<h6 translate="no">{{name}}</h6>
+{{/name.0}}
+{{/name}}
+<div class="codewrapper">
+<pre><code>{{content}}</code></pre>
+</div>
+{{/codeexamples}}
+{{#example}}
+{{{.}}}
+{{/example}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -173,27 +173,7 @@
       <h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
       <div class="markdown level1 remarks">{{{remarks}}}</div>
       {{/remarks}}
-      {{#example.0}}
-      <h5 id="{{id}}_examples">{{__global.examples}}</h5>
-      {{/example.0}}
-      {{^example.0}}
-      {{#codeexamples.0}}
-      <h5 id="{{id}}_examples">{{__global.examples}}</h5>
-      {{/codeexamples.0}}
-      {{/example.0}}
-      {{#codeexamples}}
-      {{#name}}
-      {{^name.0}}
-      <h6 translate="no">{{name}}</h6>
-      {{/name.0}}
-      {{/name}}
-      <div class="codewrapper">
-        <pre><code>{{content}}</code></pre>
-      </div>
-      {{/codeexamples}}
-      {{#example}}
-      {{{.}}}
-      {{/example}}
+      {{>partials/uref/namespace.examples}}
       {{#exceptions.0}}
       <h5 class="exceptions">{{__global.exceptions}}</h5>
       <table class="table table-bordered table-striped table-condensed">
@@ -230,6 +210,22 @@
       {{#seealso.0}}
       </div>
       {{/seealso.0}}
+
+      {{#children}}
+        {{! Note: don't print the Functions/Methods headers for children of children.}}
+        {{#children}}
+          <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+          <div class="markdown level1 summary">{{{summary}}}</div>
+          <div class="markdown level1 conceptual">{{{conceptual}}}</div>
+          {{#syntax}}
+          <h5 class="decalaration">{{__global.declaration}}</h5>
+          <div class="codewrapper">
+            <pre><code class="lang-{{syntax.content.0.lang}} hljs">{{syntax.content.0.value}}</code></pre>
+          </div>
+          {{/syntax}}
+          {{>partials/uref/namespace.examples}}  
+        {{/children}}
+      {{/children}}
     {{/children}}
   {{/isEmbedded}}
 {{/children}}


### PR DESCRIPTION
This makes it so when we're rendering a Go package, types have their methods/functions/consts/vars show up right under the type definition, rather than separately. For example, see http://pkg.go.dev/cloud.google.com/go/storage.

Other languages render each "class" as a separate page (rather than all on a single package/namespace page). So, this change isn't needed for them.

When docfx is rendering the index.yaml, the "type" of the page is "package." Packages are referred to as "namespaces." When you look at the index.yaml file, each element has a UID, the UID of a "parent", and a list of children items. When methods/functions/consts/vars are children of the type they're for, they don't show up when rendering the namespace. So, I kept them as children of the package.

But, funnily enough, the "parent" and "children" fields don't need to agree. So, this PR relies on the fact that the "parent" of each of the Go type elements is the type item, even if they are "children" of the package item.

I wish these weren't referred to as children/parents.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR

cc @codyoss @broady 