### PR TITLE
fix!: only include the path for non-leaf TOC nodes

### DIFF
--- a/testdata/goldens/dotnet/toc.yaml
+++ b/testdata/goldens/dotnet/toc.yaml
@@ -1,7 +1,6 @@
 
 toc:
 - title: Google.Cloud.Asset.V1
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.html
   section:
   - title: AnalyzeIamPolicyRequest
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -170,7 +169,6 @@ toc:
   - title: UpdateFeedRequest
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.UpdateFeedRequest.html
 - title: Google.Cloud.Iam.V1
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: AuditConfigDelta
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -207,7 +205,6 @@ toc:
   - title: TestIamPermissionsResponse
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Cloud.OrgPolicy.V1
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: Policy
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -226,7 +223,6 @@ toc:
   - title: Policy.Types.RestoreDefault
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Identity.AccessContextManager.Type
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: DeviceEncryptionStatus
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -235,7 +231,6 @@ toc:
   - title: OsType
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Identity.AccessContextManager.V1
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: AccessLevel
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -270,7 +265,6 @@ toc:
   - title: ServicePerimeterConfig.Types.VpcAccessibleServices
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.LongRunning
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: CancelOperationRequest
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -311,7 +305,6 @@ toc:
   - title: WaitOperationRequest
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Api
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: Advice
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -532,7 +525,6 @@ toc:
   - title: UsageRule
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Rpc
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: BadRequest
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -581,7 +573,6 @@ toc:
   - title: StatusReflection
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Rpc.Context
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: AttributeContext
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -602,7 +593,6 @@ toc:
   - title: AttributeContextReflection
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Type
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: CalendarPeriod
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -663,7 +653,6 @@ toc:
   - title: TimeZone
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Api.Gax.Grpc
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: ApiBidirectionalStreamingCall<TRequest, TResponse>
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -718,7 +707,6 @@ toc:
   - title: ServiceSettingsBase
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Grpc.Core
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: AsyncAuthInterceptor
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -861,7 +849,6 @@ toc:
   - title: WriteOptions
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Grpc.Core.Interceptors
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: CallInvokerExtensions
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -884,7 +871,6 @@ toc:
   - title: ServerServiceDefinitionExtensions
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Grpc.Core.Logging
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: ConsoleLogger
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -899,7 +885,6 @@ toc:
   - title: TextWriterLogger
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Grpc.Core.Utils
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: AsyncStreamExtensions
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -910,7 +895,6 @@ toc:
   - title: TaskUtils
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Protobuf
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: ByteString
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -973,7 +957,6 @@ toc:
   - title: WireFormat.WireType
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Protobuf.Collections
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: Lists
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -986,7 +969,6 @@ toc:
   - title: RepeatedField<T>
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Protobuf.Reflection
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: CustomOptions
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -1119,7 +1101,6 @@ toc:
   - title: UninterpretedOption.Types.NamePart
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Protobuf.WellKnownTypes
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: Any
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -1210,7 +1191,6 @@ toc:
   - title: WrappersReflection
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Api.Gax
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: BatchingSettings
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
@@ -1283,7 +1263,6 @@ toc:
   - title: VersionHeaderBuilder
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
 - title: Google.Api.Gax.ResourceNames
-  path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/
   section:
   - title: BillingAccountName
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/

--- a/testdata/goldens/go/toc.yaml
+++ b/testdata/goldens/go/toc.yaml
@@ -1,7 +1,6 @@
 
 toc:
 - title: cloud.google.com/go/storage
-  path: /go/docs/reference/cloud.google.com/go/latest/index.html
   section:
   - title: README
     path: /go/docs/reference/cloud.google.com/go/latest/pkg-readme.html

--- a/testdata/goldens/nodejs/toc.yaml
+++ b/testdata/goldens/nodejs/toc.yaml
@@ -1,7 +1,6 @@
 
 toc:
 - title: scheduler
-  path: /nodejs/docs/reference/scheduler/latest/
   section:
   - title: CustomHttpPattern
     path: /nodejs/docs/reference/scheduler/latest/

--- a/testdata/goldens/python-small/toc.yaml
+++ b/testdata/goldens/python-small/toc.yaml
@@ -1,12 +1,10 @@
 
 toc:
 - title: google-cloud-texttospeech
-  path: /python/docs/reference/texttospeech/latest/
   section:
   - title: Overview
     path: /python/docs/reference/texttospeech/latest/index.html
   - title: google.cloud.texttospeech_v1.services.text_to_speech
-    path: /python/docs/reference/texttospeech/latest/
     section:
     - title: Overview
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1.services.text_to_speech.html#google_cloud_texttospeech_v1_services_text_to_speech
@@ -15,7 +13,6 @@ toc:
     - title: google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html#google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient
   - title: google.cloud.texttospeech_v1.types
-    path: /python/docs/reference/texttospeech/latest/
     section:
     - title: Overview
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1.types.html#google_cloud_texttospeech_v1_types
@@ -36,7 +33,6 @@ toc:
     - title: google.cloud.texttospeech_v1.types.VoiceSelectionParams
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1.types.VoiceSelectionParams.html#google_cloud_texttospeech_v1_types_VoiceSelectionParams
   - title: google.cloud.texttospeech_v1beta1.services.text_to_speech
-    path: /python/docs/reference/texttospeech/latest/
     section:
     - title: Overview
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1beta1.services.text_to_speech.html#google_cloud_texttospeech_v1beta1_services_text_to_speech
@@ -45,7 +41,6 @@ toc:
     - title: google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html#google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient
   - title: google.cloud.texttospeech_v1beta1.types
-    path: /python/docs/reference/texttospeech/latest/
     section:
     - title: Overview
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1beta1.types.html#google_cloud_texttospeech_v1beta1_types
@@ -58,7 +53,6 @@ toc:
     - title: google.cloud.texttospeech_v1beta1.types.SynthesisInput
       path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1beta1.types.SynthesisInput.html#google_cloud_texttospeech_v1beta1_types_SynthesisInput
     - title: google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest
-      path: /python/docs/reference/texttospeech/latest/
       section:
       - title: Overview
         path: /python/docs/reference/texttospeech/latest/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.html#google_cloud_texttospeech_v1beta1_types_SynthesizeSpeechRequest

--- a/third_party/docfx/templates/devsite/partials/li.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/li.tmpl.partial
@@ -1,7 +1,9 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 {{#items}}
 - title: {{{name}}}
+  {{#leaf}}
   path: {{_rootPath}}/{{topicHref}}
+  {{/leaf}}
   {{^leaf}}
   section:
   {{>partials/li}}


### PR DESCRIPTION
This avoids DevSite implicitly adding "Overview" elements to the TOC.

Note that after this is in use, languages which are *relying* on the
implicit "Overview" link should modify their generation process to
include such a link explicitly.

Fixes internally-reported issue.