### PR TITLE
chore: remove errant console.log

### DIFF
--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -41,8 +41,6 @@ exports.transform = function (model) {
     }
   }
 
-  console.log(JSON.stringify(model, null, "  "));
-
   return model;
 }
 


### PR DESCRIPTION
This was helpful for development, but I forgot to delete it. Now, it's
spamming the logs.