### PR TITLE
fix: copy undefined check from updated default template

### DIFF
--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -118,6 +118,8 @@ function joinType(parameter) {
   var joinTypeProperty = function (type, key) {
     if (!type || !type[0] || !type[0][key]) return null;
     var value = type.map(function (t) {
+      if (!t) return null;
+      if (!t[key]) return t.uid;
       return t[key][0].value;
     }).join(' | ');
     return [{


### PR DESCRIPTION
I tested generating the problematic tarball with the default template and it worked. So, I did a diff of the JS file and noticed this change. I copied it over and generation now works with our customized template.

We need this file customized to have better support for grouping related elements together (in particular, Go functions & methods under their respective types).

Fixes #40.