### PR TITLE
cleanup: moving declaration content up

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -52,20 +52,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor">AnalyzeIamPolicyRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +85,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery">AnalysisQuery</h3>
-  <div class="markdown level1 summary"><p>The request query.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The request query.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,6 +108,9 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout">ExecutionTimeout</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Duration ExecutionTimeout { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Amount of time executable has to complete.  See JSON representation of
 <a href="https://developers.google.com/protocol-buffers/docs/proto3#json">Duration</a>.</p>
 <p>If this field is set with a value less than the RPC deadline, and the
@@ -135,10 +135,6 @@ If it&apos;s not finished until then, you will get a  DEADLINE_EXCEEDED error.</
 (--   about.                                                         --)</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Duration ExecutionTimeout { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -63,20 +63,18 @@ unmatched_node_count(implicit)</li>
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor">Stats()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -98,14 +96,13 @@ unmatched_node_count(implicit)</li>
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount">CappedNodeCount</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int CappedNodeCount { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The count of nodes that get explored, but are capped by max fanout
 setting.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int CappedNodeCount { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,13 +120,12 @@ setting.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount">DiscoveredNodeCount</h3>
-  <div class="markdown level1 summary"><p>The count of discovered nodes.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int DiscoveredNodeCount { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The count of discovered nodes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,13 +143,12 @@ setting.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount">ExecutionTimeoutNodeCount</h3>
-  <div class="markdown level1 summary"><p>The count of unexplored nodes caused by execution timeout.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExecutionTimeoutNodeCount { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The count of unexplored nodes caused by execution timeout.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,13 +166,12 @@ setting.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount">ExploredNodeCount</h3>
-  <div class="markdown level1 summary"><p>The count of explored nodes.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExploredNodeCount { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The count of explored nodes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -195,14 +189,13 @@ setting.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount">MatchedNodeCount</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int MatchedNodeCount { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The count of nodes that match the query. These nodes form a sub-graph
 of discovered nodes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int MatchedNodeCount { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -220,6 +213,9 @@ of discovered nodes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype">NodeSubtype</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string NodeSubtype { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The subtype of a node, such as:</p>
 <ul>
 <li>For Identity: Group, User, ServiceAccount etc.</li>
@@ -229,10 +225,6 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string NodeSubtype { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,13 +242,12 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType">NodeType</h3>
-  <div class="markdown level1 summary"><p>Node type.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType NodeType { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Node type.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,13 +265,12 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount">PermisionDeniedNodeCount</h3>
-  <div class="markdown level1 summary"><p>The count of unexplored nodes caused by permission denied error.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PermisionDeniedNodeCount { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The count of unexplored nodes caused by permission denied error.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor">IamPolicyAnalysis()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery">AnalysisQuery</h3>
-  <div class="markdown level1 summary"><p>The analysis query.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The analysis query.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,14 +107,13 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults">AnalysisResults</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult&gt; AnalysisResults { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of [google.cloud.asset.v1.IamPolicyAnalysisResult][google.cloud.asset.v1.IamPolicyAnalysisResult]
 that matches the analysis query, or empty if no result is found.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult&gt; AnalysisResults { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,15 +131,14 @@ that matches the analysis query, or empty if no result is found.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored">FullyExplored</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Represents whether all entries in the
 [analysis_results][analysis_results] have been fully explored to answer
 the query.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,13 +156,12 @@ the query.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors">NonCriticalErrors</h3>
-  <div class="markdown level1 summary"><p>A list of non-critical errors happened during the query handling.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisState&gt; NonCriticalErrors { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>A list of non-critical errors happened during the query handling.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,13 +179,12 @@ the query.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats">Stats</h3>
-  <div class="markdown level1 summary"><p>The stats of how the analysis has been explored.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats&gt; Stats { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The stats of how the analysis has been explored.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -52,20 +52,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor">AnalyzeIamPolicyResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,15 +85,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored">FullyExplored</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Represents whether all entries in the [main_analysis][main_analysis] and
 [service_account_impersonation_analysis][] have been fully explored to
 answer the query in the request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,13 +110,12 @@ answer the query in the request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis">MainAnalysis</h3>
-  <div class="markdown level1 summary"><p>The main analysis that matches the original request.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis MainAnalysis { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The main analysis that matches the original request.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,15 +133,14 @@ answer the query in the request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis">ServiceAccountImpersonationAnalysis</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis&gt; ServiceAccountImpersonationAnalysis { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The service account impersonation analysis if
 [google.cloud.asset.v1.AnalyzeIamPolicyRequest.analyze_service_account_impersonation][google.cloud.asset.v1.AnalyzeIamPolicyRequest.analyze_service_account_impersonation]
 is enabled.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis&gt; ServiceAccountImpersonationAnalysis { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -58,20 +58,18 @@ for more information.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset__ctor" data-uid="Google.Cloud.Asset.V1.Asset.#ctor">Asset()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)">Asset(Asset)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)">Asset(Asset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset(Asset other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,12 +91,11 @@ for more information.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase_" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase">AccessContextPolicyCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset.AccessContextPolicyOneofCase AccessContextPolicyCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,14 +113,13 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessLevel_" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_AccessLevel" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel">AccessLevel</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public AccessLevel AccessLevel { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-levels">access level user
 guide</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public AccessLevel AccessLevel { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,14 +137,13 @@ guide</a>.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_AccessPolicy" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy">AccessPolicy</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public AccessPolicy AccessPolicy { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-policies">access policy user
 guide</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public AccessPolicy AccessPolicy { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,6 +161,9 @@ guide</a>.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Ancestors_" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_Ancestors" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors">Ancestors</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Ancestors { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The ancestry path of an asset in Google Cloud <a href="https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy">resource
 hierarchy</a>,
 represented as a list of relative resource names. An ancestry path starts
@@ -175,10 +173,6 @@ asset itself.</p>
 <p>Example: <code>[&amp;quot;projects/123456789&amp;quot;, &amp;quot;folders/5432&amp;quot;, &amp;quot;organizations/1234&amp;quot;]</code></p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Ancestors { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,16 +190,15 @@ asset itself.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AssetType_" data-uid="Google.Cloud.Asset.V1.Asset.AssetType*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_AssetType" data-uid="Google.Cloud.Asset.V1.Asset.AssetType">AssetType</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The type of the asset. Example: <code>compute.googleapis.com/Disk</code></p>
 <p>See <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types">Supported asset
 types</a>
 for more information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,6 +216,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_IamPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_IamPolicy" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy">IamPolicy</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Policy IamPolicy { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A representation of the Cloud IAM policy set on a Google Cloud resource.
 There can be a maximum of one Cloud IAM policy set on any given resource.
 In addition, Cloud IAM policies inherit their granted access scope from any
@@ -234,10 +230,6 @@ the hierarchy. See
 more information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Policy IamPolicy { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,6 +247,9 @@ more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Name_" data-uid="Google.Cloud.Asset.V1.Asset.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_Name" data-uid="Google.Cloud.Asset.V1.Asset.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The full name of the asset. Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code></p>
 <p>See <a href="https://cloud.google.com/apis/design/resource_names#full_resource_name">Resource
@@ -262,10 +257,6 @@ names</a>
 for more information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,16 +274,15 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_OrgPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_OrgPolicy" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy">OrgPolicy</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;Policy&gt; OrgPolicy { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A representation of an <a href="https://cloud.google.com/resource-manager/docs/organization-policy/overview#organization_policy">organization
 policy</a>.
 There can be more than one organization policy with different constraints
 set on a given resource.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;Policy&gt; OrgPolicy { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -310,13 +300,12 @@ set on a given resource.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Resource_" data-uid="Google.Cloud.Asset.V1.Asset.Resource*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_Resource" data-uid="Google.Cloud.Asset.V1.Asset.Resource">Resource</h3>
-  <div class="markdown level1 summary"><p>A representation of the resource.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource Resource { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>A representation of the resource.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -334,13 +323,12 @@ set on a given resource.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ResourceName_" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_ResourceName" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName">ResourceName</h3>
-  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Asset.html#Google_Cloud_Asset_V1_Asset_Name">Name</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ResourceName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Asset.html#Google_Cloud_Asset_V1_Asset_Name">Name</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,14 +346,13 @@ set on a given resource.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ServicePerimeter_" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_ServicePerimeter" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter">ServicePerimeter</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public ServicePerimeter ServicePerimeter { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/vpc-service-controls/docs/overview">service perimeter user
 guide</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public ServicePerimeter ServicePerimeter { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,14 +370,13 @@ guide</a>.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_UpdateTime_" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset_UpdateTime" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime">UpdateTime</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The last update timestamp of an asset. update_time is updated when
 create/update/delete operation is performed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -45,14 +45,13 @@ public abstract class AssetServiceBase</code></pre>
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.ServerCallContext)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,6 +94,9 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.ServerCallContext)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -104,10 +106,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,14 +148,13 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.ServerCallContext)">CreateFeed(CreateFeedRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeed(CreateFeedRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeed(CreateFeedRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,13 +197,12 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.ServerCallContext)">DeleteFeed(DeleteFeedRequest, ServerCallContext)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Empty&gt; DeleteFeed(DeleteFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,6 +245,9 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.ServerCallContext)">ExportAssets(ExportAssetsRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportAssets(ExportAssetsRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -261,10 +260,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportAssets(ExportAssetsRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,6 +302,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.ServerCallContext)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -318,10 +316,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,13 +358,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.ServerCallContext)">GetFeed(GetFeedRequest, ServerCallContext)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeed(GetFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,13 +406,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.ServerCallContext)">ListFeeds(ListFeedsRequest, ServerCallContext)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeeds(ListFeedsRequest request, ServerCallContext context)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,16 +454,15 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.ServerCallContext)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,16 +505,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.ServerCallContext)">SearchAllResources(SearchAllResourcesRequest, ServerCallContext)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;SearchAllResourcesResponse&gt; SearchAllResources(SearchAllResourcesRequest request, ServerCallContext context)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;SearchAllResourcesResponse&gt; SearchAllResources(SearchAllResourcesRequest request, ServerCallContext context)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,13 +556,12 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.ServerCallContext)">UpdateFeed(UpdateFeedRequest, ServerCallContext)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeed(UpdateFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -52,22 +52,20 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor">AssetServiceClient()</h3>
-  <div class="markdown level1 summary"><p>Protected parameterless constructor to allow creation of test doubles.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)">AssetServiceClient(CallInvoker)</h3>
-  <div class="markdown level1 summary"><p>Creates a new client for AssetService that uses a custom <code>CallInvoker</code>.</p>
+  <div class="markdown level1 summary"><p>Protected parameterless constructor to allow creation of test doubles.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)">AssetServiceClient(CallInvoker)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(CallInvoker callInvoker)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new client for AssetService that uses a custom <code>CallInvoker</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,13 +86,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)">AssetServiceClient(Channel)</h3>
-  <div class="markdown level1 summary"><p>Creates a new client for AssetService</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(Channel channel)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new client for AssetService</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,13 +112,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
-  <div class="markdown level1 summary"><p>Protected constructor to allow creation of configured clients.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Protected constructor to allow creation of configured clients.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,14 +140,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,14 +189,13 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,14 +250,13 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,14 +299,13 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,6 +360,9 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -377,10 +372,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -423,6 +414,9 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -432,10 +426,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -490,6 +480,9 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -499,10 +492,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -545,6 +534,9 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -554,10 +546,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,14 +600,13 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)">CreateFeed(CreateFeedRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,14 +649,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">CreateFeed(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -724,14 +710,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)">CreateFeedAsync(CreateFeedRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,14 +759,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">CreateFeedAsync(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,14 +820,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient">CreateOperationsClient()</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operations.OperationsClient CreateOperationsClient()</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a new instance of <span class="xref">Google.LongRunning.Operations.OperationsClient</span> using the same call invoker as
 this client.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operations.OperationsClient CreateOperationsClient()</code></pre>
-  </div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,13 +845,12 @@ this client.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)">DeleteFeed(DeleteFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -911,13 +893,12 @@ this client.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">DeleteFeed(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,13 +953,12 @@ this client.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)">DeleteFeedAsync(DeleteFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,13 +1001,12 @@ this client.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">DeleteFeedAsync(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1082,6 +1061,9 @@ this client.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)">ExportAssets(ExportAssetsRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1094,10 +1076,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,6 +1118,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportAssets(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1152,10 +1133,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,6 +1187,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)">ExportAssetsAsync(ExportAssetsRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1222,10 +1202,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1268,6 +1244,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportAssetsAsync(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1280,10 +1259,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,6 +1313,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1349,10 +1327,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1395,6 +1369,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1406,10 +1383,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1464,6 +1437,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1475,10 +1451,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1521,6 +1493,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1532,10 +1507,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1590,13 +1561,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)">GetFeed(GetFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1639,13 +1609,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">GetFeed(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1700,13 +1669,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)">GetFeedAsync(GetFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1749,13 +1717,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">GetFeedAsync(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1810,13 +1777,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)">ListFeeds(ListFeedsRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1859,13 +1825,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ListFeeds(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1920,13 +1885,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)">ListFeedsAsync(ListFeedsRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1969,13 +1933,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ListFeedsAsync(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2030,13 +1993,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">NewInstance(ClientBase.ClientBaseConfiguration)</h3>
-  <div class="markdown level1 summary"><p>Creates a new instance of client from given <code>ClientBaseConfiguration</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override AssetService.AssetServiceClient NewInstance(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new instance of client from given <code>ClientBaseConfiguration</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2073,16 +2035,15 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><span class="xref">Grpc.Core.ClientBase&lt;Google.Cloud.Asset.V1.AssetService.AssetServiceClient&gt;.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2125,16 +2086,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2189,16 +2149,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2241,16 +2200,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2305,16 +2263,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)">SearchAllResources(SearchAllResourcesRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2357,16 +2314,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllResources(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2421,16 +2377,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallOptions)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallOptions options)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallOptions options)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2473,16 +2428,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllResourcesAsync(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2537,13 +2491,12 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)">UpdateFeed(UpdateFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2586,13 +2539,12 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">UpdateFeed(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2647,13 +2599,12 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)">UpdateFeedAsync(UpdateFeedRequest, CallOptions)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2696,13 +2647,12 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">UpdateFeedAsync(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -44,13 +44,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Google.Cloud.Asset.V1.AssetService.AssetServiceBase)">BindService(AssetService.AssetServiceBase)</h3>
-  <div class="markdown level1 summary"><p>Creates service definition that can be registered with a server</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServerServiceDefinition BindService(AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates service definition that can be registered with a server</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +85,13 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Grpc_Core_ServiceBinderBase_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Grpc.Core.ServiceBinderBase,Google.Cloud.Asset.V1.AssetService.AssetServiceBase)">BindService(ServiceBinderBase, AssetService.AssetServiceBase)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static void BindService(ServiceBinderBase serviceBinder, AssetService.AssetServiceBase serviceImpl)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
 Note: this method is part of an experimental API that can change or be removed without any prior notice.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static void BindService(ServiceBinderBase serviceBinder, AssetService.AssetServiceBase serviceImpl)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -48,14 +48,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint">DefaultEndpoint</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static string DefaultEndpoint { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The default endpoint for the AssetService service, which is a host of &quot;cloudasset.googleapis.com&quot; and a port
 of 443.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static string DefaultEndpoint { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,13 +72,12 @@ of 443.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes">DefaultScopes</h3>
-  <div class="markdown level1 summary"><p>The default AssetService scopes.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static IReadOnlyList&lt;string&gt; DefaultScopes { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The default AssetService scopes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -101,13 +99,12 @@ of 443.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient">ExportAssetsOperationsClient</h3>
-  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -125,13 +122,12 @@ of 443.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient">ExportIamPolicyAnalysisOperationsClient</h3>
-  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -149,13 +145,12 @@ of 443.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient">GrpcClient</h3>
-  <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -175,14 +170,13 @@ of 443.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,14 +219,13 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,14 +268,13 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,System.Threading.CancellationToken)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,6 +317,9 @@ which resources.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -334,10 +329,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,6 +371,9 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -389,10 +383,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,6 +425,9 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,System.Threading.CancellationToken)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -444,10 +437,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -490,14 +479,13 @@ error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_Create_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_Create" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create">Create()</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static AssetServiceClient Create()</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Synchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static AssetServiceClient Create()</code></pre>
-  </div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,14 +504,13 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync(System.Threading.CancellationToken)">CreateAsync(CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static Task&lt;AssetServiceClient&gt; CreateAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Asynchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static Task&lt;AssetServiceClient&gt; CreateAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,14 +547,13 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,14 +596,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(String, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Feed CreateFeed(string parent, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Feed CreateFeed(string parent, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,14 +649,13 @@ should be created in. It can only be an organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -714,14 +698,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,System.Threading.CancellationToken)">CreateFeedAsync(CreateFeedRequest, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,14 +747,13 @@ asset updates.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(String, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,14 +800,13 @@ should be created in. It can only be an organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,System.Threading.CancellationToken)">CreateFeedAsync(String, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -872,13 +853,12 @@ should be created in. It can only be an organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -905,13 +885,12 @@ should be created in. It can only be an organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(FeedName, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,13 +920,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,13 +955,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1026,13 +1003,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,System.Threading.CancellationToken)">DeleteFeedAsync(DeleteFeedRequest, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1075,13 +1051,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(FeedName, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1127,13 +1102,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)">DeleteFeedAsync(FeedName, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1179,13 +1153,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,13 +1204,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,System.Threading.CancellationToken)">DeleteFeedAsync(String, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1283,6 +1255,9 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1295,10 +1270,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1341,6 +1312,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1353,10 +1327,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1399,6 +1369,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,System.Threading.CancellationToken)">ExportAssetsAsync(ExportAssetsRequest, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1411,10 +1384,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,6 +1426,9 @@ finishes within 5 minutes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1468,10 +1440,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1514,6 +1482,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1525,10 +1496,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1571,6 +1538,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,System.Threading.CancellationToken)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CancellationToken)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CancellationToken cancellationToken)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -1582,10 +1552,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CancellationToken cancellationToken)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1628,13 +1594,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">GetFeed(FeedName, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1680,13 +1645,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeed(GetFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1729,13 +1693,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">GetFeed(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1781,13 +1744,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(FeedName, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1833,13 +1795,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)">GetFeedAsync(FeedName, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1885,13 +1846,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1934,13 +1894,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,System.Threading.CancellationToken)">GetFeedAsync(GetFeedRequest, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1983,13 +1942,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2035,13 +1993,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,System.Threading.CancellationToken)">GetFeedAsync(String, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2087,13 +2044,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(ListFeedsRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2136,13 +2092,12 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(System.String,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2187,13 +2142,12 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2236,13 +2190,12 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,System.Threading.CancellationToken)">ListFeedsAsync(ListFeedsRequest, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2285,13 +2238,12 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2336,13 +2288,12 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,System.Threading.CancellationToken)">ListFeedsAsync(String, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2387,13 +2338,12 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportAssets(String, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of <code>ExportAssets</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; PollOnceExportAssets(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of <code>ExportAssets</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2436,14 +2386,13 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportAssetsAsync(String, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; PollOnceExportAssetsAsync(string operationName, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportAssets</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; PollOnceExportAssetsAsync(string operationName, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2486,14 +2435,13 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportIamPolicyAnalysis(String, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; PollOnceExportIamPolicyAnalysis(string operationName, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; PollOnceExportIamPolicyAnalysis(string operationName, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2536,14 +2484,13 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportIamPolicyAnalysisAsync(String, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; PollOnceExportIamPolicyAnalysisAsync(string operationName, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; PollOnceExportIamPolicyAnalysisAsync(string operationName, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2586,16 +2533,15 @@ listed. It can only be using project/folder/organization number (such as
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2638,16 +2584,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2746,16 +2691,15 @@ page.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2798,16 +2742,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2906,16 +2849,15 @@ page.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2958,16 +2900,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3082,16 +3023,15 @@ page.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3134,16 +3074,15 @@ otherwise the request will be rejected.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3258,15 +3197,14 @@ page.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync">ShutdownDefaultChannelsAsync()</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static Task ShutdownDefaultChannelsAsync()</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Shuts down any channels automatically created by <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_Create">Create()</a> and
 <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_">CreateAsync(CancellationToken)</a>. Channels which weren&apos;t automatically created are not
 affected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static Task ShutdownDefaultChannelsAsync()</code></pre>
-  </div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3290,13 +3228,12 @@ by another call to this method.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(Feed, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3343,13 +3280,12 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3392,13 +3328,12 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(Feed, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3445,13 +3380,12 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,System.Threading.CancellationToken)">UpdateFeedAsync(Feed, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3498,13 +3432,12 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3547,13 +3480,12 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,System.Threading.CancellationToken)">UpdateFeedAsync(UpdateFeedRequest, CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -111,13 +111,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter">DefaultGrpcAdapter</h3>
-  <div class="markdown level1 summary"><p>Returns the default <span class="xref">Google.Api.Gax.Grpc.GrpcAdapter</span>to use if not otherwise specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override GrpcAdapter DefaultGrpcAdapter { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns the default <span class="xref">Google.Api.Gax.Grpc.GrpcAdapter</span>to use if not otherwise specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,13 +136,12 @@
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.DefaultGrpcAdapter</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings">Settings</h3>
-  <div class="markdown level1 summary"><p>The settings to use for RPCs, or <code>null</code> for the default settings.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Settings { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The settings to use for RPCs, or <code>null</code> for the default settings.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,13 +161,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build">Build()</h3>
-  <div class="markdown level1 summary"><p>Builds the resulting client.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetServiceClient Build()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Builds the resulting client.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -189,13 +186,12 @@
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.Build()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync(System.Threading.CancellationToken)">BuildAsync(CancellationToken)</h3>
-  <div class="markdown level1 summary"><p>Builds the resulting client asynchronously.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AssetServiceClient&gt; BuildAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Builds the resulting client asynchronously.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,13 +228,12 @@
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.BuildAsync(System.Threading.CancellationToken)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool">GetChannelPool()</h3>
-  <div class="markdown level1 summary"><p>Returns the channel pool to use when no other options are specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override ChannelPool GetChannelPool()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns the channel pool to use when no other options are specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,13 +253,12 @@
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetChannelPool()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint">GetDefaultEndpoint()</h3>
-  <div class="markdown level1 summary"><p>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override string GetDefaultEndpoint()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -284,13 +278,12 @@
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetDefaultEndpoint()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes">GetDefaultScopes()</h3>
-  <div class="markdown level1 summary"><p>Returns the default scopes for this builder type, used if no scopes are otherwise specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override IReadOnlyList&lt;string&gt; GetDefaultScopes()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns the default scopes for this builder type, used if no scopes are otherwise specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -177,13 +177,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_Google_Cloud_Asset_V1_AssetService_AssetServiceClient_Google_Cloud_Asset_V1_AssetServiceSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor(Google.Cloud.Asset.V1.AssetService.AssetServiceClient,Google.Cloud.Asset.V1.AssetServiceSettings)">AssetServiceClientImpl(AssetService.AssetServiceClient, AssetServiceSettings)</h3>
-  <div class="markdown level1 summary"><p>Constructs a client wrapper for the AssetService service, with the specified gRPC client and settings.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClientImpl(AssetService.AssetServiceClient grpcClient, AssetServiceSettings settings)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a client wrapper for the AssetService service, with the specified gRPC client and settings.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,13 +211,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient">ExportAssetsOperationsClient</h3>
-  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -238,13 +236,12 @@
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient">AssetServiceClient.ExportAssetsOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient">ExportIamPolicyAnalysisOperationsClient</h3>
-  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,13 +261,12 @@
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient">AssetServiceClient.ExportIamPolicyAnalysisOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient">GrpcClient</h3>
-  <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -292,14 +288,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,14 +339,13 @@ which resources.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,6 +390,9 @@ which resources.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -405,10 +402,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,6 +446,9 @@ error.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -462,10 +458,6 @@ If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,14 +502,13 @@ error.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -562,14 +553,13 @@ asset updates.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeed(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,13 +604,12 @@ asset updates.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeedAsync(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,13 +638,12 @@ asset updates.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeed(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,6 +688,9 @@ asset updates.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeedAsync(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -712,10 +703,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -760,6 +747,9 @@ finishes within 5 minutes.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssets(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -772,10 +762,6 @@ result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -820,6 +806,9 @@ finishes within 5 minutes.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssetsAsync(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -831,10 +820,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -879,6 +864,9 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Exports the answers of which identities have what accesses on which
 resources to a Google Cloud Storage or a BigQuery destination. For Cloud
 Storage destination, the output format is the JSON format that represents a
@@ -890,10 +878,6 @@ seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -938,13 +922,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeed(GetFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -989,13 +972,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeed(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,13 +1022,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeedAsync(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(ListFeedsRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,13 +1072,12 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeeds(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,16 +1122,15 @@ metadata contains the request to help callers to map responses to requests.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeedsAsync(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1196,16 +1175,15 @@ otherwise the request will be rejected.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1250,16 +1228,15 @@ otherwise the request will be rejected.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1304,16 +1281,15 @@ otherwise the request will be rejected.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResources(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1358,13 +1334,12 @@ otherwise the request will be rejected.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1409,13 +1384,12 @@ otherwise the request will be rejected.</p>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.UpdateFeed(UpdateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
-  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -60,25 +60,23 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor">AssetServiceSettings()</h3>
-  <div class="markdown level1 summary"><p>Constructs a new <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a> object with default settings.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a> object with default settings.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings">AnalyzeIamPolicySettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicySettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.AnalyzeIamPolicy</code> and <code>AssetServiceClient.AnalyzeIamPolicyAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicySettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,14 +97,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings">BatchGetAssetsHistorySettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings BatchGetAssetsHistorySettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.BatchGetAssetsHistory</code> and <code>AssetServiceClient.BatchGetAssetsHistoryAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings BatchGetAssetsHistorySettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,14 +124,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings">CreateFeedSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings CreateFeedSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.CreateFeed</code> and <code>AssetServiceClient.CreateFeedAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings CreateFeedSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,14 +151,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings">DeleteFeedSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings DeleteFeedSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.DeleteFeed</code> and <code>AssetServiceClient.DeleteFeedAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings DeleteFeedSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,14 +178,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings">ExportAssetsOperationsSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public OperationsSettings ExportAssetsOperationsSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.ExportAssets</code> and
 <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public OperationsSettings ExportAssetsOperationsSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,14 +206,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings">ExportAssetsSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings ExportAssetsSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ExportAssets</code> and <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings ExportAssetsSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,14 +233,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings">ExportIamPolicyAnalysisOperationsSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public OperationsSettings ExportIamPolicyAnalysisOperationsSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.ExportIamPolicyAnalysis</code> and
 <code>AssetServiceClient.ExportIamPolicyAnalysisAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public OperationsSettings ExportIamPolicyAnalysisOperationsSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -269,15 +261,14 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings">ExportIamPolicyAnalysisSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings ExportIamPolicyAnalysisSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ExportIamPolicyAnalysis</code> and <code>AssetServiceClient.ExportIamPolicyAnalysisAsync</code>
 .</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings ExportIamPolicyAnalysisSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,14 +289,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings">GetFeedSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings GetFeedSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to <code>AssetServiceClient.GetFeed</code>
  and <code>AssetServiceClient.GetFeedAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings GetFeedSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,14 +316,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings">ListFeedsSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings ListFeedsSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ListFeeds</code> and <code>AssetServiceClient.ListFeedsAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings ListFeedsSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -354,14 +343,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings">SearchAllIamPoliciesSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings SearchAllIamPoliciesSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllIamPolicies</code> and <code>AssetServiceClient.SearchAllIamPoliciesAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings SearchAllIamPoliciesSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -382,14 +370,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings">SearchAllResourcesSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings SearchAllResourcesSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllResources</code> and <code>AssetServiceClient.SearchAllResourcesAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings SearchAllResourcesSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,14 +397,13 @@
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings">UpdateFeedSettings</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public CallSettings UpdateFeedSettings { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.UpdateFeed</code> and <code>AssetServiceClient.UpdateFeedAsync</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public CallSettings UpdateFeedSettings { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,13 +426,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone">Clone()</h3>
-  <div class="markdown level1 summary"><p>Creates a deep clone of this object, with all the same property values.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Clone()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a deep clone of this object, with all the same property values.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -465,13 +450,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault">GetDefault()</h3>
-  <div class="markdown level1 summary"><p>Get a new instance of the default <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceSettings GetDefault()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Get a new instance of the default <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor">BatchGetAssetsHistoryRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames">AssetNames</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of the full names of the assets.
 See: <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">https://cloud.google.com/asset-inventory/docs/resource-name-format</a>
 Example:</p>
@@ -94,10 +95,6 @@ Example:</p>
 size of the asset name list is 100 in one request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,13 +112,12 @@ size of the asset name list is 100 in one request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType">ContentType</h3>
-  <div class="markdown level1 summary"><p>Optional. The content type.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Optional. The content type.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,15 +135,14 @@ size of the asset name list is 100 in one request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent">Parent</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The relative name of the root asset. It can only be an
 organization number (such as &quot;organizations/123&quot;), a project ID (such as
 &quot;projects/my-project-id&quot;)&quot;, or a project number (such as &quot;projects/12345&quot;).</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,13 +160,12 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName">ParentAsResourceName</h3>
-  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html#Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent">Parent</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html#Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent">Parent</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -189,6 +183,9 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow">ReadTimeWindow</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public TimeWindow ReadTimeWindow { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. The time window for the asset history. Both start_time and
 end_time are optional and if set, it must be after the current time minus
 35 days. If end_time is not set, it is default to current timestamp.
@@ -197,10 +194,6 @@ returned. The returned results contain all temporal assets whose time
 window overlap with read_time_window.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public TimeWindow ReadTimeWindow { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor">BatchGetAssetsHistoryResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets">Assets</h3>
-  <div class="markdown level1 summary"><p>A list of assets with valid time windows.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;TemporalAsset&gt; Assets { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>A list of assets with valid time windows.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor">BigQueryDestination()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)">BigQueryDestination(BigQueryDestination)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)">BigQueryDestination(BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(BigQueryDestination other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,16 +84,15 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset*"></a>
   <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset">Dataset</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The BigQuery dataset in format
 &quot;projects/projectId/datasets/datasetId&quot;, to which the snapshot result
 should be exported. If this dataset does not exist, the export call returns
 an INVALID_ARGUMENT error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,16 +110,15 @@ an INVALID_ARGUMENT error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Force_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force*"></a>
   <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Force" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force">Force</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool Force { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If the destination table already exists and this flag is <code>TRUE</code>, the
 table will be overwritten by the contents of assets snapshot. If the flag
 is <code>FALSE</code> or unset and the destination table already exists, the export
 call returns an INVALID_ARGUMEMT error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool Force { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,15 +136,14 @@ call returns an INVALID_ARGUMEMT error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Table_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table*"></a>
   <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Table" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table">Table</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Table { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The BigQuery table to which the snapshot result should be
 written. If this table does not exist, a new table with the given name
 will be created.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Table { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor">CreateFeedRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)">CreateFeedRequest(CreateFeedRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)">CreateFeedRequest(CreateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest(CreateFeedRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed*"></a>
   <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed">Feed</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The feed details. The field <code>name</code> must be empty and it will be generated
 in the format of:
 projects/project_number/feeds/feed_id
@@ -93,10 +94,6 @@ folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,14 +111,13 @@ organizations/organization_number/feeds/feed_id</p>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId*"></a>
   <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId">FeedId</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string FeedId { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. This is the client-assigned asset feed identifier and it needs to
 be unique under a specific parent project/folder/organization.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string FeedId { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,6 +135,9 @@ be unique under a specific parent project/folder/organization.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent*"></a>
   <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent">Parent</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The name of the project/folder/organization where this feed
 should be created in. It can only be an organization number (such as
 &quot;organizations/123&quot;), a folder number (such as &quot;folders/123&quot;), a project ID
@@ -146,10 +145,6 @@ should be created in. It can only be an organization number (such as
 &quot;projects/12345&quot;).</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -50,20 +50,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor">DeleteFeedRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)">DeleteFeedRequest(DeleteFeedRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)">DeleteFeedRequest(DeleteFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest(DeleteFeedRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,13 +83,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName*"></a>
   <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName">FeedName</h3>
-  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html#Google_Cloud_Asset_V1_DeleteFeedRequest_Name">Name</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html#Google_Cloud_Asset_V1_DeleteFeedRequest_Name">Name</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,16 +106,15 @@
   </table>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The name of the feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor">ExportAssetsRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)">ExportAssetsRequest(ExportAssetsRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)">ExportAssetsRequest(ExportAssetsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest(ExportAssetsRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes">AssetTypes</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of asset types to take a snapshot for. For example:
 &quot;compute.googleapis.com/Disk&quot;.</p>
 <p>Regular expressions are also supported. For example:</p>
@@ -104,10 +105,6 @@ Inventory</a>
 for all supported asset types.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -125,14 +122,13 @@ for all supported asset types.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType">ContentType</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name will be
 returned.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,13 +146,12 @@ returned.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig">OutputConfig</h3>
-  <div class="markdown level1 summary"><p>Required. Output configuration indicating where the results will be output to.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Required. Output configuration indicating where the results will be output to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,16 +169,15 @@ returned.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent">Parent</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The relative name of the root asset. This can only be an
 organization number (such as &quot;organizations/123&quot;), a project ID (such as
 &quot;projects/my-project-id&quot;), or a project number (such as &quot;projects/12345&quot;),
 or a folder number (such as &quot;folders/123&quot;).</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -201,13 +195,12 @@ or a folder number (such as &quot;folders/123&quot;).</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName">ParentAsResourceName</h3>
-  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html#Google_Cloud_Asset_V1_ExportAssetsRequest_Parent">Parent</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html#Google_Cloud_Asset_V1_ExportAssetsRequest_Parent">Parent</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,6 +218,9 @@ or a folder number (such as &quot;folders/123&quot;).</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime">ReadTime</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Timestamp to take an asset snapshot. This can only be set to a timestamp
 between the current time and the current time minus 35 days (inclusive).
 If not specified, the current time will be used. Due to delays in resource
@@ -232,10 +228,6 @@ data collection and indexing, there is a volatile window during which
 running the same query may get different results.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -53,20 +53,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor">ExportAssetsResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)">ExportAssetsResponse(ExportAssetsResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)">ExportAssetsResponse(ExportAssetsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse(ExportAssetsResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,13 +86,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig">OutputConfig</h3>
-  <div class="markdown level1 summary"><p>Output configuration indicating where the results were output to.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Output configuration indicating where the results were output to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,6 +109,9 @@
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult">OutputResult</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public OutputResult OutputResult { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Output result indicating where the assets were exported to. For example, a
 set of actual Google Cloud Storage object uris where the assets are
 exported to. The uris can be different from what [output_config] has
@@ -119,10 +119,6 @@ specified, as the service will split the output object into multiple ones
 once it exceeds a single Google Cloud Storage object limit.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public OutputResult OutputResult { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,13 +136,12 @@ once it exceeds a single Google Cloud Storage object limit.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime">ReadTime</h3>
-  <div class="markdown level1 summary"><p>Time the snapshot was taken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Time the snapshot was taken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor">ExportIamPolicyAnalysisRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery">AnalysisQuery</h3>
-  <div class="markdown level1 summary"><p>The request query.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The request query.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +107,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig">OutputConfig</h3>
-  <div class="markdown level1 summary"><p>Output configuration indicating where the results will be output to.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Output configuration indicating where the results will be output to.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor">ExportIamPolicyAnalysisResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -55,20 +55,18 @@ Pub/Sub topics.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed__ctor" data-uid="Google.Cloud.Asset.V1.Feed.#ctor">Feed()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)">Feed(Feed)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)">Feed(Feed)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed(Feed other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,6 +88,9 @@ Pub/Sub topics.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed_AssetNames_" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_AssetNames" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames">AssetNames</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of the full names of the assets to receive updates. You must specify
 either or both of asset_names and asset_types. Only asset updates matching
 specified asset_names or asset_types are exported to the feed.
@@ -100,10 +101,6 @@ Names</a>
 for more info.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,6 +118,9 @@ for more info.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_AssetTypes_" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_AssetTypes" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes">AssetTypes</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of types of the assets to receive updates. You must specify either
 or both of asset_names and asset_types. Only asset updates matching
 specified asset_names or asset_types are exported to the feed.
@@ -130,10 +130,6 @@ topic</a>
 for a list of all supported asset types.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -151,6 +147,9 @@ for a list of all supported asset types.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Condition_" data-uid="Google.Cloud.Asset.V1.Feed.Condition*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_Condition" data-uid="Google.Cloud.Asset.V1.Feed.Condition">Condition</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Expr Condition { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A condition which determines whether an asset update should be published.
 If specified, an asset will be returned only when the expression evaluates
 to true.
@@ -163,10 +162,6 @@ guide</a>
 for detailed instructions.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Expr Condition { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -184,14 +179,13 @@ for detailed instructions.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_ContentType_" data-uid="Google.Cloud.Asset.V1.Feed.ContentType*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_ContentType" data-uid="Google.Cloud.Asset.V1.Feed.ContentType">ContentType</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name and
 type will be returned.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,13 +203,12 @@ type will be returned.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedName_" data-uid="Google.Cloud.Asset.V1.Feed.FeedName*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_FeedName" data-uid="Google.Cloud.Asset.V1.Feed.FeedName">FeedName</h3>
-  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Feed.html#Google_Cloud_Asset_V1_Feed_Name">Name</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Feed.html#Google_Cloud_Asset_V1_Feed_Name">Name</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,14 +226,13 @@ type will be returned.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig">FeedOutputConfig</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public FeedOutputConfig FeedOutputConfig { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. Feed output configuration defining where the asset updates are
 published to.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public FeedOutputConfig FeedOutputConfig { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,6 +250,9 @@ published to.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Name_" data-uid="Google.Cloud.Asset.V1.Feed.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed_Name" data-uid="Google.Cloud.Asset.V1.Feed.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The format will be
 projects/{project_number}/feeds/{client-assigned_feed_identifier} or
 folders/{folder_number}/feeds/{client-assigned_feed_identifier} or
@@ -266,10 +261,6 @@ organizations/{organization_number}/feeds/{client-assigned_feed_identifier}</p>
 project/folder/organization.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -43,14 +43,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName__ctor_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName__ctor_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor(System.String,System.String)">FeedName(String, String)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public FeedName(string projectId, string feedId)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Constructs a new instance of a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> class from the component parts of pattern
 <code>projects/{project}/feeds/{feed}</code></p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public FeedName(string projectId, string feedId)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -79,13 +78,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_FeedId_" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FeedId" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId">FeedId</h3>
-  <div class="markdown level1 summary"><p>The <code>Feed</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The <code>Feed</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,13 +101,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FolderId_" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FolderId" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId">FolderId</h3>
-  <div class="markdown level1 summary"><p>The <code>Folder</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FolderId { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The <code>Folder</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,13 +124,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern_" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern">IsKnownPattern</h3>
-  <div class="markdown level1 summary"><p>Whether this instance contains a resource name with a known pattern.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool IsKnownPattern { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Whether this instance contains a resource name with a known pattern.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -151,14 +147,13 @@
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_OrganizationId_" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_OrganizationId" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId">OrganizationId</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string OrganizationId { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The <code>Organization</code> ID. May be <code>null</code>, depending on which resource name is contained by this
 instance.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string OrganizationId { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,13 +171,12 @@ instance.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_ProjectId_" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_ProjectId" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId">ProjectId</h3>
-  <div class="markdown level1 summary"><p>The <code>Project</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ProjectId { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The <code>Project</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,13 +194,12 @@ instance.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_Type_" data-uid="Google.Cloud.Asset.V1.FeedName.Type*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_Type" data-uid="Google.Cloud.Asset.V1.FeedName.Type">Type</h3>
-  <div class="markdown level1 summary"><p>The <a class="xref" href="Google.Cloud.Asset.V1.FeedName.ResourceNameType.html">FeedName.ResourceNameType</a> of the contained resource name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName.ResourceNameType Type { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The <a class="xref" href="Google.Cloud.Asset.V1.FeedName.ResourceNameType.html">FeedName.ResourceNameType</a> of the contained resource name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -224,14 +217,13 @@ instance.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_UnparsedResource_" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_UnparsedResource" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource">UnparsedResource</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public UnparsedResourceName UnparsedResource { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The contained <span class="xref">Google.Api.Gax.UnparsedResourceName</span>. Only non-<code>null</code> if this instance contains an
 unparsed resource name.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public UnparsedResourceName UnparsedResource { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,14 +243,13 @@ unparsed resource name.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_Format_" data-uid="Google.Cloud.Asset.V1.FeedName.Format*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_Format_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Format(System.String,System.String)">Format(String, String)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static string Format(string projectId, string feedId)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static string Format(string projectId, string feedId)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,14 +293,13 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed(System.String,System.String)">FormatFolderFeed(String, String)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static string FormatFolderFeed(string folderId, string feedId)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>folders/{folder}/feeds/{feed}</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static string FormatFolderFeed(string folderId, string feedId)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -352,14 +342,13 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed(System.String,System.String)">FormatOrganizationFeed(String, String)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static string FormatOrganizationFeed(string organizationId, string feedId)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static string FormatOrganizationFeed(string organizationId, string feedId)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,14 +392,13 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed(System.String,System.String)">FormatProjectFeed(String, String)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static string FormatProjectFeed(string projectId, string feedId)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static string FormatProjectFeed(string projectId, string feedId)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,13 +442,12 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed(System.String,System.String)">FromFolderFeed(String, String)</h3>
-  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>folders/{folder}/feeds/{feed}</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromFolderFeed(string folderId, string feedId)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>folders/{folder}/feeds/{feed}</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,13 +490,12 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed(System.String,System.String)">FromOrganizationFeed(String, String)</h3>
-  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>organizations/{organization}/feeds/{feed}</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>organizations/{organization}/feeds/{feed}</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,13 +538,12 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed(System.String,System.String)">FromProjectFeed(String, String)</h3>
-  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>projects/{project}/feeds/{feed}</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromProjectFeed(string projectId, string feedId)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>projects/{project}/feeds/{feed}</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,13 +586,12 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_Google_Api_Gax_UnparsedResourceName_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed(Google.Api.Gax.UnparsedResourceName)">FromUnparsed(UnparsedResourceName)</h3>
-  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> containing an unparsed resource name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromUnparsed(UnparsedResourceName unparsedResourceName)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> containing an unparsed resource name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,13 +628,12 @@ unparsed resource name.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_GetHashCode_" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_GetHashCode" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode">GetHashCode()</h3>
-  <div class="markdown level1 summary"><p>Returns a hash code for this resource name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override int GetHashCode()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns a hash code for this resource name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,13 +653,12 @@ unparsed resource name.</p>
   <div><span class="xref">System.Object.GetHashCode()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)">Parse(String)</h3>
-  <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,14 +699,13 @@ unparsed resource name.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_System_Boolean_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String,System.Boolean)">Parse(String, Boolean)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static FeedName Parse(string feedName, bool allowUnparsed)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally allowing an
 unparseable resource name.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static FeedName Parse(string feedName, bool allowUnparsed)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,13 +755,12 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_ToString_" data-uid="Google.Cloud.Asset.V1.FeedName.ToString*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_ToString" data-uid="Google.Cloud.Asset.V1.FeedName.ToString">ToString()</h3>
-  <div class="markdown level1 summary"><p>The string representation of the resource name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override string ToString()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The string representation of the resource name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,13 +781,12 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div><span class="xref">System.Object.ToString()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)">TryParse(String, out FeedName)</h3>
-  <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, out FeedName result)</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -854,14 +833,13 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_System_Boolean_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,System.Boolean,Google.Cloud.Asset.V1.FeedName@)">TryParse(String, Boolean, out FeedName)</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static bool TryParse(string feedName, bool allowUnparsed, out FeedName result)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally
 allowing an unparseable resource name.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public static bool TryParse(string feedName, bool allowUnparsed, out FeedName result)</code></pre>
-  </div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,12 +897,11 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Equality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_op_Equality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)">Equality(FeedName, FeedName)</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator ==(FeedName a, FeedName b)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,12 +941,11 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Inequality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedName_op_Inequality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)">Inequality(FeedName, FeedName)</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator !=(FeedName a, FeedName b)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor">FeedOutputConfig()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)">FeedOutputConfig(FeedOutputConfig)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)">FeedOutputConfig(FeedOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig(FeedOutputConfig other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,12 +84,11 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase">DestinationCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,13 +106,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination">PubsubDestination</h3>
-  <div class="markdown level1 summary"><p>Destination on Pub/Sub.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination PubsubDestination { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Destination on Pub/Sub.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor">GcsDestination()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)">GcsDestination(GcsDestination)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)">GcsDestination(GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(GcsDestination other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,12 +84,11 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase_" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase">ObjectUriCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination.ObjectUriOneofCase ObjectUriCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,6 +106,9 @@
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri">Uri</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The uri of the Cloud Storage object. It&apos;s the same uri that is used by
 gsutil. Example: &quot;gs://bucket_name/object_name&quot;. See <a href="https://cloud.google.com/storage/docs/viewing-editing-metadata">Viewing and
 Editing Object
@@ -116,10 +116,6 @@ Metadata</a>
 for more information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,6 +133,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix_" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix">UriPrefix</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string UriPrefix { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The uri prefix of all generated Cloud Storage objects. Example:
 &quot;gs://bucket_name/object_name_prefix&quot;. Each object uri is in format:
 &quot;gs://bucket_name/object_name_prefix/&lt;asset type&gt;/&lt;shard number&gt; and only
@@ -148,10 +147,6 @@ returned if file with the same name &quot;gs://bucket_name/object_name_prefix&qu
 already exists.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string UriPrefix { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor">GcsOutputResult()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)">GcsOutputResult(GcsOutputResult)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)">GcsOutputResult(GcsOutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult(GcsOutputResult other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult_Uris_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsOutputResult_Uris" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris">Uris</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Uris { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>List of uris of the Cloud Storage objects. Example:
 &quot;gs://bucket_name/object_name&quot;.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Uris { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor">GetFeedRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)">GetFeedRequest(GetFeedRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)">GetFeedRequest(GetFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest(GetFeedRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName*"></a>
   <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName">FeedName</h3>
-  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html#Google_Cloud_Asset_V1_GetFeedRequest_Name">Name</a> resource name property.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html#Google_Cloud_Asset_V1_GetFeedRequest_Name">Name</a> resource name property.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,16 +107,15 @@
   </table>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The name of the Feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor">BigQueryDestination()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,15 +84,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset">Dataset</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The BigQuery dataset in format &quot;projects/projectId/datasets/datasetId&quot;,
 to which the analysis results should be exported. If this dataset does
 not exist, the export call will return an INVALID_ARGUMENT error.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,13 +109,12 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey">PartitionKey</h3>
-  <div class="markdown level1 summary"><p>The partition key for BigQuery partitioned table.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey PartitionKey { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The partition key for BigQuery partitioned table.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,6 +132,9 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix">TablePrefix</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string TablePrefix { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The prefix of the BigQuery tables to which the analysis results will be
 written. Tables will be created based on this table_prefix if not exist:</p>
 <ul>
@@ -147,10 +146,6 @@ on the [partition_key].</li>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string TablePrefix { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,14 +163,13 @@ on the [partition_key].</li>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode">WriteMode</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode WriteMode { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The write mode when table exists. WriteMode is ignored when no existing
 tables, or no existing partitions are found.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode WriteMode { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor">GcsDestination()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri">Uri</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The uri of the Cloud Storage object. It&apos;s the same uri that is used by
 gsutil. For example: &quot;gs://bucket_name/object_name&quot;. See <a href="https://cloud.google.com/storage/docs/viewing-editing-metadata">Viewing and
 Editing Object
@@ -93,10 +94,6 @@ Metadata</a>
 for more information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor">IamPolicyAnalysisOutputConfig()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination">BigqueryDestination</h3>
-  <div class="markdown level1 summary"><p>Destination on BigQuery.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Destination on BigQuery.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,12 +107,11 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase">DestinationCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,13 +129,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination">GcsDestination</h3>
-  <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.GcsDestination GcsDestination { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -54,20 +54,18 @@ any of them.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor">AccessSelector()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,13 +87,12 @@ any of them.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions">Permissions</h3>
-  <div class="markdown level1 summary"><p>The permissions to appear in result.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The permissions to appear in result.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,13 +110,12 @@ any of them.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles">Roles</h3>
-  <div class="markdown level1 summary"><p>The roles to appear in result.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Roles { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The roles to appear in result.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -53,20 +53,18 @@ directly or indirectly.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor">IdentitySelector()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,6 +86,9 @@ directly or indirectly.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity">Identity</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Identity { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The identity appear in the form of members in
 <a href="https://cloud.google.com/iam/reference/rest/v1/Binding">IAM policy
 binding</a>.</p>
@@ -100,10 +101,6 @@ binding</a>.</p>
 You must give a specific identity.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Identity { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor">Options()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options(IamPolicyAnalysisQuery.Types.Options other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation">AnalyzeServiceAccountImpersonation</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool AnalyzeServiceAccountImpersonation { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true, the response will include access analysis from identities to
 resources via service account impersonation. This is a very expensive
 operation, because many derived queries will be executed. We highly
@@ -109,10 +110,6 @@ F. And those advanced analysis results will be included in
 <p>Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool AnalyzeServiceAccountImpersonation { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,6 +127,9 @@ F. And those advanced analysis results will be included in
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups">ExpandGroups</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool ExpandGroups { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true, the identities section of the result will expand any
 Google groups appearing in an IAM policy binding.</p>
 <p>If
@@ -139,10 +139,6 @@ selector, and this flag is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool ExpandGroups { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,6 +156,9 @@ selector, and this flag is not allowed to set.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources">ExpandResources</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool ExpandResources { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true and
 [google.cloud.asset.v1.IamPolicyAnalysisQuery.resource_selector][google.cloud.asset.v1.IamPolicyAnalysisQuery.resource_selector]
 is not specified, the resource section of the result will expand any
@@ -179,10 +178,6 @@ who have permission P on that folder or any lower resource(ex. project).</p>
 <p>Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool ExpandResources { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,6 +195,9 @@ who have permission P on that folder or any lower resource(ex. project).</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles">ExpandRoles</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool ExpandRoles { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true, the access section of result will expand any roles
 appearing in IAM policy bindings to include their permissions.</p>
 <p>If
@@ -209,10 +207,6 @@ selector, and this flag is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool ExpandRoles { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -230,15 +224,14 @@ selector, and this flag is not allowed to set.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup">MaxFanoutsPerGroup</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int MaxFanoutsPerGroup { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The maximum number of fanouts per group when [expand_groups][expand_groups]
 is enabled. This internal field is to help load testing and determine a
 proper value, and won&apos;t be public in the future.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int MaxFanoutsPerGroup { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,16 +249,15 @@ proper value, and won&apos;t be public in the future.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource">MaxFanoutsPerResource</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int MaxFanoutsPerResource { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The maximum number of fanouts per parent resource, such as
 GCP Project etc., when [expand_resources][] is enabled. This internal
 field is to help load testing and determine a proper value, and won&apos;t be
 public in the future.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int MaxFanoutsPerResource { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,15 +275,14 @@ public in the future.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges">OutputGroupEdges</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool OutputGroupEdges { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true, the result will output group identity edges, starting
 from the binding&apos;s group members, to any expanded identities.
 Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool OutputGroupEdges { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,15 +300,14 @@ Default is false.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges">OutputResourceEdges</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool OutputResourceEdges { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If true, the result will output resource edges, starting
 from the policy attached resource, to any expanded resources.
 Default is false.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool OutputResourceEdges { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -53,20 +53,18 @@ projects.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor">ResourceSelector()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,15 +86,14 @@ projects.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName">FullResourceName</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource name</a>
 of a resource of <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#analyzable_asset_types">supported resource
 types</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor">IamPolicyAnalysisQuery()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery(IamPolicyAnalysisQuery other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector">AccessSelector</h3>
-  <div class="markdown level1 summary"><p>Specifies roles or permissions for analysis. This is optional.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.AccessSelector AccessSelector { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Specifies roles or permissions for analysis. This is optional.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +107,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector">IdentitySelector</h3>
-  <div class="markdown level1 summary"><p>Specifies an identity for analysis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.IdentitySelector IdentitySelector { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Specifies an identity for analysis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,13 +130,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options">Options</h3>
-  <div class="markdown level1 summary"><p>The query options.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.Options Options { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The query options.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -158,13 +153,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector">ResourceSelector</h3>
-  <div class="markdown level1 summary"><p>Specifies a resource for analysis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.ResourceSelector ResourceSelector { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Specifies a resource for analysis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -182,6 +176,9 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope">Scope</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The relative name of the root asset. Only resources and IAM policies within
 the scope will be analyzed.</p>
 <p>This can only be an organization number (such as &quot;organizations/123&quot;), a
@@ -193,10 +190,6 @@ folder number (such as &quot;folders/123&quot;), a project ID (such as
 </a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor">Access()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)">Access(IamPolicyAnalysisResult.Types.Access)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)">Access(IamPolicyAnalysisResult.Types.Access)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access(IamPolicyAnalysisResult.Types.Access other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState">AnalysisState</h3>
-  <div class="markdown level1 summary"><p>The analysis state of this access.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The analysis state of this access.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,12 +107,11 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase">OneofAccessCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase OneofAccessCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,13 +129,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission">Permission</h3>
-  <div class="markdown level1 summary"><p>The permission.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Permission { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The permission.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,13 +152,12 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role">Role</h3>
-  <div class="markdown level1 summary"><p>The role.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Role { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The role.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -66,20 +66,18 @@ combinations.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor">AccessControlList()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -101,6 +99,9 @@ combinations.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses">Accesses</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Access&gt; Accesses { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The accesses that match one of the following conditions:</p>
 <ul>
 <li>The access_selector, if it is specified in request;</li>
@@ -108,10 +109,6 @@ combinations.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Access&gt; Accesses { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,6 +126,9 @@ combinations.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges">ResourceEdges</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; ResourceEdges { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Resource edges of the graph starting from the policy attached
 resource to any descendant resources. The [Edge.source_node][] contains
 the full resource name of a parent resource and [Edge.target_node][]
@@ -136,10 +136,6 @@ contains the full resource name of a child resource. This field is
 present only if the output_resource_edges option is enabled in request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; ResourceEdges { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,6 +153,9 @@ present only if the output_resource_edges option is enabled in request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources">Resources</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Resource&gt; Resources { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The resources that match one of the following conditions:</p>
 <ul>
 <li>The resource_selector, if it is specified in request;</li>
@@ -164,10 +163,6 @@ present only if the output_resource_edges option is enabled in request.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Resource&gt; Resources { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor">Edge()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge(IamPolicyAnalysisResult.Types.Edge other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode">SourceNode</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string SourceNode { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The source node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string SourceNode { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,14 +108,13 @@ name for a resource node or an email of an identity.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode">TargetNode</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string TargetNode { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The target node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string TargetNode { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -53,20 +53,18 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor">Identity()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity(IamPolicyAnalysisResult.Types.Identity other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,13 +86,12 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState">AnalysisState</h3>
-  <div class="markdown level1 summary"><p>The analysis state of this identity.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The analysis state of this identity.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,6 +109,9 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The identity name in any form of members appear in
 <a href="https://cloud.google.com/iam/reference/rest/v1/Binding">IAM policy
 binding</a>, such
@@ -127,10 +127,6 @@ as:</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor">IdentityList()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList(IamPolicyAnalysisResult.Types.IdentityList other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges">GroupEdges</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; GroupEdges { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Group identity edges of the graph starting from the binding&apos;s
 group members to any node of the [identities][]. The [Edge.source_node][]
 contains a group, such as <code>group:parent@google.com</code>. The
@@ -95,10 +96,6 @@ This field is present only if the output_group_edges option is enabled in
 request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; GroupEdges { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,6 +113,9 @@ request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities">Identities</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Identity&gt; Identities { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Only the identities that match one of the following conditions will be
 presented:</p>
 <ul>
@@ -124,10 +124,6 @@ presented:</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Identity&gt; Identities { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor">Resource()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(IamPolicyAnalysisResult.Types.Resource other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState">AnalysisState</h3>
-  <div class="markdown level1 summary"><p>The analysis state of this resource.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The analysis state of this resource.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,6 +107,9 @@
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName">FullResourceName</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource
 name</a>
 (-- api-linter: core::0122::name-suffix=disabled
@@ -117,10 +117,6 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
 --)</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -52,20 +52,18 @@ access control lists.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor">IamPolicyAnalysisResult()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult(IamPolicyAnalysisResult other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,15 +85,14 @@ access control lists.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists">AccessControlLists</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.AccessControlList&gt; AccessControlLists { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The access control lists derived from the [iam_binding][iam_binding] that
 match or potentially match resource and access selectors specified in the
 request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.AccessControlList&gt; AccessControlLists { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,6 +110,9 @@ request.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName">AttachedResourceFullName</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string AttachedResourceFullName { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource
 name</a>
 of the resource to which the [iam_binding][iam_binding] policy attaches.
@@ -121,10 +121,6 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
 --)</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string AttachedResourceFullName { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,14 +138,13 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored">FullyExplored</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Represents whether all analyses on the [iam_binding][iam_binding] have
 successfully finished.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -167,13 +162,12 @@ successfully finished.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding">IamBinding</h3>
-  <div class="markdown level1 summary"><p>The Cloud IAM policy binding under analysis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Binding IamBinding { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The Cloud IAM policy binding under analysis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,14 +185,13 @@ successfully finished.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList">IdentityList</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.IdentityList IdentityList { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The identity list derived from members of the [iam_binding][iam_binding]
 that match or potentially match identity selector specified in the request.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.IdentityList IdentityList { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -52,20 +52,18 @@ resource, an identity or an access.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor">IamPolicyAnalysisState()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState(IamPolicyAnalysisState other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +85,12 @@ resource, an identity or an access.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause">Cause</h3>
-  <div class="markdown level1 summary"><p>The human-readable description of the cause of failure.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Cause { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The human-readable description of the cause of failure.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,6 +108,9 @@ resource, an identity or an access.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code">Code</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Code Code { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The Google standard error code that best describes the state.
 For example:</p>
 <ul>
@@ -121,10 +121,6 @@ in time;</li>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Code Code { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor">Permissions()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions__" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_">Permissions_</h3>
-  <div class="markdown level1 summary"><p>A list of permissions. A sample permission string: <code>compute.disk.get</code>.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions_ { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>A list of permissions. A sample permission string: <code>compute.disk.get</code>.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor">Explanation()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation(IamPolicySearchResult.Types.Explanation other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions">MatchedPermissions</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public MapField&lt;string, IamPolicySearchResult.Types.Explanation.Types.Permissions&gt; MatchedPermissions { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The map from roles to their included permissions that match the
 permission query (i.e., a query containing <code>policy.role.permissions:</code>).
 Example: if query <code>policy.role.permissions:compute.disk.get</code>
@@ -95,10 +96,6 @@ roles can also be found in the returned <code>policy</code> bindings. Note that 
 map is populated only for requests with permission queries.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public MapField&lt;string, IamPolicySearchResult.Types.Explanation.Types.Permissions&gt; MatchedPermissions { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor">IamPolicySearchResult()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)">IamPolicySearchResult(IamPolicySearchResult)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)">IamPolicySearchResult(IamPolicySearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult(IamPolicySearchResult other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation">Explanation</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public IamPolicySearchResult.Types.Explanation Explanation { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Explanation about the IAM policy search result. It contains additional
 information to explain why the search result matches the query.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public IamPolicySearchResult.Types.Explanation Explanation { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,6 +108,9 @@ information to explain why the search result matches the query.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy">Policy</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Policy Policy { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The IAM policy directly set on the given resource. Note that the original
 IAM policy can contain multiple bindings. This only contains the bindings
 that match the given query. For queries that don&apos;t contain a constrain on
@@ -127,10 +127,6 @@ policies (e.g., an empty query), this contains all the bindings.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Policy Policy { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,6 +144,9 @@ policies (e.g., an empty query), this contains all the bindings.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project">Project</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The project that the associated GCP resource belongs to, in the form of
 projects/{PROJECT_NUMBER}. If an IAM policy is set on a resource (like VM
 instance, Cloud Storage bucket), the project field will indicate the
@@ -159,10 +158,6 @@ orgnization, the project field will be empty.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,6 +175,9 @@ orgnization, the project field will be empty.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource">Resource</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Resource { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The full resource name of the resource associated with this IAM policy.
 Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code>.
@@ -192,10 +190,6 @@ for more information.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Resource { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor">ListFeedsRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)">ListFeedsRequest(ListFeedsRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)">ListFeedsRequest(ListFeedsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest(ListFeedsRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,15 +84,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent">Parent</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The parent project/folder/organization whose feeds are to be
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -50,20 +50,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor">ListFeedsResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)">ListFeedsResponse(ListFeedsResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)">ListFeedsResponse(ListFeedsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse(ListFeedsResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,13 +83,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds">Feeds</h3>
-  <div class="markdown level1 summary"><p>A list of feeds.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Feed&gt; Feeds { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>A list of feeds.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor">OutputConfig()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)">OutputConfig(OutputConfig)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)">OutputConfig(OutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig(OutputConfig other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination">BigqueryDestination</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public BigQueryDestination BigqueryDestination { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Destination on BigQuery. The output table stores the fields in asset
 proto as columns in BigQuery.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public BigQueryDestination BigqueryDestination { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,12 +108,11 @@ proto as columns in BigQuery.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase">DestinationCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,13 +130,12 @@ proto as columns in BigQuery.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination">GcsDestination</h3>
-  <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination GcsDestination { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor">OutputResult()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)">OutputResult(OutputResult)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)">OutputResult(OutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult(OutputResult other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,13 +84,12 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult_GcsResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputResult_GcsResult" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult">GcsResult</h3>
-  <div class="markdown level1 summary"><p>Export result on Cloud Storage.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult GcsResult { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Export result on Cloud Storage.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,12 +107,11 @@
   </table>
   <a id="Google_Cloud_Asset_V1_OutputResult_ResultCase_" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputResult_ResultCase" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase">ResultCase</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult.ResultOneofCase ResultCase { get; }</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor">PubsubDestination()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)">PubsubDestination(PubsubDestination)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)">PubsubDestination(PubsubDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination(PubsubDestination other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination_Topic_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic*"></a>
   <h3 id="Google_Cloud_Asset_V1_PubsubDestination_Topic" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic">Topic</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Topic { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The name of the Pub/Sub topic to publish to.
 Example: <code>projects/PROJECT_ID/topics/TOPIC_ID</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Topic { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource__ctor" data-uid="Google.Cloud.Asset.V1.Resource.#ctor">Resource()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)">Resource(Resource)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)">Resource(Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(Resource other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource_Data_" data-uid="Google.Cloud.Asset.V1.Resource.Data*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_Data" data-uid="Google.Cloud.Asset.V1.Resource.Data">Data</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Struct Data { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The content of the resource, in which some sensitive fields are removed
 and may not be present.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Struct Data { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,6 +108,9 @@ and may not be present.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri">DiscoveryDocumentUri</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string DiscoveryDocumentUri { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The URL of the discovery document containing the resource&apos;s JSON schema.
 Example:
 <code>https://www.googleapis.com/discovery/v1/apis/compute/v1/rest</code></p>
@@ -118,10 +118,6 @@ Example:
 discovery document, such as Cloud Bigtable.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string DiscoveryDocumentUri { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,16 +135,15 @@ discovery document, such as Cloud Bigtable.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryName_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryName" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName">DiscoveryName</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string DiscoveryName { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The JSON schema name listed in the discovery document. Example:
 <code>Project</code></p>
 <p>This value is unspecified for resources that do not have an API based on a
 discovery document, such as Cloud Bigtable.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string DiscoveryName { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,14 +161,13 @@ discovery document, such as Cloud Bigtable.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Location_" data-uid="Google.Cloud.Asset.V1.Resource.Location*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_Location" data-uid="Google.Cloud.Asset.V1.Resource.Location">Location</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The location of the resource in Google Cloud, such as its zone and region.
 For more information, see <a href="https://cloud.google.com/about/locations/">https://cloud.google.com/about/locations/</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,6 +185,9 @@ For more information, see <a href="https://cloud.google.com/about/locations/">ht
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Parent_" data-uid="Google.Cloud.Asset.V1.Resource.Parent*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_Parent" data-uid="Google.Cloud.Asset.V1.Resource.Parent">Parent</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The full name of the immediate parent of this resource. See
 <a href="https://cloud.google.com/apis/design/resource_names#full_resource_name">Resource
 Names</a>
@@ -203,10 +200,6 @@ Example:
 <p>For third-party assets, this field may be set differently.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -224,16 +217,15 @@ Example:
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_ResourceUrl_" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_ResourceUrl" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl">ResourceUrl</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string ResourceUrl { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The REST URL for accessing the resource. An HTTP <code>GET</code> request using this
 URL returns the resource itself. Example:
 <code>https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123</code></p>
 <p>This value is unspecified for resources without a REST API.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string ResourceUrl { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,13 +243,12 @@ URL returns the resource itself. Example:
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Version_" data-uid="Google.Cloud.Asset.V1.Resource.Version*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource_Version" data-uid="Google.Cloud.Asset.V1.Resource.Version">Version</h3>
-  <div class="markdown level1 summary"><p>The API version. Example: <code>v1</code></p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Version { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The API version. Example: <code>v1</code></p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor">ResourceSearchResult()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)">ResourceSearchResult(ResourceSearchResult)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)">ResourceSearchResult(ResourceSearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult(ResourceSearchResult other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes">AdditionalAttributes</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Struct AdditionalAttributes { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The additional searchable attributes of this resource. The attributes may
 vary from one resource type to another. Examples: <code>projectId</code> for Project,
 <code>dnsName</code> for DNS ManagedZone. This field contains a subset of the resource
@@ -106,10 +107,6 @@ version.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Struct AdditionalAttributes { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +124,9 @@ version.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType">AssetType</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The type of this resource. Example: <code>compute.googleapis.com/Disk</code>.</p>
 <p>To search against the <code>asset_type</code>:</p>
 <ul>
@@ -134,10 +134,6 @@ version.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,6 +151,9 @@ version.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Description_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Description" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description">Description</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Description { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>One or more paragraphs of text description of this resource. Maximum length
 could be up to 1M bytes.</p>
 <p>To search against the <code>description</code>:</p>
@@ -164,10 +163,6 @@ could be up to 1M bytes.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Description { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,6 +180,9 @@ could be up to 1M bytes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName">DisplayName</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string DisplayName { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The display name of this resource.</p>
 <p>To search against the <code>display_name</code>:</p>
 <ul>
@@ -193,10 +191,6 @@ could be up to 1M bytes.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string DisplayName { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -214,6 +208,9 @@ could be up to 1M bytes.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels">Labels</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public MapField&lt;string, string&gt; Labels { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Labels associated with this resource. See <a href="https://cloud.google.com/blog/products/gcp/labelling-and-grouping-your-google-cloud-platform-resources">Labelling and grouping GCP
 resources</a>
 for more information.</p>
@@ -227,10 +224,6 @@ for more information.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public MapField&lt;string, string&gt; Labels { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,6 +241,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Location_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Location" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location">Location</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Location can be <code>global</code>, regional like <code>us-east1</code>, or zonal like
 <code>us-west1-b</code>.</p>
 <p>To search against the <code>location</code>:</p>
@@ -257,10 +253,6 @@ for more information.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -278,6 +270,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Name_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Name" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name">Name</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The full resource name of this resource. Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code>.
 See <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">Cloud Asset Inventory Resource Name
@@ -290,10 +285,6 @@ for more information.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,6 +302,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags">NetworkTags</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; NetworkTags { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Network tags associated with this resource. Like labels, network tags are a
 type of annotations used to group GCP resources. See <a href="https://cloud.google.com/blog/products/gcp/labelling-and-grouping-your-google-cloud-platform-resources">Labelling GCP
 resources</a>
@@ -322,10 +316,6 @@ for more information.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; NetworkTags { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,6 +333,9 @@ for more information.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Project_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Project" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project">Project</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>The project that this resource belongs to, in the form of
 projects/{PROJECT_NUMBER}.</p>
 <p>To search against the <code>project</code>:</p>
@@ -351,10 +344,6 @@ projects/{PROJECT_NUMBER}.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -52,20 +52,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor">SearchAllIamPoliciesRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,16 +85,15 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize">PageSize</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. The page size for search result pagination. Page size is capped at 500 even
 if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,16 +111,15 @@ there could be more results as long as <code>next_page_token</code> is returned.
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken">PageToken</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. If present, retrieve the next batch of results from the preceding call to
 this method. <code>page_token</code> must be the value of <code>next_page_token</code> from the
 previous response. The values of all other method parameters must be
 identical to those in the previous call.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,6 +137,9 @@ identical to those in the previous call.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query">Query</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
@@ -169,10 +168,6 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -190,6 +185,9 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope">Scope</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the IAM policies within the <code>scope</code>. The caller must be granted
 the
@@ -204,10 +202,6 @@ permission on the desired scope.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -54,20 +54,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor">SearchAllIamPoliciesResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,15 +87,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken">NextPageToken</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Set if there are more results than those appearing in this response; to get
 the next set of results, call this method again, using this value as the
 <code>page_token</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,14 +112,13 @@ the next set of results, call this method again, using this value as the
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results">Results</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicySearchResult&gt; Results { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of IamPolicy that match the search query. Related information such
 as the associated resource is returned along with the policy.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;IamPolicySearchResult&gt; Results { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@ as the associated resource is returned along with the policy.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator">GetEnumerator()</h3>
-  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;IamPolicySearchResult&gt; GetEnumerator()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,12 +163,11 @@ as the associated resource is returned along with the policy.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -52,20 +52,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor">SearchAllResourcesRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest(SearchAllResourcesRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,15 +85,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes">AssetTypes</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. A list of asset types that this request searches for. If empty, it will
 search all the <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types">searchable asset
 types</a>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,6 +110,9 @@ types</a>.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy">OrderBy</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string OrderBy { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. A comma separated list of fields specifying the sorting order of the
 results. The default order is ascending. Add &quot; DESC&quot; after the field name
 to indicate descending order. Redundant space characters are ignored.
@@ -123,10 +123,6 @@ fields (e.g., <code>labels</code>) and struct fields (e.g., <code>additionalAttr
 are not supported.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string OrderBy { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,16 +140,15 @@ are not supported.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize">PageSize</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. The page size for search result pagination. Page size is capped at 500 even
 if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,16 +166,15 @@ there could be more results as long as <code>next_page_token</code> is returned.
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken">PageToken</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. If present, then retrieve the next batch of results from the preceding call
 to this method. <code>page_token</code> must be the value of <code>next_page_token</code> from
 the previous response. The values of all other method parameters, must be
 identical to those in the previous call.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -198,6 +192,9 @@ identical to those in the previous call.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query">Query</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Optional. The query statement. See <a href="http://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
@@ -235,10 +232,6 @@ location.</li>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,6 +249,9 @@ location.</li>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope">Scope</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the resources within the <code>scope</code>. The caller must be granted the
 <a href="http://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllResources</code></a>
@@ -269,10 +265,6 @@ permission on the desired scope.</p>
 </ul>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -54,20 +54,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor">SearchAllResourcesResponse()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse(SearchAllResourcesResponse other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,15 +87,14 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken">NextPageToken</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>If there are more results than those appearing in this response, then
 <code>next_page_token</code> is included. To get the next set of results, call this
 method again using the value of <code>next_page_token</code> as <code>page_token</code>.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,14 +112,13 @@ method again using the value of <code>next_page_token</code> as <code>page_token
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results">Results</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public RepeatedField&lt;ResourceSearchResult&gt; Results { get; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>A list of Resources that match the search query. It contains the resource
 standard metadata information.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public RepeatedField&lt;ResourceSearchResult&gt; Results { get; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@ standard metadata information.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator">GetEnumerator()</h3>
-  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;ResourceSearchResult&gt; GetEnumerator()</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,12 +163,11 @@ standard metadata information.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="returns">Returns</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -52,20 +52,18 @@ when it was observed and its status during that window.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor">TemporalAsset()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)">TemporalAsset(TemporalAsset)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)">TemporalAsset(TemporalAsset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset(TemporalAsset other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +85,12 @@ when it was observed and its status during that window.</p>
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Asset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Asset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset">Asset</h3>
-  <div class="markdown level1 summary"><p>An asset in Google Cloud.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset Asset { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>An asset in Google Cloud.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,13 +108,12 @@ when it was observed and its status during that window.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Deleted_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Deleted" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted">Deleted</h3>
-  <div class="markdown level1 summary"><p>Whether the asset has been deleted or not.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Deleted { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Whether the asset has been deleted or not.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,14 +131,13 @@ when it was observed and its status during that window.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset">PriorAsset</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Asset PriorAsset { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Prior copy of the asset. Populated if prior_asset_state is PRESENT.
 Currently this is only set for responses in Real-Time Feed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Asset PriorAsset { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,13 +155,12 @@ Currently this is only set for responses in Real-Time Feed.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState">PriorAssetState</h3>
-  <div class="markdown level1 summary"><p>State of prior_asset.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset.Types.PriorAssetState PriorAssetState { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>State of prior_asset.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -184,13 +178,12 @@ Currently this is only set for responses in Real-Time Feed.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Window_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Window" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window">Window</h3>
-  <div class="markdown level1 summary"><p>The time window when the asset data and state was observed.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow Window { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>The time window when the asset data and state was observed.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor">TimeWindow()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)">TimeWindow(TimeWindow)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)">TimeWindow(TimeWindow)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow(TimeWindow other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,14 +84,13 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow_EndTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime*"></a>
   <h3 id="Google_Cloud_Asset_V1_TimeWindow_EndTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime">EndTime</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Timestamp EndTime { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>End time of the time window (inclusive). If not specified, the current
 timestamp is used instead.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Timestamp EndTime { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,13 +108,12 @@ timestamp is used instead.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_TimeWindow_StartTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime*"></a>
   <h3 id="Google_Cloud_Asset_V1_TimeWindow_StartTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime">StartTime</h3>
-  <div class="markdown level1 summary"><p>Start time of the time window (exclusive).</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp StartTime { get; set; }</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Start time of the time window (exclusive).</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -51,20 +51,18 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor">UpdateFeedRequest()</h3>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest()</code></pre>
   </div>
-  <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)">UpdateFeedRequest(UpdateFeedRequest)</h3>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
+  <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)">UpdateFeedRequest(UpdateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest(UpdateFeedRequest other)</code></pre>
   </div>
+  <div class="markdown level1 summary"></div>
+  <div class="markdown level1 conceptual"></div>
   <h4 class="parameters">Parameters</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +84,9 @@
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed*"></a>
   <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed">Feed</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. The new values of feed details. It must match an existing feed and the
 field <code>name</code> must be in the format of:
 projects/project_number/feeds/feed_id or
@@ -93,10 +94,6 @@ folders/folder_number/feeds/feed_id or
 organizations/organization_number/feeds/feed_id.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,15 +111,14 @@ organizations/organization_number/feeds/feed_id.</p>
   </table>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask*"></a>
   <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask">UpdateMask</h3>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public FieldMask UpdateMask { get; set; }</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Required. Only updates the <code>feed</code> fields indicated by this mask.
 The field mask must not be empty, and it must not contain fields that
 are immutable or only set by the server.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h4 class="decalaration">Declaration</h4>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">public FieldMask UpdateMask { get; set; }</code></pre>
-  </div>
   <h4 class="propertyValue">Property Value</h4>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -248,9 +248,6 @@ These errors can be introspected for more information by type asserting to the r
   Constants
   </h2>
         <h3 id="cloud_google_com_go_storage_DeleteAction_SetStorageClassAction" data-uid="cloud.google.com/go/storage.DeleteAction,SetStorageClassAction">DeleteAction, SetStorageClassAction</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 
@@ -263,12 +260,10 @@ These errors can be introspected for more information by type asserting to the r
 	SetStorageClassAction = "SetStorageClass"
 )</code></pre>
         </div>
+        <div class="markdown level1 summary"></div>
+        <div class="markdown level1 conceptual"></div>
         
         <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload">NoPayload, JSONPayload</h3>
-        <div class="markdown level1 summary"><p>Values for Notification.PayloadFormat.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Send no payload with notification messages.
@@ -278,12 +273,11 @@ These errors can be introspected for more information by type asserting to the r
 	JSONPayload = "JSON_API_V1"
 )</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
-        <div class="markdown level1 summary"><p>Values for Notification.EventTypes.</p>
+        <div class="markdown level1 summary"><p>Values for Notification.PayloadFormat.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Event that occurs when an object is successfully created.
@@ -300,11 +294,11 @@ These errors can be introspected for more information by type asserting to the r
 	ObjectArchiveEvent = "OBJECT_ARCHIVE"
 )</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>Values for Notification.EventTypes.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
         <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// ScopeFullControl grants permissions to manage your
@@ -320,14 +314,13 @@ These errors can be introspected for more information by type asserting to the r
 	ScopeReadWrite = <a href="https://pkg.go.dev/google.golang.org/api/storage/v1">raw</a>.<a href="https://pkg.go.dev/google.golang.org/api/storage/v1#DevstorageReadWriteScope">DevstorageReadWriteScope</a>
 )</code></pre>
         </div>
+        <div class="markdown level1 summary"></div>
+        <div class="markdown level1 conceptual"></div>
         
     <h2 id="variables">Variables
   
   </h2>
         <h3 id="cloud_google_com_go_storage_ErrBucketNotExist_ErrObjectNotExist" data-uid="cloud.google.com/go/storage.ErrBucketNotExist,ErrObjectNotExist">ErrBucketNotExist, ErrObjectNotExist</h3>
-        <div class="markdown level1 summary"></div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">var (
 	// ErrBucketNotExist indicates that the bucket does not exist.
@@ -336,11 +329,16 @@ These errors can be introspected for more information by type asserting to the r
 	ErrObjectNotExist = <a href="https://pkg.go.dev/errors">errors</a>.<a href="https://pkg.go.dev/errors#New">New</a>("storage: object doesn't exist")
 )</code></pre>
         </div>
+        <div class="markdown level1 summary"></div>
+        <div class="markdown level1 conceptual"></div>
         
     <h2 id="types">
   Types
   </h2>
         <h3 id="cloud_google_com_go_storage_ACLEntity" data-uid="cloud.google.com/go/storage.ACLEntity">ACLEntity</h3>
+        <div class="codewrapper">
+          <pre><code class="prettyprint">type ACLEntity <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
+        </div>
         <div class="markdown level1 summary"><p>ACLEntity refers to a user or group.
 They are sometimes referred to as grantees.</p>
 <p>It could be in the form of:
@@ -349,44 +347,37 @@ They are sometimes referred to as grantees.</p>
 <p>Or one of the predefined constants: AllUsers, AllAuthenticatedUsers.</p>
 </projectid></domain></email></groupid></email></userid></div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="prettyprint">type ACLEntity <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
-        </div>
         
             <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers">AllUsers, AllAuthenticatedUsers</h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	AllUsers              <a href="#aclentity">ACLEntity</a> = "allUsers"
 	AllAuthenticatedUsers <a href="#aclentity">ACLEntity</a> = "allAuthenticatedUsers"
 )</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                   <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle">ACLHandle</h3>
-        <div class="markdown level1 summary"><p>ACLHandle provides operations on an access control list for a Google Cloud Storage bucket or object.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLHandle struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>ACLHandle provides operations on an access control list for a Google Cloud Storage bucket or object.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete">func (*ACLHandle) Delete
 </h4>
-            <div class="markdown level1 summary"><p>Delete permanently deletes the ACL entry for the given entity.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Delete permanently deletes the ACL entry for the given entity.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_Delete_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -405,19 +396,18 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List">func (*ACLHandle) List
 </h4>
-            <div class="markdown level1 summary"><p>List retrieves ACL entries.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) List(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (rules []<a href="#aclrule">ACLRule</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>List retrieves ACL entries.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_List_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -439,19 +429,18 @@ func main() {
 	fmt.Println(aclRules)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set">func (*ACLHandle) Set
 </h4>
-            <div class="markdown level1 summary"><p>Set sets the role for the given entity.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Set(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>, role <a href="#aclrole">ACLRole</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Set sets the role for the given entity.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ACLHandle_Set_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -471,20 +460,16 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole">ACLRole</h3>
-        <div class="markdown level1 summary"><p>ACLRole is the level of access to grant.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRole <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
+        <div class="markdown level1 summary"><p>ACLRole is the level of access to grant.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter">RoleOwner, RoleReader, RoleWriter</h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	RoleOwner  <a href="#aclrole">ACLRole</a> = "OWNER"
@@ -492,12 +477,9 @@ func main() {
 	RoleWriter <a href="#aclrole">ACLRole</a> = "WRITER"
 )</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                   <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule">ACLRule</h3>
-        <div class="markdown level1 summary"><p>ACLRule represents a grant for a role to an entity (user, group or team) for a
-Google Cloud Storage object or bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRule struct {
 	<a href="#entity">Entity</a>      <a href="#aclentity">ACLEntity</a>
@@ -508,13 +490,12 @@ Google Cloud Storage object or bucket.</p>
 	<a href="#projectteam">ProjectTeam</a> *<a href="#projectteam">ProjectTeam</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs">BucketAttrs</h3>
-        <div class="markdown level1 summary"><p>BucketAttrs represents the metadata for a Google Cloud Storage bucket.
-Read-only fields are ignored by BucketHandle.Create.</p>
+        <div class="markdown level1 summary"><p>ACLRule represents a grant for a role to an entity (user, group or team) for a
+Google Cloud Storage object or bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs">BucketAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrs struct {
 	// Name is the name of the bucket.
@@ -623,12 +604,12 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	<a href="#locationtype">LocationType</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate">BucketAttrsToUpdate</h3>
-        <div class="markdown level1 summary"><p>BucketAttrsToUpdate define the attributes to update during an Update call.</p>
+        <div class="markdown level1 summary"><p>BucketAttrs represents the metadata for a Google Cloud Storage bucket.
+Read-only fields are ignored by BucketHandle.Create.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate">BucketAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrsToUpdate struct {
 	// If set, updates whether the bucket uses versioning.
@@ -691,33 +672,29 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>BucketAttrsToUpdate define the attributes to update during an Update call.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel">func (*BucketAttrsToUpdate) DeleteLabel
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) DeleteLabel(name <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>DeleteLabel causes a label to be deleted when ua is used in a
 call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) DeleteLabel(name <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel">func (*BucketAttrsToUpdate) SetLabel
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) SetLabel(name, value <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>SetLabel causes a label to be added or modified when ua is used
 in a call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) SetLabel(name, value <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions">BucketConditions</h3>
-        <div class="markdown level1 summary"><p>BucketConditions constrain bucket methods to act on specific metagenerations.</p>
-<p>The zero value is an empty set of constraints.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketConditions struct {
 	// MetagenerationMatch specifies that the bucket must have the given
@@ -731,12 +708,12 @@ in a call to Bucket.Update.</p>
 	<a href="#metagenerationnotmatch">MetagenerationNotMatch</a> <a href="https://pkg.go.dev/builtin#int64">int64</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption">BucketEncryption</h3>
-        <div class="markdown level1 summary"><p>BucketEncryption is a bucket&#39;s encryption configuration.</p>
+        <div class="markdown level1 summary"><p>BucketConditions constrain bucket methods to act on specific metagenerations.</p>
+<p>The zero value is an empty set of constraints.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption">BucketEncryption</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketEncryption struct {
 	// A Cloud KMS key name, in the form
@@ -746,18 +723,20 @@ in a call to Bucket.Update.</p>
 	<a href="#defaultkmskeyname">DefaultKMSKeyName</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle">BucketHandle</h3>
-        <div class="markdown level1 summary"><p>BucketHandle provides operations on a Google Cloud Storage bucket.
-Use Client.Bucket to get a handle.</p>
+        <div class="markdown level1 summary"><p>BucketEncryption is a bucket&#39;s encryption configuration.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle">BucketHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketHandle struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>BucketHandle provides operations on a Google Cloud Storage bucket.
+Use Client.Bucket to get a handle.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         <h5 id="cloud_google_com_go_storage_BucketHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
@@ -791,19 +770,18 @@ func main() {
   
             <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL">func (*BucketHandle) ACL
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ACL returns an ACLHandle, which provides access to the bucket&#39;s access control list.
 This controls who can list, create or overwrite the objects in a bucket.
 This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_ACL_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -829,21 +807,20 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification">func (*BucketHandle) AddNotification
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) AddNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, n *<a href="#notification">Notification</a>) (ret *<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>AddNotification adds a notification to b. You must set n&#39;s TopicProjectID, TopicID
 and PayloadFormat, and must not set its ID. The other fields are all optional. The
 returned Notification&#39;s ID can be used to refer to it.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) AddNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, n *<a href="#notification">Notification</a>) (ret *<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_AddNotification_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -869,19 +846,18 @@ func main() {
 	fmt.Println(n.ID)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs">func (*BucketHandle) Attrs
 </h4>
-            <div class="markdown level1 summary"><p>Attrs returns the metadata for the bucket.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Attrs returns the metadata for the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Attrs_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -902,20 +878,19 @@ func main() {
 	fmt.Println(attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create">func (*BucketHandle) Create
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Create(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, attrs *<a href="#bucketattrs">BucketAttrs</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Create creates the Bucket in the project.
 If attrs is nil the API defaults will be used.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Create(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, attrs *<a href="#bucketattrs">BucketAttrs</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Create_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -933,22 +908,21 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL">func (*BucketHandle) DefaultObjectACL
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DefaultObjectACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>DefaultObjectACL returns an ACLHandle, which provides access to the bucket&#39;s default object ACLs.
 These ACLs are applied to newly created objects in this bucket that do not have a defined ACL.
 This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DefaultObjectACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -974,19 +948,18 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete">func (*BucketHandle) Delete
 </h4>
-            <div class="markdown level1 summary"><p>Delete deletes the Bucket.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Delete deletes the Bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Delete_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1004,19 +977,18 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification">func (*BucketHandle) DeleteNotification
 </h4>
-            <div class="markdown level1 summary"><p>DeleteNotification deletes the notification with the given ID.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DeleteNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, id <a href="https://pkg.go.dev/builtin#string">string</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>DeleteNotification deletes the notification with the given ID.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1040,20 +1012,19 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM">func (*BucketHandle) IAM
 </h4>
-            <div class="markdown level1 summary"><p>IAM provides access to IAM access control for the bucket.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) IAM() *<a href="https://pkg.go.dev/cloud.google.com/go/iam">iam</a>.<a href="https://pkg.go.dev/cloud.google.com/go/iam#Handle">Handle</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>IAM provides access to IAM access control for the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_IAM_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1079,9 +1050,12 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If">func (*BucketHandle) If
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) If(conds <a href="#bucketconditions">BucketConditions</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>If returns a new BucketHandle that applies a set of preconditions.
 Preconditions already set on the BucketHandle are ignored.
 Operations on the new handle will return an error if the preconditions are not
@@ -1089,14 +1063,10 @@ satisfied. The only valid preconditions for buckets are MetagenerationMatch
 and MetagenerationNotMatch.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) If(conds <a href="#bucketconditions">BucketConditions</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_If_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1122,9 +1092,12 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy">func (*BucketHandle) LockRetentionPolicy
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) LockRetentionPolicy(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>LockRetentionPolicy locks a bucket&#39;s retention policy until a previously-configured
 RetentionPeriod past the EffectiveTime. Note that if RetentionPeriod is set to less
 than a day, the retention policy is treated as a development configuration and locking
@@ -1135,13 +1108,9 @@ most customers. It might be changed in backwards-incompatible ways and is not
 subject to any SLA or deprecation policy.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) LockRetentionPolicy(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1167,20 +1136,19 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications">func (*BucketHandle) Notifications
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Notifications(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (n map[<a href="https://pkg.go.dev/builtin#string">string</a>]*<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Notifications returns all the Notifications configured for this bucket, as a map
 indexed by notification ID.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Notifications(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (n map[<a href="https://pkg.go.dev/builtin#string">string</a>]*<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Notifications_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1204,9 +1172,12 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object">func (*BucketHandle) Object
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Object(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Object returns an ObjectHandle, which provides operations on the named object.
 This call does not perform any network operations.</p>
 <p>name must consist entirely of valid UTF-8-encoded runes. The full specification
@@ -1214,14 +1185,10 @@ for valid object names can be found at:
   <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Object(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Object_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1247,22 +1214,21 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects">func (*BucketHandle) Objects
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Objects(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, q *<a href="#query">Query</a>) *<a href="#objectiterator">ObjectIterator</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Objects returns an iterator over the objects in the bucket that match the
 Query q. If q is nil, no filtering is done. Objects will be iterated over
 lexicographically by name.</p>
 <p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Objects(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, q *<a href="#query">Query</a>) *<a href="#objectiterator">ObjectIterator</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Objects_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1279,19 +1245,18 @@ func main() {
 	_ = it // TODO: iterate using Next or iterator.Pager.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update">func (*BucketHandle) Update
 </h4>
-            <div class="markdown level1 summary"><p>Update updates a bucket&#39;s attributes.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Update updates a bucket&#39;s attributes.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Update_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1314,10 +1279,10 @@ func main() {
 	fmt.Println(attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">readModifyWrite</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">readModifyWrite</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1350,23 +1315,22 @@ func main() {
 	fmt.Println(attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject">func (*BucketHandle) UserProject
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) UserProject(projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>UserProject returns a new BucketHandle that passes the project ID as the user
 project for all subsequent calls. Calls with a user project will be billed to that
 project rather than to the bucket&#39;s owning project.</p>
 <p>A user project is required for all operations on Requester Pays buckets.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) UserProject(projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_UserProject_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1392,13 +1356,8 @@ func main() {
 	fmt.Printf(&quot;The bucket exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator">BucketIterator</h3>
-        <div class="markdown level1 summary"><p>A BucketIterator is an iterator over BucketAttrs.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketIterator struct {
 	// Prefix restricts the iterator to buckets whose names begin with it.
@@ -1406,22 +1365,25 @@ func main() {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>A BucketIterator is an iterator over BucketAttrs.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next">func (*BucketIterator) Next
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) Next() (*<a href="#bucketattrs">BucketAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
 there are no more results. Once Next returns iterator.Done, all subsequent
 calls will return iterator.Done.</p>
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) Next() (*<a href="#bucketattrs">BucketAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_BucketIterator_Next_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1449,24 +1411,17 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo">func (*BucketIterator) PageInfo
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging">BucketLogging</h3>
-        <div class="markdown level1 summary"><p>BucketLogging holds the bucket&#39;s logging configuration, which defines the
-destination bucket and optional name prefix for the current bucket&#39;s
-logs.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketLogging struct {
 	// The destination bucket where the current bucket's logs
@@ -1477,13 +1432,13 @@ logs.</p>
 	<a href="#logobjectprefix">LogObjectPrefix</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly">BucketPolicyOnly</h3>
-        <div class="markdown level1 summary"><p>BucketPolicyOnly is an alias for UniformBucketLevelAccess.
-Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
+        <div class="markdown level1 summary"><p>BucketLogging holds the bucket&#39;s logging configuration, which defines the
+destination bucket and optional name prefix for the current bucket&#39;s
+logs.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly">BucketPolicyOnly</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketPolicyOnly struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -1494,14 +1449,12 @@ Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
 	<a href="#lockedtime">LockedTime</a> <a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite">BucketWebsite</h3>
-        <div class="markdown level1 summary"><p>BucketWebsite holds the bucket&#39;s website configuration, controlling how the
-service behaves when accessing bucket contents as a web site. See
-<a href="https://cloud.google.com/storage/docs/static-website">https://cloud.google.com/storage/docs/static-website</a> for more information.</p>
+        <div class="markdown level1 summary"><p>BucketPolicyOnly is an alias for UniformBucketLevelAccess.
+Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite">BucketWebsite</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketWebsite struct {
 	// If the requested object path is missing, the service will ensure the path has
@@ -1516,12 +1469,13 @@ service behaves when accessing bucket contents as a web site. See
 	<a href="#notfoundpage">NotFoundPage</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS">CORS</h3>
-        <div class="markdown level1 summary"><p>CORS is the bucket&#39;s Cross-Origin Resource Sharing (CORS) configuration.</p>
+        <div class="markdown level1 summary"><p>BucketWebsite holds the bucket&#39;s website configuration, controlling how the
+service behaves when accessing bucket contents as a web site. See
+<a href="https://cloud.google.com/storage/docs/static-website">https://cloud.google.com/storage/docs/static-website</a> for more information.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS">CORS</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type CORS struct {
 	// MaxAge is the value to return in the Access-Control-Max-Age
@@ -1544,22 +1498,27 @@ service behaves when accessing bucket contents as a web site. See
 	<a href="#responseheaders">ResponseHeaders</a> []<a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client">Client</h3>
-        <div class="markdown level1 summary"><p>Client is a client for interacting with Google Cloud Storage.</p>
-<p>Clients should be reused instead of created as needed.
-The methods of Client are safe for concurrent use by multiple goroutines.</p>
+        <div class="markdown level1 summary"><p>CORS is the bucket&#39;s Cross-Origin Resource Sharing (CORS) configuration.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client">Client</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Client struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>Client is a client for interacting with Google Cloud Storage.</p>
+<p>Clients should be reused instead of created as needed.
+The methods of Client are safe for concurrent use by multiple goroutines.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient">func NewClient
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func NewClient(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="https://pkg.go.dev/google.golang.org/api/option">option</a>.<a href="https://pkg.go.dev/google.golang.org/api/option#ClientOption">ClientOption</a>) (*<a href="#client">Client</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>NewClient creates a new Google Cloud Storage client.
 The default scope is ScopeFullControl. To use a different scope, like
 ScopeReadOnly, use option.WithScopes.</p>
@@ -1567,13 +1526,9 @@ ScopeReadOnly, use option.WithScopes.</p>
 are safe for concurrent use by multiple goroutines.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func NewClient(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="https://pkg.go.dev/google.golang.org/api/option">option</a>.<a href="https://pkg.go.dev/google.golang.org/api/option#ClientOption">ClientOption</a>) (*<a href="#client">Client</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_Client_NewClient_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1597,10 +1552,10 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">unauthenticated</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">unauthenticated</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1622,9 +1577,12 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket">func (*Client) Bucket
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Bucket(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Bucket returns a BucketHandle, which provides operations on the named bucket.
 This call does not perform any network operations.</p>
 <p>The supplied name must contain only lowercase letters, numbers, dashes,
@@ -1633,12 +1591,11 @@ found at:
   <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Bucket(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets">func (*Client) Buckets
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Buckets(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#bucketiterator">BucketIterator</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Buckets returns an iterator over the buckets in the project. You may
 optionally set the iterator&#39;s Prefix field to restrict the list to buckets
 whose names begin with the prefix. By default, all buckets in the project
@@ -1646,13 +1603,9 @@ are returned.</p>
 <p>Note: The returned iterator is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Buckets(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#bucketiterator">BucketIterator</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_Client_Buckets_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1669,30 +1622,28 @@ func main() {
 	_ = it // TODO: iterate using Next or iterator.Pager.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close">func (*Client) Close
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Close closes the Client.</p>
 <p>Close need not be called at program exit.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey">func (*Client) CreateHMACKey
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) CreateHMACKey(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID, serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>CreateHMACKey invokes an RPC for Google Cloud Storage to create a new HMACKey.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) CreateHMACKey(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID, serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_Client_CreateHMACKey_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1713,31 +1664,29 @@ func main() {
 	_ = hkey // TODO: Use the HMAC Key.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle">func (*Client) HMACKeyHandle
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) HMACKeyHandle(projectID, accessID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#hmackeyhandle">HMACKeyHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>HMACKeyHandle creates a handle that will be used for HMACKey operations.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) HMACKeyHandle(projectID, accessID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#hmackeyhandle">HMACKeyHandle</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys">func (*Client) ListHMACKeys
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ListHMACKeys(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) *<a href="#hmackeysiterator">HMACKeysIterator</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ListHMACKeys returns an iterator for listing HMACKeys.</p>
 <p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ListHMACKeys(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) *<a href="#hmackeysiterator">HMACKeysIterator</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_Client_ListHMACKeys_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1765,10 +1714,10 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">forServiceAccountEmail</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">forServiceAccountEmail</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1796,10 +1745,10 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">showDeletedKeys</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">showDeletedKeys</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1827,22 +1776,16 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount">func (*Client) ServiceAccount
 </h4>
-            <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ServiceAccount(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
-                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer">Composer</h3>
-        <div class="markdown level1 summary"><p>A Composer composes source objects into a destination object.</p>
-<p>For Requester Pays buckets, the user project of dst is billed.</p>
+            <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
 </div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+            <div class="markdown level1 conceptual"></div>
+                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer">Composer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Composer struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1859,19 +1802,22 @@ func main() {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>A Composer composes source objects into a destination object.</p>
+<p>For Requester Pays buckets, the user project of dst is billed.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run">func (*Composer) Run
 </h4>
-            <div class="markdown level1 summary"><p>Run performs the compose operation.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#composer">Composer</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Run performs the compose operation.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_Composer_Run_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -1912,17 +1858,8 @@ func main() {
 	fmt.Println(attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions">Conditions</h3>
-        <div class="markdown level1 summary"><p>Conditions constrain methods to act on specific generations of
-objects.</p>
-<p>The zero value is an empty set of constraints. Not all conditions or
-combinations of conditions are applicable to all methods.
-See <a href="https://cloud.google.com/storage/docs/generations-preconditions">https://cloud.google.com/storage/docs/generations-preconditions</a>
-for details on how these operate.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Conditions struct {
 
@@ -1953,12 +1890,16 @@ for details on how these operate.</p>
 	<a href="#metagenerationnotmatch">MetagenerationNotMatch</a> <a href="https://pkg.go.dev/builtin#int64">int64</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier">Copier</h3>
-        <div class="markdown level1 summary"><p>A Copier copies a source object to a destination.</p>
+        <div class="markdown level1 summary"><p>Conditions constrain methods to act on specific generations of
+objects.</p>
+<p>The zero value is an empty set of constraints. Not all conditions or
+combinations of conditions are applicable to all methods.
+See <a href="https://cloud.google.com/storage/docs/generations-preconditions">https://cloud.google.com/storage/docs/generations-preconditions</a>
+for details on how these operate.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier">Copier</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Copier struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1997,19 +1938,21 @@ for details on how these operate.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>A Copier copies a source object to a destination.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run">func (*Copier) Run
 </h4>
-            <div class="markdown level1 summary"><p>Run performs the copy.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#copier">Copier</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Run performs the copy.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_Copier_Run_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2043,10 +1986,10 @@ func main() {
 	fmt.Println(attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">progress</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">progress</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2073,15 +2016,8 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey">HMACKey</h3>
-        <div class="markdown level1 summary"><p>HMACKey is the representation of a Google Cloud Storage HMAC key.</p>
-<p>HMAC keys are used to authenticate signed access to objects. To enable HMAC key
-authentication, please visit <a href="https://cloud.google.com/storage/docs/migrating">https://cloud.google.com/storage/docs/migrating</a>.</p>
-<p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKey struct {
 	// The HMAC's secret key.
@@ -2115,13 +2051,14 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	<a href="#state">State</a> <a href="#hmacstate">HMACState</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate">HMACKeyAttrsToUpdate</h3>
-        <div class="markdown level1 summary"><p>HMACKeyAttrsToUpdate defines the attributes of an HMACKey that will be updated.</p>
+        <div class="markdown level1 summary"><p>HMACKey is the representation of a Google Cloud Storage HMAC key.</p>
+<p>HMAC keys are used to authenticate signed access to objects. To enable HMAC key
+authentication, please visit <a href="https://cloud.google.com/storage/docs/migrating">https://cloud.google.com/storage/docs/migrating</a>.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate">HMACKeyAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyAttrsToUpdate struct {
 	// State is required and must be either StateActive or StateInactive.
@@ -2131,34 +2068,36 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 	<a href="#etag">Etag</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle">HMACKeyHandle</h3>
-        <div class="markdown level1 summary"><p>HMACKeyHandle helps provide access and management for HMAC keys.</p>
+        <div class="markdown level1 summary"><p>HMACKeyAttrsToUpdate defines the attributes of an HMACKey that will be updated.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle">HMACKeyHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyHandle struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>HMACKeyHandle helps provide access and management for HMAC keys.</p>
+<p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete">func (*HMACKeyHandle) Delete
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Delete invokes an RPC to delete the key referenced by accessID, on Google Cloud Storage.
 Only inactive HMAC keys can be deleted.
 After deletion, a key cannot be used to authenticate requests.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Delete_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2179,9 +2118,12 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get">func (*HMACKeyHandle) Get
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Get(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Get invokes an RPC to retrieve the HMAC key referenced by the
 HMACKeyHandle&#39;s accessID.</p>
 <p>Options such as UserProjectForHMACKeys can be used to set the
@@ -2189,13 +2131,9 @@ userProject to be billed against for operations.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Get(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Get_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2217,20 +2155,19 @@ func main() {
 	_ = hkey // TODO: Use the HMAC Key.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update">func (*HMACKeyHandle) Update
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (h *<a href="#hmackeyhandle">HMACKeyHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, au <a href="#hmackeyattrstoupdate">HMACKeyAttrsToUpdate</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Update mutates the HMACKey referred to by accessID.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (h *<a href="#hmackeyhandle">HMACKeyHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, au <a href="#hmackeyattrstoupdate">HMACKeyAttrsToUpdate</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_HMACKeyHandle_Update_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2254,21 +2191,23 @@ func main() {
 	_ = ukey // TODO: Use the HMAC Key.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption">HMACKeyOption</h3>
-        <div class="markdown level1 summary"><p>HMACKeyOption configures the behavior of HMACKey related methods and actions.</p>
-<p>This interface is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyOption interface {
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>HMACKeyOption configures the behavior of HMACKey related methods and actions.</p>
+<p>This interface is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail">func ForHMACKeyServiceAccountEmail
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func ForHMACKeyServiceAccountEmail(serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ForHMACKeyServiceAccountEmail returns HMAC Keys that are
 associated with the email address of a service account in the project.</p>
 <p>Only one service account email can be used as a filter, so if multiple
@@ -2276,47 +2215,43 @@ of these options are applied, the last email to be set will be used.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func ForHMACKeyServiceAccountEmail(serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys">func ShowDeletedHMACKeys
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func ShowDeletedHMACKeys() <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ShowDeletedHMACKeys will also list keys whose state is &quot;DELETED&quot;.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func ShowDeletedHMACKeys() <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys">func UserProjectForHMACKeys
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func UserProjectForHMACKeys(userProjectID <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>UserProjectForHMACKeys will bill the request against userProjectID
 if userProjectID is non-empty.</p>
 <p>Note: This is a noop right now and only provided for API compatibility.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func UserProjectForHMACKeys(userProjectID <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator">HMACKeysIterator</h3>
-        <div class="markdown level1 summary"><p>An HMACKeysIterator is an iterator over HMACKeys.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-<p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeysIterator struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>An HMACKeysIterator is an iterator over HMACKeys.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+<p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next">func (*HMACKeysIterator) Next
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) Next() (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
 there are no more results. Once Next returns iterator.Done, all subsequent
 calls will return iterator.Done.</p>
@@ -2324,35 +2259,26 @@ calls will return iterator.Done.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) Next() (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo">func (*HMACKeysIterator) PageInfo
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
 <p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState">HMACState</h3>
+        <div class="codewrapper">
+          <pre><code class="prettyprint">type HMACState <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
+        </div>
         <div class="markdown level1 summary"><p>HMACState is the state of the HMAC key.</p>
 <p>This type is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="prettyprint">type HMACState <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
-        </div>
         
             <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted">Active, Inactive, Deleted</h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// Active is the status for an active key that can be used to sign
@@ -2370,22 +2296,19 @@ calls will return iterator.Done.</p>
 	Deleted <a href="#hmacstate">HMACState</a> = "DELETED"
 )</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                   <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle">Lifecycle</h3>
-        <div class="markdown level1 summary"><p>Lifecycle is the lifecycle configuration for objects in the bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Lifecycle struct {
 	<a href="#rules">Rules</a> []<a href="#lifecyclerule">LifecycleRule</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction">LifecycleAction</h3>
-        <div class="markdown level1 summary"><p>LifecycleAction is a lifecycle configuration action.</p>
+        <div class="markdown level1 summary"><p>Lifecycle is the lifecycle configuration for objects in the bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction">LifecycleAction</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleAction struct {
 	// Type is the type of action to take on matching objects.
@@ -2400,14 +2323,11 @@ calls will return iterator.Done.</p>
 	<a href="#storageclass">StorageClass</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition">LifecycleCondition</h3>
-        <div class="markdown level1 summary"><p>LifecycleCondition is a set of conditions used to match objects and take an
-action automatically.</p>
-<p>All configured conditions must be met for the associated action to be taken.</p>
+        <div class="markdown level1 summary"><p>LifecycleAction is a lifecycle configuration action.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition">LifecycleCondition</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleCondition struct {
 	// AgeInDays is the age of the object in days.
@@ -2458,14 +2378,13 @@ action automatically.</p>
 	<a href="#numnewerversions">NumNewerVersions</a> <a href="https://pkg.go.dev/builtin#int64">int64</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule">LifecycleRule</h3>
-        <div class="markdown level1 summary"><p>LifecycleRule is a lifecycle configuration rule.</p>
-<p>When all the configured conditions are met by an object in the bucket, the
-configured action will automatically be taken on that object.</p>
+        <div class="markdown level1 summary"><p>LifecycleCondition is a set of conditions used to match objects and take an
+action automatically.</p>
+<p>All configured conditions must be met for the associated action to be taken.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule">LifecycleRule</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleRule struct {
 	// Action is the action to take when all of the associated conditions are
@@ -2477,20 +2396,21 @@ configured action will automatically be taken on that object.</p>
 	<a href="#condition">Condition</a> <a href="#lifecyclecondition">LifecycleCondition</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness">Liveness</h3>
-        <div class="markdown level1 summary"><p>Liveness specifies whether the object is live or not.</p>
+        <div class="markdown level1 summary"><p>LifecycleRule is a lifecycle configuration rule.</p>
+<p>When all the configured conditions are met by an object in the bucket, the
+configured action will automatically be taken on that object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness">Liveness</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Liveness <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
+        <div class="markdown level1 summary"><p>Liveness specifies whether the object is live or not.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived">LiveAndArchived, Live, Archived</h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// LiveAndArchived includes both live and archived objects.
@@ -2501,12 +2421,9 @@ configured action will automatically be taken on that object.</p>
 	Archived
 )</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                   <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification">Notification</h3>
-        <div class="markdown level1 summary"><p>A Notification describes how to send Cloud PubSub messages when certain
-events occur in a bucket.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Notification struct {
 	//The ID of the notification.
@@ -2536,12 +2453,12 @@ events occur in a bucket.</p>
 	<a href="#payloadformat">PayloadFormat</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs">ObjectAttrs</h3>
-        <div class="markdown level1 summary"><p>ObjectAttrs represents the metadata for a Google Cloud Storage (GCS) object.</p>
+        <div class="markdown level1 summary"><p>A Notification describes how to send Cloud PubSub messages when certain
+events occur in a bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs">ObjectAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrs struct {
 	// Bucket is the name of the bucket containing this GCS object.
@@ -2687,21 +2604,11 @@ events occur in a bucket.</p>
 	<a href="#customtime">CustomTime</a> <a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>
 }</userid></code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate">ObjectAttrsToUpdate</h3>
-        <div class="markdown level1 summary"><p>ObjectAttrsToUpdate is used to update the attributes of an object.
-Only fields set to non-nil values will be updated.
-Set a field to its zero value to delete it.</p>
-<p>For example, to change ContentType and delete ContentEncoding and
-Metadata, use
-   ObjectAttrsToUpdate{
-       ContentType: &quot;text/html&quot;,
-       ContentEncoding: &quot;&quot;,
-       Metadata: map[string]string{},
-   }</p>
+        <div class="markdown level1 summary"><p>ObjectAttrs represents the metadata for a Google Cloud Storage (GCS) object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate">ObjectAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrsToUpdate struct {
 	<a href="#eventbasedhold">EventBasedHold</a>     <a href="https://pkg.go.dev/cloud.google.com/go/internal/optional">optional</a>.<a href="https://pkg.go.dev/cloud.google.com/go/internal/optional#Bool">Bool</a>
@@ -2720,18 +2627,29 @@ Metadata, use
 	<a href="#predefinedacl">PredefinedACL</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle">ObjectHandle</h3>
-        <div class="markdown level1 summary"><p>ObjectHandle provides operations on an object in a Google Cloud Storage bucket.
-Use BucketHandle.Object to get a handle.</p>
+        <div class="markdown level1 summary"><p>ObjectAttrsToUpdate is used to update the attributes of an object.
+Only fields set to non-nil values will be updated.
+Set a field to its zero value to delete it.</p>
+<p>For example, to change ContentType and delete ContentEncoding and
+Metadata, use
+   ObjectAttrsToUpdate{
+       ContentType: &quot;text/html&quot;,
+       ContentEncoding: &quot;&quot;,
+       Metadata: map[string]string{},
+   }</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle">ObjectHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectHandle struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>ObjectHandle provides operations on an object in a Google Cloud Storage bucket.
+Use BucketHandle.Object to get a handle.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         <h5 id="cloud_google_com_go_storage_ObjectHandle_examples">Examples</h5>
         <h6 translate="no">exists</h6>
         <div class="codewrapper">
@@ -2765,19 +2683,18 @@ func main() {
   
             <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL">func (*ObjectHandle) ACL
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ACL provides access to the object&#39;s access control list.
 This controls who can read and write this object.
 This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ACL_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2803,20 +2720,19 @@ func main() {
 	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs">func (*ObjectHandle) Attrs
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Attrs returns meta information about the object.
 ErrObjectNotExist will be returned if the object is not found.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Attrs_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2837,10 +2753,10 @@ func main() {
 	fmt.Println(objAttrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">withConditions</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">withConditions</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2871,20 +2787,19 @@ func main() {
 	fmt.Println(objAttrs1, objAttrs2)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName">func (*ObjectHandle) BucketName
 </h4>
-            <div class="markdown level1 summary"><p>BucketName returns the name of the bucket.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) BucketName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>BucketName returns the name of the bucket.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_BucketName_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2910,9 +2825,12 @@ func main() {
 	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom">func (*ObjectHandle) ComposerFrom
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) ComposerFrom(srcs ...*<a href="#objecthandle">ObjectHandle</a>) *<a href="#composer">Composer</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ComposerFrom creates a Composer that can compose srcs into dst.
 You can immediately call Run on the returned Composer, or you can
 configure it first.</p>
@@ -2921,14 +2839,10 @@ source objects and encrypt the destination object. It is an error
 to specify an encryption key for any of the source objects.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) ComposerFrom(srcs ...*<a href="#objecthandle">ObjectHandle</a>) *<a href="#composer">Composer</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2954,9 +2868,12 @@ func main() {
 	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom">func (*ObjectHandle) CopierFrom
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) CopierFrom(src *<a href="#objecthandle">ObjectHandle</a>) *<a href="#copier">Copier</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>CopierFrom creates a Copier that can copy src to dst.
 You can immediately call Run on the returned Copier, or
 you can configure it first.</p>
@@ -2964,14 +2881,10 @@ you can configure it first.</p>
 in which case the user project of src is billed.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) CopierFrom(src *<a href="#objecthandle">ObjectHandle</a>) *<a href="#copier">Copier</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom_examples">Examples</h5>
-            <h6 translate="no">rotateEncryptionKeys</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">rotateEncryptionKeys</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -2995,19 +2908,18 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete">func (*ObjectHandle) Delete
 </h4>
-            <div class="markdown level1 summary"><p>Delete deletes the single specified object.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Delete deletes the single specified object.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Delete_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3045,9 +2957,12 @@ func main() {
 	fmt.Println(&quot;deleted all object items in the bucket specified.&quot;)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation">func (*ObjectHandle) Generation
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Generation(gen <a href="https://pkg.go.dev/builtin#int64">int64</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Generation returns a new ObjectHandle that operates on a specific generation
 of the object.
 By default, the handle operates on the latest generation. Not
@@ -3055,13 +2970,9 @@ all operations work when given a specific generation; check the API
 endpoints at <a href="https://cloud.google.com/storage/docs/json_api/">https://cloud.google.com/storage/docs/json_api/</a> for details.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Generation(gen <a href="https://pkg.go.dev/builtin#int64">int64</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Generation_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3091,9 +3002,12 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If">func (*ObjectHandle) If
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) If(conds <a href="#conditions">Conditions</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>If returns a new ObjectHandle that applies a set of preconditions.
 Preconditions already set on the ObjectHandle are ignored.
 Operations on the new handle will return an error if the preconditions are not
@@ -3101,13 +3015,9 @@ satisfied. See <a href="https://cloud.google.com/storage/docs/generations-precon
 for more details.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) If(conds <a href="#conditions">Conditions</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_If_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3152,22 +3062,21 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key">func (*ObjectHandle) Key
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Key(encryptionKey []<a href="https://pkg.go.dev/builtin#byte">byte</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Key returns a new ObjectHandle that uses the supplied encryption
 key to encrypt and decrypt the object&#39;s contents.</p>
 <p>Encryption key must be a 32-byte AES-256 key.
 See <a href="https://cloud.google.com/storage/docs/encryption">https://cloud.google.com/storage/docs/encryption</a> for details.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Key(encryptionKey []<a href="https://pkg.go.dev/builtin#byte">byte</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Key_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3193,9 +3102,12 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader">func (*ObjectHandle) NewRangeReader
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewRangeReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, offset, length <a href="https://pkg.go.dev/builtin#int64">int64</a>) (r *<a href="#reader">Reader</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>NewRangeReader reads part of an object, reading at most length bytes
 starting at the given offset. If length is negative, the object is read
 until the end. If offset is negative, the object is read abs(offset) bytes
@@ -3207,13 +3119,9 @@ that file will be served back whole, regardless of the requested range as
 Google Cloud Storage dictates.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewRangeReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, offset, length <a href="https://pkg.go.dev/builtin#int64">int64</a>) (r *<a href="#reader">Reader</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3242,10 +3150,10 @@ func main() {
 	fmt.Printf(&quot;first 64K of file contents:\n%s\n&quot;, slurp)
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">lastNBytes</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">lastNBytes</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3274,10 +3182,10 @@ func main() {
 	fmt.Printf(&quot;Last 10 bytes from the end of the file:\n%s\n&quot;, slurp)
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">untilEnd</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">untilEnd</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3306,22 +3214,21 @@ func main() {
 	fmt.Printf(&quot;From 101st byte until the end:\n%s\n&quot;, slurp)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader">func (*ObjectHandle) NewReader
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (*<a href="#reader">Reader</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>NewReader creates a new Reader to read the contents of the
 object.
 ErrObjectNotExist will be returned if the object is not found.</p>
 <p>The caller must call Close on the returned Reader when done reading.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (*<a href="#reader">Reader</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewReader_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3348,9 +3255,12 @@ func main() {
 	fmt.Println(&quot;file contents:&quot;, slurp)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter">func (*ObjectHandle) NewWriter
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewWriter(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) *<a href="#writer">Writer</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>NewWriter returns a storage Writer that writes to the GCS object
 associated with this ObjectHandle.</p>
 <p>A new object will be created unless an object with this name already exists.
@@ -3365,13 +3275,9 @@ using net/http.DetectContentType.</p>
 stop writing without saving the data, cancel the context.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewWriter(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) *<a href="#writer">Writer</a></code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_NewWriter_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3388,20 +3294,19 @@ func main() {
 	_ = wc // TODO: Use the Writer.
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName">func (*ObjectHandle) ObjectName
 </h4>
-            <div class="markdown level1 summary"><p>ObjectName returns the name of the object.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ObjectName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>ObjectName returns the name of the object.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ObjectName_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3427,20 +3332,19 @@ func main() {
 	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed">func (*ObjectHandle) ReadCompressed
 </h4>
-            <div class="markdown level1 summary"><p>ReadCompressed when true causes the read to happen without decompressing.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ReadCompressed(compressed <a href="https://pkg.go.dev/builtin#bool">bool</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>ReadCompressed when true causes the read to happen without decompressing.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed_examples">Examples</h5>
-            <h6 translate="no">exists</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <h6 translate="no">exists</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3466,21 +3370,20 @@ func main() {
 	fmt.Printf(&quot;The object exists and has attributes: %#v\n&quot;, attrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update">func (*ObjectHandle) Update
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#objectattrstoupdate">ObjectAttrsToUpdate</a>) (oa *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Update updates an object with the provided attributes.
 All zero-value attributes are ignored.
 ErrObjectNotExist will be returned if the object is not found.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#objectattrstoupdate">ObjectAttrsToUpdate</a>) (oa *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_Update_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3505,21 +3408,23 @@ func main() {
 	fmt.Println(objAttrs)
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator">ObjectIterator</h3>
-        <div class="markdown level1 summary"><p>An ObjectIterator is an iterator over ObjectAttrs.</p>
-<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectIterator struct {
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>An ObjectIterator is an iterator over ObjectAttrs.</p>
+<p>Note: This iterator is not safe for concurrent operations without explicit synchronization.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next">func (*ObjectIterator) Next
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) Next() (*<a href="#objectattrs">ObjectAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Next returns the next result. Its second return value is iterator.Done if
 there are no more results. Once Next returns iterator.Done, all subsequent
 calls will return iterator.Done.</p>
@@ -3535,13 +3440,9 @@ represent prefixes.</p>
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) Next() (*<a href="#objectattrs">ObjectAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_ObjectIterator_Next_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -3569,22 +3470,17 @@ func main() {
 	}
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
             <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo">func (*ObjectIterator) PageInfo
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>PageInfo supports pagination. See the google.golang.org/api/iterator package for details.</p>
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields">PolicyV4Fields</h3>
-        <div class="markdown level1 summary"><p>PolicyV4Fields describes the attributes for a PostPolicyV4 request.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PolicyV4Fields struct {
 	// ACL specifies the access control permissions for the object.
@@ -3618,12 +3514,11 @@ func main() {
 	<a href="#redirecttourlonsuccess">RedirectToURLOnSuccess</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4">PostPolicyV4</h3>
-        <div class="markdown level1 summary"><p>PostPolicyV4 describes the URL and respective form fields for a generated PostPolicyV4 request.</p>
+        <div class="markdown level1 summary"><p>PolicyV4Fields describes the attributes for a PostPolicyV4 request.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4">PostPolicyV4</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4 struct {
 	// URL is the generated URL that the file upload will be made to.
@@ -3633,20 +3528,22 @@ func main() {
 	<a href="#fields">Fields</a> map[<a href="https://pkg.go.dev/builtin#string">string</a>]<a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>PostPolicyV4 describes the URL and respective form fields for a generated PostPolicyV4 request.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4">func GenerateSignedPostPolicyV4
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func GenerateSignedPostPolicyV4(bucket, object <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#postpolicyv4options">PostPolicyV4Options</a>) (*<a href="#postpolicyv4">PostPolicyV4</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>GenerateSignedPostPolicyV4 generates a PostPolicyV4 value from bucket, object and opts.
 The generated URL and fields will then allow an unauthenticated client to perform multipart uploads.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func GenerateSignedPostPolicyV4(bucket, object <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#postpolicyv4options">PostPolicyV4Options</a>) (*<a href="#postpolicyv4">PostPolicyV4</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;bytes&quot;
@@ -3718,47 +3615,38 @@ func main() {
 	_ = res
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
         <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition">PostPolicyV4Condition</h3>
-        <div class="markdown level1 summary"><p>PostPolicyV4Condition describes the constraints that the subsequent
-object upload&#39;s multipart form fields will be expected to conform to.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Condition interface {
 	<a href="https://pkg.go.dev/encoding/json">json</a>.<a href="https://pkg.go.dev/encoding/json#Marshaler">Marshaler</a>
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>PostPolicyV4Condition describes the constraints that the subsequent
+object upload&#39;s multipart form fields will be expected to conform to.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange">func ConditionContentLengthRange
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func ConditionContentLengthRange(start, end <a href="https://pkg.go.dev/builtin#uint64">uint64</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ConditionContentLengthRange constraints the limits that the
 multipart upload&#39;s range header will be expected to be within.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func ConditionContentLengthRange(start, end <a href="https://pkg.go.dev/builtin#uint64">uint64</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith">func ConditionStartsWith
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func ConditionStartsWith(key, value <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ConditionStartsWith checks that an attributes starts with value.
 An empty value will cause this condition to be ignored.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func ConditionStartsWith(key, value <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options">PostPolicyV4Options</h3>
-        <div class="markdown level1 summary"><p>PostPolicyV4Options are used to construct a signed post policy.
-Please see <a href="https://cloud.google.com/storage/docs/xml-api/post-object">https://cloud.google.com/storage/docs/xml-api/post-object</a>
-for reference about the fields.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Options struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -3827,24 +3715,24 @@ for reference about the fields.</p>
 	<a href="#conditions">Conditions</a> []<a href="#postpolicyv4condition">PostPolicyV4Condition</a>
 }</your-project-id></code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam">ProjectTeam</h3>
-        <div class="markdown level1 summary"><p>ProjectTeam is the project team associated with the entity, if any.</p>
+        <div class="markdown level1 summary"><p>PostPolicyV4Options are used to construct a signed post policy.
+Please see <a href="https://cloud.google.com/storage/docs/xml-api/post-object">https://cloud.google.com/storage/docs/xml-api/post-object</a>
+for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam">ProjectTeam</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ProjectTeam struct {
 	<a href="#projectnumber">ProjectNumber</a> <a href="https://pkg.go.dev/builtin#string">string</a>
 	<a href="#team">Team</a>          <a href="https://pkg.go.dev/builtin#string">string</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query">Query</h3>
-        <div class="markdown level1 summary"><p>Query represents a query to filter objects from a bucket.</p>
+        <div class="markdown level1 summary"><p>ProjectTeam is the project team associated with the entity, if any.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query">Query</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Query struct {
 	// Delimiter returns results in a directory-like fashion.
@@ -3878,9 +3766,15 @@ for reference about the fields.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>Query represents a query to filter objects from a bucket.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection">func (*Query) SetAttrSelection
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (q *<a href="#query">Query</a>) SetAttrSelection(attrs []<a href="https://pkg.go.dev/builtin#string">string</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>SetAttrSelection makes the query populate only specific attributes of
 objects. When iterating over objects, if you only need each object&#39;s name
 and size, pass []string{&quot;Name&quot;, &quot;Size&quot;} to this method. Only these fields
@@ -3890,11 +3784,13 @@ optimization; for more information, see
 <a href="https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance">https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (q *<a href="#query">Query</a>) SetAttrSelection(attrs []<a href="https://pkg.go.dev/builtin#string">string</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader">Reader</h3>
+        <div class="codewrapper">
+          <pre><code class="prettyprint">type Reader struct {
+	<a href="#attrs">Attrs</a> <a href="#readerobjectattrs">ReaderObjectAttrs</a>
+	// contains filtered or unexported fields
+}</code></pre>
+        </div>
         <div class="markdown level1 summary"><p>Reader reads a Cloud Storage object.
 It implements io.Reader.</p>
 <p>Typically, a Reader computes the CRC of the downloaded content and compares it to
@@ -3902,100 +3798,78 @@ the stored CRC, returning an error from Read if there is a mismatch. This integr
 is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/docs/transcoding">https://cloud.google.com/storage/docs/transcoding</a>.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="prettyprint">type Reader struct {
-	<a href="#attrs">Attrs</a> <a href="#readerobjectattrs">ReaderObjectAttrs</a>
-	// contains filtered or unexported fields
-}</code></pre>
-        </div>
         
             <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl">func (*Reader) CacheControl
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) CacheControl() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>CacheControl returns the cache control of the object.</p>
 <p>Deprecated: use Reader.Attrs.CacheControl.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) CacheControl() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close">func (*Reader) Close
 </h4>
-            <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
                       <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding">func (*Reader) ContentEncoding
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentEncoding() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ContentEncoding returns the content encoding of the object.</p>
 <p>Deprecated: use Reader.Attrs.ContentEncoding.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentEncoding() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType">func (*Reader) ContentType
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentType() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>ContentType returns the content type of the object.</p>
 <p>Deprecated: use Reader.Attrs.ContentType.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentType() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified">func (*Reader) LastModified
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) LastModified() (<a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>LastModified returns the value of the Last-Modified header.</p>
 <p>Deprecated: use Reader.Attrs.LastModified.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) LastModified() (<a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read">func (*Reader) Read
 </h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Read(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (<a href="https://pkg.go.dev/builtin#int">int</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                       <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain">func (*Reader) Remain
 </h4>
-            <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
-</div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Remain() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
             </div>
+            <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
+</div>
+            <div class="markdown level1 conceptual"></div>
                       <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size">func (*Reader) Size
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Size() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Size returns the size of the object in bytes.
 The returned value is always the same and is not affected by
 calls to Read or Close.</p>
 <p>Deprecated: use Reader.Attrs.Size.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Size() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs">ReaderObjectAttrs</h3>
-        <div class="markdown level1 summary"><p>ReaderObjectAttrs are attributes about the object being read. These are populated
-during the New call. This struct only holds a subset of object attributes: to
-get the full set of attributes, use ObjectHandle.Attrs.</p>
-<p>Each field is read-only.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ReaderObjectAttrs struct {
 	// Size is the length of the object's content.
@@ -4030,21 +3904,14 @@ get the full set of attributes, use ObjectHandle.Attrs.</p>
 	<a href="#metageneration">Metageneration</a> <a href="https://pkg.go.dev/builtin#int64">int64</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy">RetentionPolicy</h3>
-        <div class="markdown level1 summary"><p>RetentionPolicy enforces a minimum retention time for all objects
-contained in the bucket.</p>
-<p>Any attempt to overwrite or delete objects younger than the retention
-period will result in an error. An unlocked retention policy can be
-modified or removed from the bucket via the Update method. A
-locked retention policy cannot be removed or shortened in duration
-for the lifetime of the bucket.</p>
-<p>This feature is in private alpha release. It is not currently available to
-most customers. It might be changed in backwards-incompatible ways and is not
-subject to any SLA or deprecation policy.</p>
+        <div class="markdown level1 summary"><p>ReaderObjectAttrs are attributes about the object being read. These are populated
+during the New call. This struct only holds a subset of object attributes: to
+get the full set of attributes, use ObjectHandle.Attrs.</p>
+<p>Each field is read-only.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy">RetentionPolicy</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type RetentionPolicy struct {
 	// RetentionPeriod specifies the duration that objects need to be
@@ -4064,12 +3931,20 @@ subject to any SLA or deprecation policy.</p>
 	<a href="#islocked">IsLocked</a> <a href="https://pkg.go.dev/builtin#bool">bool</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions">SignedURLOptions</h3>
-        <div class="markdown level1 summary"><p>SignedURLOptions allows you to restrict the access to the signed URL.</p>
+        <div class="markdown level1 summary"><p>RetentionPolicy enforces a minimum retention time for all objects
+contained in the bucket.</p>
+<p>Any attempt to overwrite or delete objects younger than the retention
+period will result in an error. An unlocked retention policy can be
+modified or removed from the bucket via the Update method. A
+locked retention policy cannot be removed or shortened in duration
+for the lifetime of the bucket.</p>
+<p>This feature is in private alpha release. It is not currently available to
+most customers. It might be changed in backwards-incompatible ways and is not
+subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions">SignedURLOptions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SignedURLOptions struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -4162,20 +4037,19 @@ subject to any SLA or deprecation policy.</p>
 	<a href="#scheme">Scheme</a> <a href="#signingscheme">SigningScheme</a>
 }</your-project-id></code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme">SigningScheme</h3>
-        <div class="markdown level1 summary"><p>SigningScheme determines the API version to use when signing URLs.</p>
+        <div class="markdown level1 summary"><p>SignedURLOptions allows you to restrict the access to the signed URL.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme">SigningScheme</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SigningScheme <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
+        <div class="markdown level1 summary"><p>SigningScheme determines the API version to use when signing URLs.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
-            <div class="markdown level1 summary"></div>
-            <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// SigningSchemeDefault is presently V2 and will change to V4 in the future.
@@ -4188,21 +4062,25 @@ subject to any SLA or deprecation policy.</p>
 	SigningSchemeV4
 )</code></pre>	
             </div>
+            <div class="markdown level1 summary"></div>
+            <div class="markdown level1 conceptual"></div>
                   <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle">URLStyle</h3>
-        <div class="markdown level1 summary"><p>URLStyle determines the style to use for the signed URL. pathStyle is the
-default. All non-default options work with V4 scheme only. See
-<a href="https://cloud.google.com/storage/docs/request-endpoints">https://cloud.google.com/storage/docs/request-endpoints</a> for details.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type URLStyle interface {
 	// contains filtered or unexported methods
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>URLStyle determines the style to use for the signed URL. pathStyle is the
+default. All non-default options work with V4 scheme only. See
+<a href="https://cloud.google.com/storage/docs/request-endpoints">https://cloud.google.com/storage/docs/request-endpoints</a> for details.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname">func BucketBoundHostname
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func BucketBoundHostname(hostname <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#urlstyle">URLStyle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>BucketBoundHostname generates a URL with a custom hostname tied to a
 specific GCS bucket. The desired hostname should be passed in using the
 hostname argument. Generated urls will be of the form
@@ -4213,36 +4091,25 @@ for details. Note that for CNAMEs, only HTTP is supported, so Insecure must
 be set to true.<p>
 </object-name></bucket-bound-hostname></div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func BucketBoundHostname(hostname <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#urlstyle">URLStyle</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle">func PathStyle
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func PathStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>PathStyle is the default style, and will generate a URL of the form
 &quot;storage.googleapis.com/<bucket-name>/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func PathStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle">func VirtualHostedStyle
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func VirtualHostedStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>VirtualHostedStyle generates a URL relative to the bucket&#39;s virtual
 hostname, e.g. &quot;<bucket-name>.storage.googleapis.com/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func VirtualHostedStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
-            </div>
                   <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess">UniformBucketLevelAccess</h3>
-        <div class="markdown level1 summary"><p>UniformBucketLevelAccess configures access checks to use only bucket-level IAM
-policies.</p>
-</div>
-        <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
         <div class="codewrapper">
           <pre><code class="prettyprint">type UniformBucketLevelAccess struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -4253,12 +4120,12 @@ policies.</p>
 	<a href="#lockedtime">LockedTime</a> <a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>
 }</code></pre>
         </div>
-        
-        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer">Writer</h3>
-        <div class="markdown level1 summary"><p>A Writer writes a Cloud Storage object.</p>
+        <div class="markdown level1 summary"><p>UniformBucketLevelAccess configures access checks to use only bucket-level IAM
+policies.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
+        
+        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer">Writer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Writer struct {
 	// ObjectAttrs are optional attributes to set on the object. Any attributes
@@ -4307,41 +4174,44 @@ policies.</p>
 	// contains filtered or unexported fields
 }</code></pre>
         </div>
+        <div class="markdown level1 summary"><p>A Writer writes a Cloud Storage object.</p>
+</div>
+        <div class="markdown level1 conceptual"></div>
         
             <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs">func (*Writer) Attrs
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Attrs() *<a href="#objectattrs">ObjectAttrs</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Attrs returns metadata about a successfully-written object.
 It&#39;s only valid to call it after Close returns nil.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Attrs() *<a href="#objectattrs">ObjectAttrs</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close">func (*Writer) Close
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Close completes the write operation and flushes any buffered data.
 If Close doesn&#39;t return an error, metadata about the written object
 can be retrieved by calling Attrs.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError">func (*Writer) CloseWithError
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) CloseWithError(err <a href="https://pkg.go.dev/builtin#error">error</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>CloseWithError aborts the write operation with the provided error.
 CloseWithError always returns nil.</p>
 <p>Deprecated: cancel the context passed to NewWriter instead.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) CloseWithError(err <a href="https://pkg.go.dev/builtin#error">error</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
-            </div>
                       <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write">func (*Writer) Write
 </h4>
+            <div class="codewrapper">	
+              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Write(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (n <a href="https://pkg.go.dev/builtin#int">int</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
+            </div>
             <div class="markdown level1 summary"><p>Write appends to w. It implements the io.Writer interface.</p>
 <p>Since writes happen asynchronously, Write may return a nil
 error even though the write failed (or will fail). Always
@@ -4351,13 +4221,9 @@ the upload was successful.</p>
 Writer.ChunkSize has been set to zero.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-            <h5 class="decalaration">Declaration</h5>
-            <div class="codewrapper">	
-              <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Write(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (n <a href="https://pkg.go.dev/builtin#int">int</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
-            </div>
             <h5 id="cloud_google_com_go_storage_Writer_Write_examples">Examples</h5>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4385,10 +4251,10 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">checksum</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">checksum</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4418,10 +4284,10 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 {% endverbatim %}</code></pre>
-            </div>
-            <h6 translate="no">timeout</h6>
-            <div class="codewrapper">
-            <pre><code class="prettyprint">{% verbatim %}package main
+  </div>
+  <h6 translate="no">timeout</h6>
+  <div class="codewrapper">
+  <pre><code class="prettyprint">{% verbatim %}package main
 
 import (
 	&quot;cloud.google.com/go/storage&quot;
@@ -4452,22 +4318,21 @@ func main() {
 	fmt.Println(&quot;updated object:&quot;, wc.Attrs())
 }
 {% endverbatim %}</code></pre>
-            </div>
+  </div>
     <h2 id="functions">Functions
   
   </h2>
         <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL">func SignedURL
 </h3>
+        <div class="codewrapper">
+          <pre><code class="prettyprint">func SignedURL(bucket, name <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#signedurloptions">SignedURLOptions</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>
+        </div>
         <div class="markdown level1 summary"><p>SignedURL returns a URL for the specified object. Signed URLs allow
 the users access to a restricted resource for a limited time without having a
 Google account or signing in. For more information about the signed
 URLs, see <a href="https://cloud.google.com/storage/docs/accesscontrol#Signed-URLs">https://cloud.google.com/storage/docs/accesscontrol#Signed-URLs</a>.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
-        <h5 class="decalaration">Declaration</h5>
-        <div class="codewrapper">
-          <pre><code class="prettyprint">func SignedURL(bucket, name <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#signedurloptions">SignedURLOptions</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>
-        </div>
         <h5 id="cloud_google_com_go_storage_SignedURL_examples">Examples</h5>
         <div class="codewrapper">
         <pre><code class="prettyprint">{% verbatim %}package main

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new AppEngineHttpTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new AppEngineHttpTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#appEngineRouting:member">appEngineRouting</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#body:member">body</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget body.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget body.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#headers:member">headers</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget headers.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget headers.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,13 +114,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#httpMethod:member">httpMethod</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,13 +136,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#relativeUri:member">relativeUri</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public relativeUri: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,13 +160,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new AppEngineHttpTarget instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new AppEngineHttpTarget instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -211,13 +204,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -265,13 +257,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -310,13 +301,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,13 +354,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +407,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates an AppEngineHttpTarget message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates an AppEngineHttpTarget message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,13 +451,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this AppEngineHttpTarget to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this AppEngineHttpTarget to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,13 +474,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineHttpTarget message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineHttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineHttpTarget message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,13 +527,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies an AppEngineHttpTarget message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies an AppEngineHttpTarget message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new AppEngineRouting.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineRouting);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new AppEngineRouting.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#host:member">host</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting host.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public host: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting host.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#instance:member">instance</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting instance.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public instance: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting instance.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#service:member">service</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting service.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public service: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting service.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,13 +114,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#version:member">version</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting version.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public version: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting version.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,13 +138,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new AppEngineRouting instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineRouting): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new AppEngineRouting instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -188,13 +182,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -242,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,13 +279,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,13 +332,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates an AppEngineRouting message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates an AppEngineRouting message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,13 +429,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this AppEngineRouting to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this AppEngineRouting to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,13 +452,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineRouting message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineRouting, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineRouting message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,13 +505,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies an AppEngineRouting message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies an AppEngineRouting message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
@@ -23,13 +23,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler:constructor(1)">(constructor)(rpcImpl, requestDelimited, responseDelimited)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new CloudScheduler service.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new CloudScheduler service.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +71,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler.create:member(1)">create(rpcImpl, requestDelimited, responseDelimited)</h4>
-  <div class="markdown level1 summary"><p>Creates new CloudScheduler service using the specified rpc implementation.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): CloudScheduler;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates new CloudScheduler service using the specified rpc implementation.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,13 +133,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(1)">createJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls CreateJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.CreateJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls CreateJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -188,13 +185,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(2)">createJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls CreateJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls CreateJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,13 +229,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(1)">deleteJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.DeleteJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,13 +281,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(2)">deleteJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest): Promise&lt;google.protobuf.Empty&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,13 +325,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(1)">getJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls GetJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.GetJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls GetJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -384,13 +377,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(2)">getJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls GetJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls GetJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,13 +421,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(1)">listJobs(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls ListJobs.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ListJobsCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls ListJobs.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,13 +473,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(2)">listJobs(request)</h4>
-  <div class="markdown level1 summary"><p>Calls ListJobs.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest): Promise&lt;google.cloud.scheduler.v1.ListJobsResponse&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls ListJobs.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,13 +517,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(1)">pauseJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls PauseJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.PauseJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls PauseJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,13 +569,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(2)">pauseJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls PauseJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls PauseJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,13 +613,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(1)">resumeJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ResumeJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,13 +665,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(2)">resumeJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,13 +709,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(1)">runJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls RunJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.RunJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls RunJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,13 +761,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(2)">runJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls RunJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls RunJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -821,13 +805,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(1)">updateJob(request, callback)</h4>
-  <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.UpdateJobCallback): void;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,13 +857,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(2)">updateJob(request)</h4>
-  <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new CreateJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.ICreateJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new CreateJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#job:member">job</h4>
-  <div class="markdown level1 summary"><p>CreateJobRequest job.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>CreateJobRequest job.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#parent:member">parent</h4>
-  <div class="markdown level1 summary"><p>CreateJobRequest parent.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>CreateJobRequest parent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,13 +94,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new CreateJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.ICreateJobRequest): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new CreateJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,13 +191,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,13 +288,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,13 +341,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a CreateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a CreateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this CreateJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this CreateJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +408,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a CreateJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.CreateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a CreateJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,13 +461,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a CreateJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a CreateJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new DeleteJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IDeleteJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new DeleteJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>DeleteJobRequest name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>DeleteJobRequest name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,13 +72,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new DeleteJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IDeleteJobRequest): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new DeleteJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,13 +116,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,13 +169,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,13 +266,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,13 +319,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a DeleteJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a DeleteJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this DeleteJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this DeleteJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +386,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a DeleteJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.DeleteJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a DeleteJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,13 +439,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a DeleteJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a DeleteJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new GetJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IGetJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new GetJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>GetJobRequest name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>GetJobRequest name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,13 +72,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new GetJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IGetJobRequest): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new GetJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,13 +116,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,13 +169,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,13 +266,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,13 +319,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a GetJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a GetJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this GetJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this GetJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +386,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a GetJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.GetJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a GetJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,13 +439,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a GetJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a GetJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new HttpTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IHttpTarget);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new HttpTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_authorizationHeader_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#authorizationHeader:member">authorizationHeader</h4>
-  <div class="markdown level1 summary"><p>HttpTarget authorizationHeader.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public authorizationHeader?: (&quot;oauthToken&quot;|&quot;oidcToken&quot;);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget authorizationHeader.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#body:member">body</h4>
-  <div class="markdown level1 summary"><p>HttpTarget body.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget body.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#headers:member">headers</h4>
-  <div class="markdown level1 summary"><p>HttpTarget headers.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget headers.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,13 +114,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#httpMethod:member">httpMethod</h4>
-  <div class="markdown level1 summary"><p>HttpTarget httpMethod.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget httpMethod.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,13 +136,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oauthToken:member">oauthToken</h4>
-  <div class="markdown level1 summary"><p>HttpTarget oauthToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget oauthToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,13 +158,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oidcToken:member">oidcToken</h4>
-  <div class="markdown level1 summary"><p>HttpTarget oidcToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget oidcToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -187,13 +180,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#uri:member">uri</h4>
-  <div class="markdown level1 summary"><p>HttpTarget uri.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public uri: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget uri.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,13 +204,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new HttpTarget instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IHttpTarget): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new HttpTarget instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,13 +248,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,13 +301,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -356,13 +345,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,13 +398,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,13 +451,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a HttpTarget message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a HttpTarget message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,13 +495,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this HttpTarget to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this HttpTarget to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,13 +518,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a HttpTarget message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.HttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a HttpTarget message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,13 +571,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a HttpTarget message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a HttpTarget message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#appEngineRouting:member">appEngineRouting</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#body:member">body</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget body</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget body</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#headers:member">headers</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget headers</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget headers</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +84,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#httpMethod:member">httpMethod</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +106,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#relativeUri:member">relativeUri</h4>
-  <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">relativeUri?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#host:member">host</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting host</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">host?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting host</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#instance:member">instance</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting instance</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">instance?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting instance</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#service:member">service</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting service</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">service?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting service</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +84,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#version:member">version</h4>
-  <div class="markdown level1 summary"><p>AppEngineRouting version</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">version?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>AppEngineRouting version</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#job:member">job</h4>
-  <div class="markdown level1 summary"><p>CreateJobRequest job</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>CreateJobRequest job</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#parent:member">parent</h4>
-  <div class="markdown level1 summary"><p>CreateJobRequest parent</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>CreateJobRequest parent</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IDeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IDeleteJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>DeleteJobRequest name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>DeleteJobRequest name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IGetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IGetJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>GetJobRequest name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>GetJobRequest name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#body:member">body</h4>
-  <div class="markdown level1 summary"><p>HttpTarget body</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget body</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#headers:member">headers</h4>
-  <div class="markdown level1 summary"><p>HttpTarget headers</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget headers</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#httpMethod:member">httpMethod</h4>
-  <div class="markdown level1 summary"><p>HttpTarget httpMethod</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget httpMethod</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +84,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oauthToken:member">oauthToken</h4>
-  <div class="markdown level1 summary"><p>HttpTarget oauthToken</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget oauthToken</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +106,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oidcToken:member">oidcToken</h4>
-  <div class="markdown level1 summary"><p>HttpTarget oidcToken</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget oidcToken</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,13 +128,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#uri:member">uri</h4>
-  <div class="markdown level1 summary"><p>HttpTarget uri</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">uri?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>HttpTarget uri</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#appEngineHttpTarget:member">appEngineHttpTarget</h4>
-  <div class="markdown level1 summary"><p>Job appEngineHttpTarget</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job appEngineHttpTarget</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#attemptDeadline:member">attemptDeadline</h4>
-  <div class="markdown level1 summary"><p>Job attemptDeadline</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job attemptDeadline</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#description:member">description</h4>
-  <div class="markdown level1 summary"><p>Job description</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">description?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job description</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +84,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#httpTarget:member">httpTarget</h4>
-  <div class="markdown level1 summary"><p>Job httpTarget</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job httpTarget</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +106,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#lastAttemptTime:member">lastAttemptTime</h4>
-  <div class="markdown level1 summary"><p>Job lastAttemptTime</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job lastAttemptTime</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,13 +128,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#name:member">name</h4>
-  <div class="markdown level1 summary"><p>Job name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -156,13 +150,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#pubsubTarget:member">pubsubTarget</h4>
-  <div class="markdown level1 summary"><p>Job pubsubTarget</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job pubsubTarget</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,13 +172,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#retryConfig:member">retryConfig</h4>
-  <div class="markdown level1 summary"><p>Job retryConfig</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job retryConfig</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,13 +194,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#schedule:member">schedule</h4>
-  <div class="markdown level1 summary"><p>Job schedule</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">schedule?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job schedule</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,13 +216,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#scheduleTime:member">scheduleTime</h4>
-  <div class="markdown level1 summary"><p>Job scheduleTime</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job scheduleTime</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,13 +238,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#state:member">state</h4>
-  <div class="markdown level1 summary"><p>Job state</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">state?: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job state</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,13 +260,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#status:member">status</h4>
-  <div class="markdown level1 summary"><p>Job status</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">status?: (google.rpc.IStatus|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job status</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -294,13 +282,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#timeZone:member">timeZone</h4>
-  <div class="markdown level1 summary"><p>Job timeZone</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">timeZone?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job timeZone</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,13 +304,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#userUpdateTime:member">userUpdateTime</h4>
-  <div class="markdown level1 summary"><p>Job userUpdateTime</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job userUpdateTime</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageSize:member">pageSize</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest pageSize</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageSize?: (number|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest pageSize</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageToken:member">pageToken</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest pageToken</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageToken?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest pageToken</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#parent:member">parent</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest parent</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest parent</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#jobs:member">jobs</h4>
-  <div class="markdown level1 summary"><p>ListJobsResponse jobs</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">jobs?: (google.cloud.scheduler.v1.IJob[]|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsResponse jobs</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#nextPageToken:member">nextPageToken</h4>
-  <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">nextPageToken?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#scope:member">scope</h4>
-  <div class="markdown level1 summary"><p>OAuthToken scope</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">scope?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OAuthToken scope</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#serviceAccountEmail:member">serviceAccountEmail</h4>
-  <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#audience:member">audience</h4>
-  <div class="markdown level1 summary"><p>OidcToken audience</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">audience?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OidcToken audience</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#serviceAccountEmail:member">serviceAccountEmail</h4>
-  <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPauseJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>PauseJobRequest name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PauseJobRequest name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#attributes:member">attributes</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget attributes</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">attributes?: ({ [k: string]: string }|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget attributes</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#data:member">data</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget data</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">data?: (Uint8Array|string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget data</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#topicName:member">topicName</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget topicName</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">topicName?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget topicName</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IResumeJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>ResumeJobRequest name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ResumeJobRequest name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxBackoffDuration:member">maxBackoffDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxDoublings:member">maxDoublings</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxDoublings</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxDoublings?: (number|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxDoublings</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,13 +62,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxRetryDuration:member">maxRetryDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,13 +84,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#minBackoffDuration:member">minBackoffDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,13 +106,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#retryCount:member">retryCount</h4>
-  <div class="markdown level1 summary"><p>RetryConfig retryCount</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryCount?: (number|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig retryCount</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRunJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>RunJobRequest name</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RunJobRequest name</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#job:member">job</h4>
-  <div class="markdown level1 summary"><p>UpdateJobRequest job</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>UpdateJobRequest job</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,13 +40,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#updateMask:member">updateMask</h4>
-  <div class="markdown level1 summary"><p>UpdateJobRequest updateMask</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>UpdateJobRequest updateMask</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new Job.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IJob);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new Job.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#appEngineHttpTarget:member">appEngineHttpTarget</h4>
-  <div class="markdown level1 summary"><p>Job appEngineHttpTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job appEngineHttpTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#attemptDeadline:member">attemptDeadline</h4>
-  <div class="markdown level1 summary"><p>Job attemptDeadline.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job attemptDeadline.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#description:member">description</h4>
-  <div class="markdown level1 summary"><p>Job description.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public description: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job description.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,13 +114,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#httpTarget:member">httpTarget</h4>
-  <div class="markdown level1 summary"><p>Job httpTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job httpTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,13 +136,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#lastAttemptTime:member">lastAttemptTime</h4>
-  <div class="markdown level1 summary"><p>Job lastAttemptTime.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job lastAttemptTime.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,13 +158,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#name:member">name</h4>
-  <div class="markdown level1 summary"><p>Job name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -187,13 +180,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#pubsubTarget:member">pubsubTarget</h4>
-  <div class="markdown level1 summary"><p>Job pubsubTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job pubsubTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -210,13 +202,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#retryConfig:member">retryConfig</h4>
-  <div class="markdown level1 summary"><p>Job retryConfig.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job retryConfig.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,13 +224,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#schedule:member">schedule</h4>
-  <div class="markdown level1 summary"><p>Job schedule.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public schedule: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job schedule.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,13 +246,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#scheduleTime:member">scheduleTime</h4>
-  <div class="markdown level1 summary"><p>Job scheduleTime.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job scheduleTime.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -279,13 +268,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#state:member">state</h4>
-  <div class="markdown level1 summary"><p>Job state.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public state: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job state.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,13 +290,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#status:member">status</h4>
-  <div class="markdown level1 summary"><p>Job status.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public status?: (google.rpc.IStatus|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job status.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,13 +312,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_target_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#target:member">target</h4>
-  <div class="markdown level1 summary"><p>Job target.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public target?: (&quot;pubsubTarget&quot;|&quot;appEngineHttpTarget&quot;|&quot;httpTarget&quot;);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job target.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,13 +334,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#timeZone:member">timeZone</h4>
-  <div class="markdown level1 summary"><p>Job timeZone.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public timeZone: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job timeZone.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +356,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#userUpdateTime:member">userUpdateTime</h4>
-  <div class="markdown level1 summary"><p>Job userUpdateTime.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Job userUpdateTime.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,13 +380,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new Job instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IJob): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new Job instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,13 +424,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,13 +477,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,13 +521,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified Job message. Does not implicitly  messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified Job message. Does not implicitly  messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,13 +574,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified Job message, length delimited. Does not implicitly  messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified Job message, length delimited. Does not implicitly  messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,13 +627,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a Job message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a Job message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,13 +671,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this Job to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this Job to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,13 +694,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a Job message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.Job, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a Job message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -771,13 +747,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a Job message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a Job message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new ListJobsRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new ListJobsRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageSize:member">pageSize</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest pageSize.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageSize: number;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest pageSize.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageToken:member">pageToken</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest pageToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageToken: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest pageToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#parent:member">parent</h4>
-  <div class="markdown level1 summary"><p>ListJobsRequest parent.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsRequest parent.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,13 +116,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new ListJobsRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsRequest): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new ListJobsRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,13 +160,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,13 +257,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,13 +310,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a ListJobsRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a ListJobsRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,13 +407,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this ListJobsRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this ListJobsRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,13 +430,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,13 +483,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a ListJobsRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a ListJobsRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new ListJobsResponse.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsResponse);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new ListJobsResponse.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#jobs:member">jobs</h4>
-  <div class="markdown level1 summary"><p>ListJobsResponse jobs.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public jobs: google.cloud.scheduler.v1.IJob[];</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsResponse jobs.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#nextPageToken:member">nextPageToken</h4>
-  <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public nextPageToken: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,13 +94,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new ListJobsResponse instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsResponse): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new ListJobsResponse instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,13 +191,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,13 +288,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,13 +341,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a ListJobsResponse message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a ListJobsResponse message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this ListJobsResponse to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this ListJobsResponse to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +408,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsResponse message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsResponse message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,13 +461,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a ListJobsResponse message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a ListJobsResponse message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new OAuthToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOAuthToken);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new OAuthToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#scope:member">scope</h4>
-  <div class="markdown level1 summary"><p>OAuthToken scope.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scope: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OAuthToken scope.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#serviceAccountEmail:member">serviceAccountEmail</h4>
-  <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,13 +94,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new OAuthToken instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOAuthToken): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new OAuthToken instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,13 +191,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,13 +288,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,13 +341,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a OAuthToken message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a OAuthToken message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this OAuthToken to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this OAuthToken to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +408,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a OAuthToken message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OAuthToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a OAuthToken message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,13 +461,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a OAuthToken message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a OAuthToken message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new OidcToken.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOidcToken);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new OidcToken.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#audience:member">audience</h4>
-  <div class="markdown level1 summary"><p>OidcToken audience.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public audience: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OidcToken audience.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#serviceAccountEmail:member">serviceAccountEmail</h4>
-  <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,13 +94,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new OidcToken instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOidcToken): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new OidcToken instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,13 +191,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified OidcToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified OidcToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,13 +288,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified OidcToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified OidcToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,13 +341,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates an OidcToken message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates an OidcToken message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this OidcToken to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this OidcToken to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +408,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from an OidcToken message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OidcToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from an OidcToken message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,13 +461,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies an OidcToken message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies an OidcToken message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new PauseJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPauseJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new PauseJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>PauseJobRequest name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PauseJobRequest name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,13 +72,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new PauseJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPauseJobRequest): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new PauseJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,13 +116,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,13 +169,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,13 +266,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,13 +319,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a PauseJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a PauseJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this PauseJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this PauseJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +386,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a PauseJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PauseJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a PauseJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,13 +439,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a PauseJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a PauseJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new PubsubTarget.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPubsubTarget);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new PubsubTarget.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#attributes:member">attributes</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget attributes.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attributes: { [k: string]: string };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget attributes.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#data:member">data</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget data.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public data: (Uint8Array|string);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget data.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#topicName:member">topicName</h4>
-  <div class="markdown level1 summary"><p>PubsubTarget topicName.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public topicName: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>PubsubTarget topicName.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,13 +116,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new PubsubTarget instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPubsubTarget): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new PubsubTarget instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,13 +160,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,13 +257,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,13 +310,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a PubsubTarget message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a PubsubTarget message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,13 +407,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this PubsubTarget to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this PubsubTarget to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,13 +430,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a PubsubTarget message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PubsubTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a PubsubTarget message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,13 +483,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a PubsubTarget message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a PubsubTarget message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new ResumeJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IResumeJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new ResumeJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>ResumeJobRequest name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>ResumeJobRequest name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,13 +72,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new ResumeJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IResumeJobRequest): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new ResumeJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,13 +116,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,13 +169,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,13 +266,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,13 +319,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a ResumeJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a ResumeJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this ResumeJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this ResumeJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +386,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a ResumeJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ResumeJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a ResumeJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,13 +439,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a ResumeJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a ResumeJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new RetryConfig.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRetryConfig);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new RetryConfig.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxBackoffDuration:member">maxBackoffDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxDoublings:member">maxDoublings</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxDoublings.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxDoublings: number;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxDoublings.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,13 +92,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxRetryDuration:member">maxRetryDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,13 +114,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#minBackoffDuration:member">minBackoffDuration</h4>
-  <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,13 +136,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#retryCount:member">retryCount</h4>
-  <div class="markdown level1 summary"><p>RetryConfig retryCount.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryCount: number;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RetryConfig retryCount.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,13 +160,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new RetryConfig instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRetryConfig): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new RetryConfig instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -211,13 +204,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -265,13 +257,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -310,13 +301,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,13 +354,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +407,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a RetryConfig message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a RetryConfig message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,13 +451,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this RetryConfig to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this RetryConfig to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,13 +474,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a RetryConfig message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RetryConfig, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a RetryConfig message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,13 +527,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a RetryConfig message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a RetryConfig message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new RunJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRunJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new RunJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#name:member">name</h4>
-  <div class="markdown level1 summary"><p>RunJobRequest name.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>RunJobRequest name.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,13 +72,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new RunJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRunJobRequest): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new RunJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,13 +116,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,13 +169,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,13 +213,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,13 +266,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,13 +319,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates a RunJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a RunJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,13 +363,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this RunJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this RunJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,13 +386,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from a RunJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RunJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from a RunJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,13 +439,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies a RunJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies a RunJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
@@ -18,13 +18,12 @@
   <h3 id="constructors">Constructors
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest:constructor(1)">(constructor)(properties)</h4>
-  <div class="markdown level1 summary"><p>Constructs a new UpdateJobRequest.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IUpdateJobRequest);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Constructs a new UpdateJobRequest.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -49,13 +48,12 @@
   <h3 id="properties">Properties
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#job:member">job</h4>
-  <div class="markdown level1 summary"><p>UpdateJobRequest job.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>UpdateJobRequest job.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,13 +70,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#updateMask:member">updateMask</h4>
-  <div class="markdown level1 summary"><p>UpdateJobRequest updateMask.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>UpdateJobRequest updateMask.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="propertyValue">Property Value</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,13 +94,12 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.create:member(1)">create(properties)</h4>
-  <div class="markdown level1 summary"><p>Creates a new UpdateJobRequest instance using the specified properties.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IUpdateJobRequest): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a new UpdateJobRequest instance using the specified properties.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,13 +138,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decode:member(1)">decode(reader, length)</h4>
-  <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,13 +191,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
-  <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer, length delimited.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer, length delimited.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,13 +235,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encode:member(1)">encode(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,13 +288,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
-  <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,13 +341,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.fromObject:member(1)">fromObject(object)</h4>
-  <div class="markdown level1 summary"><p>Creates an UpdateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates an UpdateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,13 +385,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#toJSON:member(1)">toJSON()</h4>
-  <div class="markdown level1 summary"><p>Converts this UpdateJobRequest to JSON.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Converts this UpdateJobRequest to JSON.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="returns">Returns</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,13 +408,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.toObject:member(1)">toObject(message, options)</h4>
-  <div class="markdown level1 summary"><p>Creates a plain object from an UpdateJobRequest message. Also converts values to other types if specified.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.UpdateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Creates a plain object from an UpdateJobRequest message. Also converts values to other types if specified.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,13 +461,12 @@
     </tbody>
   </table>
   <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.verify:member(1)">verify(message)</h4>
-  <div class="markdown level1 summary"><p>Verifies an UpdateJobRequest message.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Verifies an UpdateJobRequest message.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -23,14 +23,13 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,14 +87,13 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,13 +151,12 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.list_voices">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
-  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,14 +247,13 @@ method.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
@@ -23,14 +23,13 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,14 +87,13 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,13 +151,12 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.list_voices">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
-  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,14 +247,13 @@ method.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -23,14 +23,13 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,14 +87,13 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,13 +151,12 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.list_voices">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
-  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,14 +247,13 @@ method.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
@@ -23,14 +23,13 @@
   <h3 id="methods">Methods
   </h3>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,14 +87,13 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,13 +151,12 @@ file.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.list_voices">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
-  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
-</div>
-  <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
+  <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
+</div>
+  <div class="markdown level1 conceptual"></div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,14 +247,13 @@ method.</p>
     </tbody>
   </table>
   <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <div class="codewrapper">
+    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
+  </div>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
   <div class="markdown level1 conceptual"></div>
-  <h5 class="decalaration">Declaration</h5>
-  <div class="codewrapper">
-    <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
-  </div>
   <h5 class="parameters">Parameters</h5>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -19,13 +19,14 @@
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
 <h3 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h3>
-<div class="markdown level1 summary">{{{summary}}}</div>
-<div class="markdown level1 conceptual">{{{conceptual}}}</div>
-<h4 class="decalaration">{{__global.declaration}}</h4>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
+{{/syntax}}
+<div class="markdown level1 summary">{{{summary}}}</div>
+<div class="markdown level1 conceptual">{{{conceptual}}}</div>
+{{#syntax}}
 {{#parameters.0}}
 <h4 class="parameters">{{__global.parameters}}</h4>
 <table class="table table-bordered table-striped table-condensed">

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -19,13 +19,14 @@
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
 <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
-<div class="markdown level1 summary">{{{summary}}}</div>
-<div class="markdown level1 conceptual">{{{conceptual}}}</div>
-<h5 class="decalaration">{{__global.declaration}}</h5>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
+{{/syntax}}
+<div class="markdown level1 summary">{{{summary}}}</div>
+<div class="markdown level1 conceptual">{{{conceptual}}}</div>
+{{#syntax}}
 {{#parameters.0}}
 <h5 class="parameters">{{__global.parameters}}</h5>
 <table class="table table-bordered table-striped table-condensed">

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -34,13 +34,14 @@
       <a id="{{id}}" data-uid="{{uid}}"></a>
       {{/overload}}
       <h3 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h3>
-      <div class="markdown level1 summary">{{{summary}}}</div>
-      <div class="markdown level1 conceptual">{{{conceptual}}}</div>
       {{#syntax}}
-      <h5 class="decalaration">{{__global.declaration}}</h5>
       <div class="codewrapper">
         <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>
       </div>
+      {{/syntax}}
+      <div class="markdown level1 summary">{{{summary}}}</div>
+      <div class="markdown level1 conceptual">{{{conceptual}}}</div>
+      {{#syntax}}
       {{#parameters.0}}
       <h5 class="parameters">{{__global.parameters}}</h5>
       <table class="table table-bordered table-striped table-condensed">
@@ -218,14 +219,13 @@
         {{! Note: don't print the Functions/Methods headers for children of children.}}
         {{#children}}
           <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
-          <div class="markdown level1 summary">{{{summary}}}</div>
-          <div class="markdown level1 conceptual">{{{conceptual}}}</div>
           {{#syntax}}
-          <h5 class="decalaration">{{__global.declaration}}</h5>
           <div class="codewrapper">	
             <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>	
           </div>
           {{/syntax}}
+          <div class="markdown level1 summary">{{{summary}}}</div>
+          <div class="markdown level1 conceptual">{{{conceptual}}}</div>
           {{>partials/uref/namespace.examples}}  
         {{/children}}
       {{/children}}


### PR DESCRIPTION
Moving declaration content up, getting rid of declaration headers.

Some (most) declaration snippet is only accessible when there is a syntax, and the summary/conceptual content does not depend on it, so I had to escape them out of the syntax block within the template.

Fixes #136