### PR TITLE
fix: missing source code highlight on example code

### DIFF
--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -326,7 +326,7 @@ They are sometimes referred to as grantees.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_Delete_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -357,7 +357,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_List_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -391,7 +391,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_Set_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -701,7 +701,7 @@ Use Client.Bucket to get a handle.</p>
         <h5 id="cloud_google_com_go_storage_BucketHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
-        <pre><code>{% verbatim %}package main
+        <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -743,7 +743,7 @@ This call does not perform any network operations.</p>
             <h5 id="cloud_google_com_go_storage_BucketHandle_ACL_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -783,7 +783,7 @@ returned Notification&#39;s ID can be used to refer to it.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_AddNotification_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -821,7 +821,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Attrs_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -855,7 +855,7 @@ If attrs is nil the API defaults will be used.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Create_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -888,7 +888,7 @@ This call does not perform any network operations.</p>
             <h5 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -926,7 +926,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Delete_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -956,7 +956,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -993,7 +993,7 @@ func main() {
             <h5 id="cloud_google_com_go_storage_BucketHandle_IAM_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1036,7 +1036,7 @@ and MetagenerationNotMatch.</p>
             <h5 id="cloud_google_com_go_storage_BucketHandle_If_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1081,7 +1081,7 @@ subject to any SLA or deprecation policy.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1120,7 +1120,7 @@ indexed by notification ID.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Notifications_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1161,7 +1161,7 @@ for valid object names can be found at:
             <h5 id="cloud_google_com_go_storage_BucketHandle_Object_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1201,7 +1201,7 @@ If q is nil, no filtering is done.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Objects_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1230,7 +1230,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Update_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1256,7 +1256,7 @@ func main() {
             </div>
             <h6 translate="no">readModifyWrite</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1305,7 +1305,7 @@ project rather than to the bucket&#39;s owning project.</p>
             <h5 id="cloud_google_com_go_storage_BucketHandle_UserProject_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1360,7 +1360,7 @@ calls will return iterator.Done.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_BucketIterator_Next_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1512,7 +1512,7 @@ are safe for concurrent use by multiple goroutines.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_Client_NewClient_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1539,7 +1539,7 @@ func main() {
             </div>
             <h6 translate="no">unauthenticated</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1591,7 +1591,7 @@ are returned.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_Client_Buckets_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1631,7 +1631,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_Client_CreateHMACKey_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1676,7 +1676,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_Client_ListHMACKeys_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1707,7 +1707,7 @@ func main() {
             </div>
             <h6 translate="no">forServiceAccountEmail</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1738,7 +1738,7 @@ func main() {
             </div>
             <h6 translate="no">showDeletedKeys</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1810,7 +1810,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_Composer_Run_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1948,7 +1948,7 @@ for details on how these operate.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_Copier_Run_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1985,7 +1985,7 @@ func main() {
             </div>
             <h6 translate="no">progress</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2097,7 +2097,7 @@ After deletion, a key cannot be used to authenticate requests.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Delete_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2134,7 +2134,7 @@ userProject to be billed against for operations.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Get_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2169,7 +2169,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Update_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2674,7 +2674,7 @@ Use BucketHandle.Object to get a handle.</p>
         <h5 id="cloud_google_com_go_storage_ObjectHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
-        <pre><code>{% verbatim %}package main
+        <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2716,7 +2716,7 @@ This call does not perform any network operations.</p>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ACL_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2755,7 +2755,7 @@ ErrObjectNotExist will be returned if the object is not found.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Attrs_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2779,7 +2779,7 @@ func main() {
             </div>
             <h6 translate="no">withConditions</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2823,7 +2823,7 @@ func main() {
             <h5 id="cloud_google_com_go_storage_ObjectHandle_BucketName_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2867,7 +2867,7 @@ to specify an encryption key for any of the source objects.</p>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2910,7 +2910,7 @@ in which case the user project of src is billed.</p>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom_examples">Examples</h5>
             <h6 translate="no">rotateEncryptionKeys</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2946,7 +2946,7 @@ func main() {
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Delete_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3000,7 +3000,7 @@ endpoints at <a href="https://cloud.google.com/storage/docs/json_api/">https://c
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Generation_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3046,7 +3046,7 @@ for more details.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_If_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3106,7 +3106,7 @@ See <a href="https://cloud.google.com/storage/docs/encryption">https://cloud.goo
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Key_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3152,7 +3152,7 @@ Google Cloud Storage dictates.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3184,7 +3184,7 @@ func main() {
             </div>
             <h6 translate="no">lastNBytes</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3216,7 +3216,7 @@ func main() {
             </div>
             <h6 translate="no">untilEnd</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3260,7 +3260,7 @@ ErrObjectNotExist will be returned if the object is not found.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewReader_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3310,7 +3310,7 @@ stop writing without saving the data, cancel the context.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewWriter_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3340,7 +3340,7 @@ func main() {
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ObjectName_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3379,7 +3379,7 @@ func main() {
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed_examples">Examples</h5>
             <h6 translate="no">exists</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3419,7 +3419,7 @@ ErrObjectNotExist will be returned if the object is not found.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Update_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3474,7 +3474,7 @@ represent prefixes.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_ObjectIterator_Next_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3579,7 +3579,7 @@ The generated URL and fields will then allow an unauthenticated client to perfor
             </div>
             <h5 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;bytes&quot;
@@ -4290,7 +4290,7 @@ Writer.ChunkSize has been set to zero.</p>
             </div>
             <h5 id="cloud_google_com_go_storage_Writer_Write_examples">Examples</h5>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4321,7 +4321,7 @@ func main() {
             </div>
             <h6 translate="no">checksum</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4354,7 +4354,7 @@ func main() {
             </div>
             <h6 translate="no">timeout</h6>
             <div class="codewrapper">
-            <pre><code>{% verbatim %}package main
+            <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4403,7 +4403,7 @@ URLs, see <a href="https://cloud.google.com/storage/docs/accesscontrol#Signed-UR
         </div>
         <h5 id="cloud_google_com_go_storage_SignedURL_examples">Examples</h5>
         <div class="codewrapper">
-        <pre><code>{% verbatim %}package main
+        <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
@@ -14,7 +14,7 @@
 {{/name.0}}
 {{/name}}
 <div class="codewrapper">
-<pre><code>{% verbatim %}{{content}}{% endverbatim %}</code></pre>
+<pre><code class="prettyprint">{% verbatim %}{{content}}{% endverbatim %}</code></pre>
 </div>
 {{/codeexamples}}
 {{#example}}


### PR DESCRIPTION
There were example code missing the "prettyprint" class for syntax
highlighting

Fixes #33 