### PR TITLE
fix: remove noisy titles and docfx versions

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AnalyzeIamPolicyResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AnalyzeIamPolicyResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.AccessContextPolicyOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.AccessContextPolicyOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum Asset.AccessContextPolicyOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum Asset.AccessContextPolicyOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Asset
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Asset
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetService.AssetServiceBase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetService.AssetServiceBase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetService.AssetServiceClient
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetService.AssetServiceClient
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetService
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetService
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetServiceClient
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetServiceClient
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetServiceClientBuilder
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetServiceClientBuilder
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetServiceClientImpl
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetServiceClientImpl
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AssetServiceSettings
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AssetServiceSettings
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class BatchGetAssetsHistoryRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class BatchGetAssetsHistoryRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class BatchGetAssetsHistoryResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class BatchGetAssetsHistoryResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class BigQueryDestination
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class BigQueryDestination
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ContentType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ContentType.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum ContentType
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum ContentType
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class CreateFeedRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class CreateFeedRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class DeleteFeedRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class DeleteFeedRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ExportAssetsRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ExportAssetsRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ExportAssetsResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ExportAssetsResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ExportIamPolicyAnalysisRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ExportIamPolicyAnalysisRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ExportIamPolicyAnalysisResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ExportIamPolicyAnalysisResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Feed
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Feed
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.ResourceNameType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.ResourceNameType.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum FeedName.ResourceNameType
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum FeedName.ResourceNameType
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class FeedName
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class FeedName
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.DestinationOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum FeedOutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum FeedOutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class FeedOutputConfig
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class FeedOutputConfig
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.ObjectUriOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.ObjectUriOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum GcsDestination.ObjectUriOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum GcsDestination.ObjectUriOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class GcsDestination
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class GcsDestination
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class GcsOutputResult
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class GcsOutputResult
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class GetFeedRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class GetFeedRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum IamPolicyAnalysisOutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum IamPolicyAnalysisOutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisOutputConfig.Types.BigQueryDestination
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisOutputConfig.Types.BigQueryDestination
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisOutputConfig.Types.GcsDestination
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisOutputConfig.Types.GcsDestination
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisOutputConfig.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisOutputConfig.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisOutputConfig
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisOutputConfig
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery.Types.AccessSelector
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery.Types.AccessSelector
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery.Types.IdentitySelector
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery.Types.IdentitySelector
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery.Types.Options
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery.Types.Options
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery.Types.ResourceSelector
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery.Types.ResourceSelector
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisQuery
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisQuery
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.Access
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.Access
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.AccessControlList
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.AccessControlList
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.Edge
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.Edge
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.Identity
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.Identity
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.IdentityList
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.IdentityList
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types.Resource
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types.Resource
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisResult
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisResult
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicyAnalysisState
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicyAnalysisState
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicySearchResult.Types.Explanation.Types.Permissions
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicySearchResult.Types.Explanation.Types.Permissions
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicySearchResult.Types.Explanation.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicySearchResult.Types.Explanation.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicySearchResult.Types.Explanation
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicySearchResult.Types.Explanation
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicySearchResult.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicySearchResult.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class IamPolicySearchResult
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class IamPolicySearchResult
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListFeedsRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListFeedsRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListFeedsResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListFeedsResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.DestinationOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum OutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum OutputConfig.DestinationOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class OutputConfig
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class OutputConfig
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.ResultOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.ResultOneofCase.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum OutputResult.ResultOneofCase
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum OutputResult.ResultOneofCase
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class OutputResult
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class OutputResult
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class PubsubDestination
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class PubsubDestination
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Resource
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Resource
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ResourceSearchResult
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ResourceSearchResult
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SearchAllIamPoliciesRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SearchAllIamPoliciesRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SearchAllIamPoliciesResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SearchAllIamPoliciesResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SearchAllResourcesRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SearchAllResourcesRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SearchAllResourcesResponse
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SearchAllResourcesResponse
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.PriorAssetState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.PriorAssetState.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Enum TemporalAsset.Types.PriorAssetState
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Enum TemporalAsset.Types.PriorAssetState
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TemporalAsset.Types
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TemporalAsset.Types
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TemporalAsset
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TemporalAsset
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TimeWindow
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TimeWindow
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class UpdateFeedRequest
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class UpdateFeedRequest
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Namespace Google.Cloud.Asset.V1
-   | Google.Cloud.Asset.V1 </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Namespace Google.Cloud.Asset.V1
-   | Google.Cloud.Asset.V1 ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/dotnet/_project.yaml">
     <meta name="book_path" value="/dotnet/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package cloud.google.com/go/storage
-   </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package cloud.google.com/go/storage
-   ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/go/_project.yaml">
     <meta name="book_path" value="/go/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TextToSpeechAsyncClient
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TextToSpeechAsyncClient
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TextToSpeechClient
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TextToSpeechClient
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package text_to_speech
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package text_to_speech
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.AudioConfig.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.AudioConfig.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AudioConfig
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AudioConfig
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListVoicesRequest
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListVoicesRequest
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListVoicesResponse
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListVoicesResponse
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesisInput.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesisInput.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesisInput
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesisInput
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesizeSpeechRequest
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesizeSpeechRequest
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesizeSpeechResponse
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesizeSpeechResponse
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.Voice.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.Voice.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Voice
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Voice
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.VoiceSelectionParams.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.VoiceSelectionParams.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class VoiceSelectionParams
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class VoiceSelectionParams
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package types
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package types
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TextToSpeechAsyncClient
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TextToSpeechAsyncClient
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TextToSpeechClient
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TextToSpeechClient
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package text_to_speech
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package text_to_speech
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.AudioConfig.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.AudioConfig.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class AudioConfig
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class AudioConfig
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListVoicesRequest
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListVoicesRequest
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class ListVoicesResponse
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class ListVoicesResponse
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesisInput.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesisInput.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesisInput
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesisInput
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class TimepointType
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class TimepointType
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesizeSpeechRequest
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesizeSpeechRequest
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class SynthesizeSpeechResponse
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class SynthesizeSpeechResponse
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Timepoint.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Timepoint.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Timepoint
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Timepoint
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Voice.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Voice.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class Voice
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class Voice
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Class VoiceSelectionParams
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Class VoiceSelectionParams
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package types
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package types
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/testdata/goldens/python-small/index.html
+++ b/testdata/goldens/python-small/index.html
@@ -6,19 +6,14 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <title>Package google-cloud-texttospeech
-   | texttospeech </title>
+  </title>
     <meta name="viewport" content="width=device-width">
     <meta name="title" content="Package google-cloud-texttospeech
-   | texttospeech ">
-    <meta name="generator" content="docfx 2.56.1.0">
+  ">
     
     <link rel="shortcut icon" href="../favicon.ico">
     <meta name="project_path" value="/python/_project.yaml">
     <meta name="book_path" value="/python/_book.yaml">
-    <meta property="docfx:navrel" content="">
-    <meta property="docfx:tocrel" content="toc.html">
-    
-    
     
   </head>
   <body data-spy="scroll" data-target="#affix" data-offset="120">

--- a/third_party/docfx/templates/devsite/partials/head.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/head.tmpl.partial
@@ -3,17 +3,12 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-  <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}</title>
+  <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}}</title>
   <meta name="viewport" content="width=device-width">
-  <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
-  <meta name="generator" content="docfx {{_docfxVersion}}">
+  <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}}">
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
   <meta name="project_path" value="{{_projectPath}}_project.yaml" />
   <meta name="book_path" value="{{_projectPath}}_book.yaml" />
-  <meta property="docfx:navrel" content="{{_navRel}}">
-  <meta property="docfx:tocrel" content="{{_tocRel}}">
   {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
-  {{#_enableSearch}}<meta property="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
-  {{#_enableNewTab}}<meta property="docfx:newtab" content="true">{{/_enableNewTab}}
 </head>


### PR DESCRIPTION
Removed "|app titles" and docfx versions that are no longer needed

Fixes #18 
