### PR TITLE
fix: Mark headings as translate="no"

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor">AnalyzeIamPolicyRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor" translate="no">AnalyzeIamPolicyRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)" translate="no">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery" translate="no">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout">ExecutionTimeout</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout" translate="no">ExecutionTimeout</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration ExecutionTimeout { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor" translate="no">AnalyzeIamPolicyRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor" class="notranslate">AnalyzeIamPolicyRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)" translate="no">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)" class="notranslate">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery" translate="no">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.AnalysisQuery" class="notranslate">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout" translate="no">ExecutionTimeout</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_ExecutionTimeout" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.ExecutionTimeout" class="notranslate">ExecutionTimeout</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration ExecutionTimeout { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -62,14 +62,14 @@ unmatched_node_count(implicit)</li>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor">Stats()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor" translate="no">Stats()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)" translate="no">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats other)</code></pre>
   </div>
@@ -95,7 +95,7 @@ unmatched_node_count(implicit)</li>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount">CappedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount" translate="no">CappedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int CappedNodeCount { get; set; }</code></pre>
   </div>
@@ -119,7 +119,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount">DiscoveredNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount" translate="no">DiscoveredNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int DiscoveredNodeCount { get; set; }</code></pre>
   </div>
@@ -142,7 +142,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount">ExecutionTimeoutNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount" translate="no">ExecutionTimeoutNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExecutionTimeoutNodeCount { get; set; }</code></pre>
   </div>
@@ -165,7 +165,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount">ExploredNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount" translate="no">ExploredNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExploredNodeCount { get; set; }</code></pre>
   </div>
@@ -188,7 +188,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount">MatchedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount" translate="no">MatchedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MatchedNodeCount { get; set; }</code></pre>
   </div>
@@ -212,7 +212,7 @@ of discovered nodes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype">NodeSubtype</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype" translate="no">NodeSubtype</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NodeSubtype { get; set; }</code></pre>
   </div>
@@ -241,7 +241,7 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType">NodeType</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType" translate="no">NodeType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType NodeType { get; set; }</code></pre>
   </div>
@@ -264,7 +264,7 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount">PermisionDeniedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount" translate="no">PermisionDeniedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PermisionDeniedNodeCount { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -62,14 +62,14 @@ unmatched_node_count(implicit)</li>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor" translate="no">Stats()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor" class="notranslate">Stats()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)" translate="no">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)" class="notranslate">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats other)</code></pre>
   </div>
@@ -95,7 +95,7 @@ unmatched_node_count(implicit)</li>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount" translate="no">CappedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_CappedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.CappedNodeCount" class="notranslate">CappedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int CappedNodeCount { get; set; }</code></pre>
   </div>
@@ -119,7 +119,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount" translate="no">DiscoveredNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_DiscoveredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.DiscoveredNodeCount" class="notranslate">DiscoveredNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int DiscoveredNodeCount { get; set; }</code></pre>
   </div>
@@ -142,7 +142,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount" translate="no">ExecutionTimeoutNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExecutionTimeoutNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExecutionTimeoutNodeCount" class="notranslate">ExecutionTimeoutNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExecutionTimeoutNodeCount { get; set; }</code></pre>
   </div>
@@ -165,7 +165,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount" translate="no">ExploredNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_ExploredNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.ExploredNodeCount" class="notranslate">ExploredNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int ExploredNodeCount { get; set; }</code></pre>
   </div>
@@ -188,7 +188,7 @@ setting.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount" translate="no">MatchedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_MatchedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.MatchedNodeCount" class="notranslate">MatchedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MatchedNodeCount { get; set; }</code></pre>
   </div>
@@ -212,7 +212,7 @@ of discovered nodes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype" translate="no">NodeSubtype</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeSubtype" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeSubtype" class="notranslate">NodeSubtype</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NodeSubtype { get; set; }</code></pre>
   </div>
@@ -241,7 +241,7 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType" translate="no">NodeType</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_NodeType" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.NodeType" class="notranslate">NodeType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType NodeType { get; set; }</code></pre>
   </div>
@@ -264,7 +264,7 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount" translate="no">PermisionDeniedNodeCount</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_PermisionDeniedNodeCount" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.PermisionDeniedNodeCount" class="notranslate">PermisionDeniedNodeCount</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PermisionDeniedNodeCount { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor" translate="no">IamPolicyAnalysis()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor" class="notranslate">IamPolicyAnalysis()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)" translate="no">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)" class="notranslate">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery" translate="no">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery" class="notranslate">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults" translate="no">AnalysisResults</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults" class="notranslate">AnalysisResults</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult&gt; AnalysisResults { get; }</code></pre>
   </div>
@@ -130,7 +130,7 @@ that matches the analysis query, or empty if no result is found.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored" translate="no">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored" class="notranslate">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -155,7 +155,7 @@ the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors" translate="no">NonCriticalErrors</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors" class="notranslate">NonCriticalErrors</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisState&gt; NonCriticalErrors { get; }</code></pre>
   </div>
@@ -178,7 +178,7 @@ the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats" translate="no">Stats</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats" class="notranslate">Stats</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats&gt; Stats { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor">IamPolicyAnalysis()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor" translate="no">IamPolicyAnalysis()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)" translate="no">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisQuery" translate="no">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults">AnalysisResults</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_AnalysisResults" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.AnalysisResults" translate="no">AnalysisResults</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult&gt; AnalysisResults { get; }</code></pre>
   </div>
@@ -130,7 +130,7 @@ that matches the analysis query, or empty if no result is found.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.FullyExplored" translate="no">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -155,7 +155,7 @@ the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors">NonCriticalErrors</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_NonCriticalErrors" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.NonCriticalErrors" translate="no">NonCriticalErrors</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisState&gt; NonCriticalErrors { get; }</code></pre>
   </div>
@@ -178,7 +178,7 @@ the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats">Stats</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Stats" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Stats" translate="no">Stats</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats&gt; Stats { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor">AnalyzeIamPolicyResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor" translate="no">AnalyzeIamPolicyResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)" translate="no">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored" translate="no">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ answer the query in the request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis">MainAnalysis</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis" translate="no">MainAnalysis</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis MainAnalysis { get; set; }</code></pre>
   </div>
@@ -132,7 +132,7 @@ answer the query in the request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis">ServiceAccountImpersonationAnalysis</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis" translate="no">ServiceAccountImpersonationAnalysis</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis&gt; ServiceAccountImpersonationAnalysis { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor" translate="no">AnalyzeIamPolicyResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor" class="notranslate">AnalyzeIamPolicyResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)" translate="no">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)" class="notranslate">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored" translate="no">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_FullyExplored" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.FullyExplored" class="notranslate">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ answer the query in the request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis" translate="no">MainAnalysis</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_MainAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.MainAnalysis" class="notranslate">MainAnalysis</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis MainAnalysis { get; set; }</code></pre>
   </div>
@@ -132,7 +132,7 @@ answer the query in the request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis" translate="no">ServiceAccountImpersonationAnalysis</h3>
+  <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_ServiceAccountImpersonationAnalysis" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.ServiceAccountImpersonationAnalysis" class="notranslate">ServiceAccountImpersonationAnalysis</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis&gt; ServiceAccountImpersonationAnalysis { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -57,14 +57,14 @@ for more information.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset__ctor" data-uid="Google.Cloud.Asset.V1.Asset.#ctor">Asset()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset__ctor" data-uid="Google.Cloud.Asset.V1.Asset.#ctor" translate="no">Asset()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)">Asset(Asset)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)" translate="no">Asset(Asset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset(Asset other)</code></pre>
   </div>
@@ -90,7 +90,7 @@ for more information.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase_" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase">AccessContextPolicyCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase" translate="no">AccessContextPolicyCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset.AccessContextPolicyOneofCase AccessContextPolicyCase { get; }</code></pre>
   </div>
@@ -112,7 +112,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessLevel_" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessLevel" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel">AccessLevel</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessLevel" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel" translate="no">AccessLevel</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessLevel AccessLevel { get; set; }</code></pre>
   </div>
@@ -136,7 +136,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessPolicy" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy">AccessPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessPolicy" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy" translate="no">AccessPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessPolicy AccessPolicy { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Ancestors_" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Ancestors" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors">Ancestors</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Ancestors" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors" translate="no">Ancestors</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Ancestors { get; }</code></pre>
   </div>
@@ -189,7 +189,7 @@ asset itself.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AssetType_" data-uid="Google.Cloud.Asset.V1.Asset.AssetType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AssetType" data-uid="Google.Cloud.Asset.V1.Asset.AssetType">AssetType</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AssetType" data-uid="Google.Cloud.Asset.V1.Asset.AssetType" translate="no">AssetType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
@@ -215,7 +215,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_IamPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_IamPolicy" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy">IamPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_IamPolicy" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy" translate="no">IamPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy IamPolicy { get; set; }</code></pre>
   </div>
@@ -246,7 +246,7 @@ more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Name_" data-uid="Google.Cloud.Asset.V1.Asset.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Name" data-uid="Google.Cloud.Asset.V1.Asset.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Name" data-uid="Google.Cloud.Asset.V1.Asset.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
@@ -273,7 +273,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_OrgPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_OrgPolicy" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy">OrgPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_OrgPolicy" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy" translate="no">OrgPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Policy&gt; OrgPolicy { get; }</code></pre>
   </div>
@@ -299,7 +299,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Resource_" data-uid="Google.Cloud.Asset.V1.Asset.Resource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Resource" data-uid="Google.Cloud.Asset.V1.Asset.Resource">Resource</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Resource" data-uid="Google.Cloud.Asset.V1.Asset.Resource" translate="no">Resource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource Resource { get; set; }</code></pre>
   </div>
@@ -322,7 +322,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ResourceName_" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_ResourceName" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName">ResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_ResourceName" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName" translate="no">ResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ResourceName { get; set; }</code></pre>
   </div>
@@ -345,7 +345,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ServicePerimeter_" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_ServicePerimeter" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter">ServicePerimeter</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_ServicePerimeter" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter" translate="no">ServicePerimeter</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServicePerimeter ServicePerimeter { get; set; }</code></pre>
   </div>
@@ -369,7 +369,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_UpdateTime_" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_UpdateTime" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime">UpdateTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_UpdateTime" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime" translate="no">UpdateTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -57,14 +57,14 @@ for more information.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset__ctor" data-uid="Google.Cloud.Asset.V1.Asset.#ctor" translate="no">Asset()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset__ctor" data-uid="Google.Cloud.Asset.V1.Asset.#ctor" class="notranslate">Asset()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)" translate="no">Asset(Asset)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)" class="notranslate">Asset(Asset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset(Asset other)</code></pre>
   </div>
@@ -90,7 +90,7 @@ for more information.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase_" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase" translate="no">AccessContextPolicyCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyCase" data-uid="Google.Cloud.Asset.V1.Asset.AccessContextPolicyCase" class="notranslate">AccessContextPolicyCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset.AccessContextPolicyOneofCase AccessContextPolicyCase { get; }</code></pre>
   </div>
@@ -112,7 +112,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessLevel_" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessLevel" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel" translate="no">AccessLevel</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessLevel" data-uid="Google.Cloud.Asset.V1.Asset.AccessLevel" class="notranslate">AccessLevel</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessLevel AccessLevel { get; set; }</code></pre>
   </div>
@@ -136,7 +136,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AccessPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AccessPolicy" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy" translate="no">AccessPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AccessPolicy" data-uid="Google.Cloud.Asset.V1.Asset.AccessPolicy" class="notranslate">AccessPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessPolicy AccessPolicy { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Ancestors_" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Ancestors" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors" translate="no">Ancestors</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Ancestors" data-uid="Google.Cloud.Asset.V1.Asset.Ancestors" class="notranslate">Ancestors</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Ancestors { get; }</code></pre>
   </div>
@@ -189,7 +189,7 @@ asset itself.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_AssetType_" data-uid="Google.Cloud.Asset.V1.Asset.AssetType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_AssetType" data-uid="Google.Cloud.Asset.V1.Asset.AssetType" translate="no">AssetType</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_AssetType" data-uid="Google.Cloud.Asset.V1.Asset.AssetType" class="notranslate">AssetType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
@@ -215,7 +215,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_IamPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_IamPolicy" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy" translate="no">IamPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_IamPolicy" data-uid="Google.Cloud.Asset.V1.Asset.IamPolicy" class="notranslate">IamPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy IamPolicy { get; set; }</code></pre>
   </div>
@@ -246,7 +246,7 @@ more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Name_" data-uid="Google.Cloud.Asset.V1.Asset.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Name" data-uid="Google.Cloud.Asset.V1.Asset.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Name" data-uid="Google.Cloud.Asset.V1.Asset.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
@@ -273,7 +273,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_OrgPolicy_" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_OrgPolicy" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy" translate="no">OrgPolicy</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_OrgPolicy" data-uid="Google.Cloud.Asset.V1.Asset.OrgPolicy" class="notranslate">OrgPolicy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Policy&gt; OrgPolicy { get; }</code></pre>
   </div>
@@ -299,7 +299,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_Resource_" data-uid="Google.Cloud.Asset.V1.Asset.Resource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_Resource" data-uid="Google.Cloud.Asset.V1.Asset.Resource" translate="no">Resource</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_Resource" data-uid="Google.Cloud.Asset.V1.Asset.Resource" class="notranslate">Resource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource Resource { get; set; }</code></pre>
   </div>
@@ -322,7 +322,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ResourceName_" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_ResourceName" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName" translate="no">ResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_ResourceName" data-uid="Google.Cloud.Asset.V1.Asset.ResourceName" class="notranslate">ResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ResourceName { get; set; }</code></pre>
   </div>
@@ -345,7 +345,7 @@ set on a given resource.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_ServicePerimeter_" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_ServicePerimeter" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter" translate="no">ServicePerimeter</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_ServicePerimeter" data-uid="Google.Cloud.Asset.V1.Asset.ServicePerimeter" class="notranslate">ServicePerimeter</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServicePerimeter ServicePerimeter { get; set; }</code></pre>
   </div>
@@ -369,7 +369,7 @@ guide</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Asset_UpdateTime_" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Asset_UpdateTime" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime" translate="no">UpdateTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_Asset_UpdateTime" data-uid="Google.Cloud.Asset.V1.Asset.UpdateTime" class="notranslate">UpdateTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -44,7 +44,7 @@ public abstract class AssetServiceBase</code></pre>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.ServerCallContext)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.ServerCallContext)" class="notranslate">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -93,7 +93,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.ServerCallContext)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.ServerCallContext)" class="notranslate">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -147,7 +147,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.ServerCallContext)" translate="no">CreateFeed(CreateFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.ServerCallContext)" class="notranslate">CreateFeed(CreateFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeed(CreateFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -196,7 +196,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.ServerCallContext)" translate="no">DeleteFeed(DeleteFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.ServerCallContext)" class="notranslate">DeleteFeed(DeleteFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Empty&gt; DeleteFeed(DeleteFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -244,7 +244,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.ServerCallContext)" translate="no">ExportAssets(ExportAssetsRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.ServerCallContext)" class="notranslate">ExportAssets(ExportAssetsRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportAssets(ExportAssetsRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -301,7 +301,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.ServerCallContext)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.ServerCallContext)" class="notranslate">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -357,7 +357,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.ServerCallContext)" translate="no">GetFeed(GetFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.ServerCallContext)" class="notranslate">GetFeed(GetFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeed(GetFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -405,7 +405,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.ServerCallContext)" translate="no">ListFeeds(ListFeedsRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.ServerCallContext)" class="notranslate">ListFeeds(ListFeedsRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeeds(ListFeedsRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -453,7 +453,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.ServerCallContext)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.ServerCallContext)" class="notranslate">SearchAllIamPolicies(SearchAllIamPoliciesRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -504,7 +504,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.ServerCallContext)" translate="no">SearchAllResources(SearchAllResourcesRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.ServerCallContext)" class="notranslate">SearchAllResources(SearchAllResourcesRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllResourcesResponse&gt; SearchAllResources(SearchAllResourcesRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -555,7 +555,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.ServerCallContext)" translate="no">UpdateFeed(UpdateFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.ServerCallContext)" class="notranslate">UpdateFeed(UpdateFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeed(UpdateFeedRequest request, ServerCallContext context)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -44,7 +44,7 @@ public abstract class AssetServiceBase</code></pre>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.ServerCallContext)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.ServerCallContext)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -93,7 +93,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.ServerCallContext)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.ServerCallContext)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -147,7 +147,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.ServerCallContext)">CreateFeed(CreateFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.ServerCallContext)" translate="no">CreateFeed(CreateFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeed(CreateFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -196,7 +196,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.ServerCallContext)">DeleteFeed(DeleteFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.ServerCallContext)" translate="no">DeleteFeed(DeleteFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Empty&gt; DeleteFeed(DeleteFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -244,7 +244,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.ServerCallContext)">ExportAssets(ExportAssetsRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.ServerCallContext)" translate="no">ExportAssets(ExportAssetsRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportAssets(ExportAssetsRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -301,7 +301,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.ServerCallContext)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.ServerCallContext)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -357,7 +357,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.ServerCallContext)">GetFeed(GetFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.ServerCallContext)" translate="no">GetFeed(GetFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeed(GetFeedRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -405,7 +405,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.ServerCallContext)">ListFeeds(ListFeedsRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.ServerCallContext)" translate="no">ListFeeds(ListFeedsRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeeds(ListFeedsRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -453,7 +453,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.ServerCallContext)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.ServerCallContext)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -504,7 +504,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.ServerCallContext)">SearchAllResources(SearchAllResourcesRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.ServerCallContext)" translate="no">SearchAllResources(SearchAllResourcesRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllResourcesResponse&gt; SearchAllResources(SearchAllResourcesRequest request, ServerCallContext context)</code></pre>
   </div>
@@ -555,7 +555,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.ServerCallContext)">UpdateFeed(UpdateFeedRequest, ServerCallContext)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceBase_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_ServerCallContext_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.ServerCallContext)" translate="no">UpdateFeed(UpdateFeedRequest, ServerCallContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeed(UpdateFeedRequest request, ServerCallContext context)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -51,7 +51,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor" translate="no">AssetServiceClient()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor" class="notranslate">AssetServiceClient()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient()</code></pre>
   </div>
@@ -59,7 +59,7 @@
 </div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)" translate="no">AssetServiceClient(CallInvoker)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)" class="notranslate">AssetServiceClient(CallInvoker)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(CallInvoker callInvoker)</code></pre>
   </div>
@@ -85,7 +85,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)" translate="no">AssetServiceClient(Channel)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)" class="notranslate">AssetServiceClient(Channel)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(Channel channel)</code></pre>
   </div>
@@ -111,7 +111,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)" translate="no">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)" class="notranslate">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
@@ -139,7 +139,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" class="notranslate">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
@@ -188,7 +188,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -249,7 +249,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" class="notranslate">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
@@ -298,7 +298,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -359,7 +359,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" class="notranslate">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
@@ -413,7 +413,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -479,7 +479,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" class="notranslate">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
@@ -533,7 +533,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -599,7 +599,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" translate="no">CreateFeed(CreateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" class="notranslate">CreateFeed(CreateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -648,7 +648,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">CreateFeed(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">CreateFeed(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -709,7 +709,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" translate="no">CreateFeedAsync(CreateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" class="notranslate">CreateFeedAsync(CreateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -758,7 +758,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">CreateFeedAsync(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">CreateFeedAsync(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -819,7 +819,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient" translate="no">CreateOperationsClient()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient" class="notranslate">CreateOperationsClient()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operations.OperationsClient CreateOperationsClient()</code></pre>
   </div>
@@ -844,7 +844,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" translate="no">DeleteFeed(DeleteFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" class="notranslate">DeleteFeed(DeleteFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -892,7 +892,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">DeleteFeed(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">DeleteFeed(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -952,7 +952,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1000,7 +1000,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1060,7 +1060,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" translate="no">ExportAssets(ExportAssetsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" class="notranslate">ExportAssets(ExportAssetsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1117,7 +1117,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportAssets(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ExportAssets(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1186,7 +1186,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" class="notranslate">ExportAssetsAsync(ExportAssetsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1243,7 +1243,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportAssetsAsync(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ExportAssetsAsync(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1312,7 +1312,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" class="notranslate">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
   </div>
@@ -1368,7 +1368,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1436,7 +1436,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" class="notranslate">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
   </div>
@@ -1492,7 +1492,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1560,7 +1560,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" translate="no">GetFeed(GetFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" class="notranslate">GetFeed(GetFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1608,7 +1608,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">GetFeed(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">GetFeed(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1668,7 +1668,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" translate="no">GetFeedAsync(GetFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" class="notranslate">GetFeedAsync(GetFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1716,7 +1716,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">GetFeedAsync(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">GetFeedAsync(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1776,7 +1776,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" translate="no">ListFeeds(ListFeedsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" class="notranslate">ListFeeds(ListFeedsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1824,7 +1824,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ListFeeds(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ListFeeds(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1884,7 +1884,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" translate="no">ListFeedsAsync(ListFeedsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" class="notranslate">ListFeedsAsync(ListFeedsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1932,7 +1932,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ListFeedsAsync(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">ListFeedsAsync(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1992,7 +1992,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)" translate="no">NewInstance(ClientBase.ClientBaseConfiguration)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)" class="notranslate">NewInstance(ClientBase.ClientBaseConfiguration)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override AssetService.AssetServiceClient NewInstance(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
@@ -2034,7 +2034,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Grpc.Core.ClientBase&lt;Google.Cloud.Asset.V1.AssetService.AssetServiceClient&gt;.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" class="notranslate">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2085,7 +2085,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">SearchAllIamPolicies(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2148,7 +2148,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" class="notranslate">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2199,7 +2199,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2262,7 +2262,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" class="notranslate">SearchAllResources(SearchAllResourcesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2313,7 +2313,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllResources(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">SearchAllResources(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2376,7 +2376,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" class="notranslate">SearchAllResourcesAsync(SearchAllResourcesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2427,7 +2427,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">SearchAllResourcesAsync(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2490,7 +2490,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" translate="no">UpdateFeed(UpdateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" class="notranslate">UpdateFeed(UpdateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -2538,7 +2538,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">UpdateFeed(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">UpdateFeed(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2598,7 +2598,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" class="notranslate">UpdateFeedAsync(UpdateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -2646,7 +2646,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" class="notranslate">UpdateFeedAsync(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -51,7 +51,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor">AssetServiceClient()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor" translate="no">AssetServiceClient()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient()</code></pre>
   </div>
@@ -59,7 +59,7 @@
 </div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)">AssetServiceClient(CallInvoker)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)" translate="no">AssetServiceClient(CallInvoker)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(CallInvoker callInvoker)</code></pre>
   </div>
@@ -85,7 +85,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)">AssetServiceClient(Channel)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)" translate="no">AssetServiceClient(Channel)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(Channel channel)</code></pre>
   </div>
@@ -111,7 +111,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)" translate="no">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
@@ -139,7 +139,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
@@ -188,7 +188,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -249,7 +249,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.CallOptions)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
@@ -298,7 +298,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -359,7 +359,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
@@ -413,7 +413,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -479,7 +479,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.CallOptions)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
@@ -533,7 +533,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -599,7 +599,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)">CreateFeed(CreateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" translate="no">CreateFeed(CreateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -648,7 +648,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">CreateFeed(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">CreateFeed(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -709,7 +709,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)">CreateFeedAsync(CreateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.CallOptions)" translate="no">CreateFeedAsync(CreateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -758,7 +758,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">CreateFeedAsync(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">CreateFeedAsync(CreateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -819,7 +819,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient">CreateOperationsClient()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_CreateOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.CreateOperationsClient" translate="no">CreateOperationsClient()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operations.OperationsClient CreateOperationsClient()</code></pre>
   </div>
@@ -844,7 +844,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)">DeleteFeed(DeleteFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" translate="no">DeleteFeed(DeleteFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -892,7 +892,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">DeleteFeed(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">DeleteFeed(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -952,7 +952,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)">DeleteFeedAsync(DeleteFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.CallOptions)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1000,7 +1000,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">DeleteFeedAsync(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(DeleteFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1060,7 +1060,7 @@ this client.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)">ExportAssets(ExportAssetsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" translate="no">ExportAssets(ExportAssetsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1117,7 +1117,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportAssets(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportAssets(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1186,7 +1186,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)">ExportAssetsAsync(ExportAssetsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.CallOptions)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1243,7 +1243,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportAssetsAsync(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportAssetsAsync(ExportAssetsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1312,7 +1312,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
   </div>
@@ -1368,7 +1368,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1436,7 +1436,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.CallOptions)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallOptions options)</code></pre>
   </div>
@@ -1492,7 +1492,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1560,7 +1560,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)">GetFeed(GetFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" translate="no">GetFeed(GetFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1608,7 +1608,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">GetFeed(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">GetFeed(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1668,7 +1668,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)">GetFeedAsync(GetFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.CallOptions)" translate="no">GetFeedAsync(GetFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -1716,7 +1716,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">GetFeedAsync(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">GetFeedAsync(GetFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1776,7 +1776,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)">ListFeeds(ListFeedsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" translate="no">ListFeeds(ListFeedsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1824,7 +1824,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ListFeeds(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ListFeeds(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1884,7 +1884,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)">ListFeedsAsync(ListFeedsRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.CallOptions)" translate="no">ListFeedsAsync(ListFeedsRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
@@ -1932,7 +1932,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">ListFeedsAsync(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">ListFeedsAsync(ListFeedsRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -1992,7 +1992,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)">NewInstance(ClientBase.ClientBaseConfiguration)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_NewInstance_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)" translate="no">NewInstance(ClientBase.ClientBaseConfiguration)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override AssetService.AssetServiceClient NewInstance(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
@@ -2034,7 +2034,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Grpc.Core.ClientBase&lt;Google.Cloud.Asset.V1.AssetService.AssetServiceClient&gt;.NewInstance(Grpc.Core.ClientBase.ClientBaseConfiguration)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2085,7 +2085,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2148,7 +2148,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2199,7 +2199,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2262,7 +2262,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)">SearchAllResources(SearchAllResourcesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2313,7 +2313,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllResources(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllResources(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2376,7 +2376,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.CallOptions)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
@@ -2427,7 +2427,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">SearchAllResourcesAsync(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2490,7 +2490,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)">UpdateFeed(UpdateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" translate="no">UpdateFeed(UpdateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -2538,7 +2538,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">UpdateFeed(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">UpdateFeed(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -2598,7 +2598,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)">UpdateFeedAsync(UpdateFeedRequest, CallOptions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_CallOptions_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.CallOptions)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallOptions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
@@ -2646,7 +2646,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)">UpdateFeedAsync(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Grpc_Core_Metadata_System_Nullable_System_DateTime__System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Grpc.Core.Metadata,System.Nullable{System.DateTime},System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(UpdateFeedRequest, Metadata, Nullable&lt;DateTime&gt;, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -43,7 +43,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Google.Cloud.Asset.V1.AssetService.AssetServiceBase)">BindService(AssetService.AssetServiceBase)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" translate="no">BindService(AssetService.AssetServiceBase)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServerServiceDefinition BindService(AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>
@@ -84,7 +84,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Grpc_Core_ServiceBinderBase_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Grpc.Core.ServiceBinderBase,Google.Cloud.Asset.V1.AssetService.AssetServiceBase)">BindService(ServiceBinderBase, AssetService.AssetServiceBase)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Grpc_Core_ServiceBinderBase_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Grpc.Core.ServiceBinderBase,Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" translate="no">BindService(ServiceBinderBase, AssetService.AssetServiceBase)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void BindService(ServiceBinderBase serviceBinder, AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -43,7 +43,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" translate="no">BindService(AssetService.AssetServiceBase)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" class="notranslate">BindService(AssetService.AssetServiceBase)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServerServiceDefinition BindService(AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>
@@ -84,7 +84,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_BindService_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Grpc_Core_ServiceBinderBase_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Grpc.Core.ServiceBinderBase,Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" translate="no">BindService(ServiceBinderBase, AssetService.AssetServiceBase)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetService_BindService_Grpc_Core_ServiceBinderBase_Google_Cloud_Asset_V1_AssetService_AssetServiceBase_" data-uid="Google.Cloud.Asset.V1.AssetService.BindService(Grpc.Core.ServiceBinderBase,Google.Cloud.Asset.V1.AssetService.AssetServiceBase)" class="notranslate">BindService(ServiceBinderBase, AssetService.AssetServiceBase)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void BindService(ServiceBinderBase serviceBinder, AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -47,7 +47,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint">DefaultEndpoint</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint" translate="no">DefaultEndpoint</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string DefaultEndpoint { get; }</code></pre>
   </div>
@@ -71,7 +71,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes">DefaultScopes</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes" translate="no">DefaultScopes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static IReadOnlyList&lt;string&gt; DefaultScopes { get; }</code></pre>
   </div>
@@ -98,7 +98,7 @@ of 443.</p>
 <ul><li><a href="https://www.googleapis.com/auth/cloud-platform">https://www.googleapis.com/auth/cloud-platform</a></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient">ExportAssetsOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient" translate="no">ExportAssetsOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
@@ -121,7 +121,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient">ExportIamPolicyAnalysisOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient" translate="no">ExportIamPolicyAnalysisOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
@@ -144,7 +144,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient">GrpcClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient" translate="no">GrpcClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
@@ -169,7 +169,7 @@ of 443.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -218,7 +218,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -267,7 +267,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,System.Threading.CancellationToken)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -316,7 +316,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -370,7 +370,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -424,7 +424,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,System.Threading.CancellationToken)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -478,7 +478,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_Create_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_Create" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create">Create()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_Create" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create" translate="no">Create()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceClient Create()</code></pre>
   </div>
@@ -503,7 +503,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync(System.Threading.CancellationToken)">CreateAsync(CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync(System.Threading.CancellationToken)" translate="no">CreateAsync(CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task&lt;AssetServiceClient&gt; CreateAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -546,7 +546,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -595,7 +595,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -648,7 +648,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -697,7 +697,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,System.Threading.CancellationToken)">CreateFeedAsync(CreateFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,System.Threading.CancellationToken)" translate="no">CreateFeedAsync(CreateFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -746,7 +746,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -799,7 +799,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,System.Threading.CancellationToken)">CreateFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">CreateFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -852,7 +852,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -884,7 +884,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -919,7 +919,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -954,7 +954,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1002,7 +1002,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,System.Threading.CancellationToken)">DeleteFeedAsync(DeleteFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1050,7 +1050,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1101,7 +1101,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)">DeleteFeedAsync(FeedName, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(FeedName, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1152,7 +1152,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1203,7 +1203,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,System.Threading.CancellationToken)">DeleteFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1254,7 +1254,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1311,7 +1311,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1368,7 +1368,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,System.Threading.CancellationToken)">ExportAssetsAsync(ExportAssetsRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,System.Threading.CancellationToken)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1425,7 +1425,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1481,7 +1481,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1537,7 +1537,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,System.Threading.CancellationToken)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1593,7 +1593,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">GetFeed(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1644,7 +1644,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeed(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1692,7 +1692,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(System.String,Google.Api.Gax.Grpc.CallSettings)">GetFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1743,7 +1743,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1794,7 +1794,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)">GetFeedAsync(FeedName, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" translate="no">GetFeedAsync(FeedName, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1845,7 +1845,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1893,7 +1893,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,System.Threading.CancellationToken)">GetFeedAsync(GetFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,System.Threading.CancellationToken)" translate="no">GetFeedAsync(GetFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1941,7 +1941,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1992,7 +1992,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,System.Threading.CancellationToken)">GetFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">GetFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2043,7 +2043,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2091,7 +2091,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(System.String,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2141,7 +2141,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2189,7 +2189,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,System.Threading.CancellationToken)">ListFeedsAsync(ListFeedsRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,System.Threading.CancellationToken)" translate="no">ListFeedsAsync(ListFeedsRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2237,7 +2237,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2287,7 +2287,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,System.Threading.CancellationToken)">ListFeedsAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,System.Threading.CancellationToken)" translate="no">ListFeedsAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2337,7 +2337,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportAssets(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportAssets(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; PollOnceExportAssets(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2385,7 +2385,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportAssetsAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportAssetsAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; PollOnceExportAssetsAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2434,7 +2434,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportIamPolicyAnalysis(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportIamPolicyAnalysis(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; PollOnceExportIamPolicyAnalysis(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2483,7 +2483,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync(System.String,Google.Api.Gax.Grpc.CallSettings)">PollOnceExportIamPolicyAnalysisAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportIamPolicyAnalysisAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; PollOnceExportIamPolicyAnalysisAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2532,7 +2532,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2583,7 +2583,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -2690,7 +2690,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2741,7 +2741,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -2848,7 +2848,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2899,7 +2899,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -3022,7 +3022,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3073,7 +3073,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -3196,7 +3196,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync">ShutdownDefaultChannelsAsync()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync" translate="no">ShutdownDefaultChannelsAsync()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task ShutdownDefaultChannelsAsync()</code></pre>
   </div>
@@ -3227,7 +3227,7 @@ affected.</p>
 by another call to this method.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(Feed, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(Feed, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3279,7 +3279,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3327,7 +3327,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(Feed, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(Feed, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3379,7 +3379,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,System.Threading.CancellationToken)">UpdateFeedAsync(Feed, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(Feed, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -3431,7 +3431,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3479,7 +3479,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,System.Threading.CancellationToken)">UpdateFeedAsync(UpdateFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -47,7 +47,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint" translate="no">DefaultEndpoint</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultEndpoint" class="notranslate">DefaultEndpoint</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string DefaultEndpoint { get; }</code></pre>
   </div>
@@ -71,7 +71,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes" translate="no">DefaultScopes</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DefaultScopes" class="notranslate">DefaultScopes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static IReadOnlyList&lt;string&gt; DefaultScopes { get; }</code></pre>
   </div>
@@ -98,7 +98,7 @@ of 443.</p>
 <ul><li><a href="https://www.googleapis.com/auth/cloud-platform">https://www.googleapis.com/auth/cloud-platform</a></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient" translate="no">ExportAssetsOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsOperationsClient" class="notranslate">ExportAssetsOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
@@ -121,7 +121,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient" translate="no">ExportIamPolicyAnalysisOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisOperationsClient" class="notranslate">ExportIamPolicyAnalysisOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
@@ -144,7 +144,7 @@ of 443.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient" translate="no">GrpcClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GrpcClient" class="notranslate">GrpcClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
@@ -169,7 +169,7 @@ of 443.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -218,7 +218,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -267,7 +267,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,System.Threading.CancellationToken)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,System.Threading.CancellationToken)" class="notranslate">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -316,7 +316,7 @@ which resources.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -370,7 +370,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -424,7 +424,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,System.Threading.CancellationToken)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,System.Threading.CancellationToken)" class="notranslate">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -478,7 +478,7 @@ error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_Create_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_Create" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create" translate="no">Create()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_Create" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.Create" class="notranslate">Create()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceClient Create()</code></pre>
   </div>
@@ -503,7 +503,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync(System.Threading.CancellationToken)" translate="no">CreateAsync(CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateAsync(System.Threading.CancellationToken)" class="notranslate">CreateAsync(CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task&lt;AssetServiceClient&gt; CreateAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -546,7 +546,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeed(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -595,7 +595,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -648,7 +648,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -697,7 +697,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,System.Threading.CancellationToken)" translate="no">CreateFeedAsync(CreateFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,System.Threading.CancellationToken)" class="notranslate">CreateFeedAsync(CreateFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -746,7 +746,7 @@ asset updates.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -799,7 +799,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">CreateFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.CreateFeedAsync(System.String,System.Threading.CancellationToken)" class="notranslate">CreateFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -852,7 +852,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -884,7 +884,7 @@ should be created in. It can only be an organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -919,7 +919,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -954,7 +954,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1002,7 +1002,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,System.Threading.CancellationToken)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1050,7 +1050,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeedAsync(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1101,7 +1101,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(FeedName, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" class="notranslate">DeleteFeedAsync(FeedName, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1152,7 +1152,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1203,7 +1203,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">DeleteFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(System.String,System.Threading.CancellationToken)" class="notranslate">DeleteFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1254,7 +1254,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1311,7 +1311,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1368,7 +1368,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,System.Threading.CancellationToken)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,System.Threading.CancellationToken)" class="notranslate">ExportAssetsAsync(ExportAssetsRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1425,7 +1425,7 @@ finishes within 5 minutes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1481,7 +1481,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1537,7 +1537,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,System.Threading.CancellationToken)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,System.Threading.CancellationToken)" class="notranslate">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1593,7 +1593,7 @@ metadata contains the request to help callers to map responses to requests.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeed(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1644,7 +1644,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeed(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1692,7 +1692,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1743,7 +1743,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(FeedName, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeedAsync(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1794,7 +1794,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" translate="no">GetFeedAsync(FeedName, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_FeedName_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.FeedName,System.Threading.CancellationToken)" class="notranslate">GetFeedAsync(FeedName, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1845,7 +1845,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1893,7 +1893,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,System.Threading.CancellationToken)" translate="no">GetFeedAsync(GetFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,System.Threading.CancellationToken)" class="notranslate">GetFeedAsync(GetFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -1941,7 +1941,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeedAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1992,7 +1992,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,System.Threading.CancellationToken)" translate="no">GetFeedAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.GetFeedAsync(System.String,System.Threading.CancellationToken)" class="notranslate">GetFeedAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2043,7 +2043,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeeds(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2091,7 +2091,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeeds(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeeds(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2141,7 +2141,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2189,7 +2189,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,System.Threading.CancellationToken)" translate="no">ListFeedsAsync(ListFeedsRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,System.Threading.CancellationToken)" class="notranslate">ListFeedsAsync(ListFeedsRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2237,7 +2237,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeedsAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2287,7 +2287,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,System.Threading.CancellationToken)" translate="no">ListFeedsAsync(String, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_System_String_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ListFeedsAsync(System.String,System.Threading.CancellationToken)" class="notranslate">ListFeedsAsync(String, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -2337,7 +2337,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportAssets(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssets_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssets(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">PollOnceExportAssets(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; PollOnceExportAssets(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2385,7 +2385,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportAssetsAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportAssetsAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportAssetsAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">PollOnceExportAssetsAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; PollOnceExportAssetsAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2434,7 +2434,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportIamPolicyAnalysis(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysis_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysis(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">PollOnceExportIamPolicyAnalysis(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; PollOnceExportIamPolicyAnalysis(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2483,7 +2483,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" translate="no">PollOnceExportIamPolicyAnalysisAsync(String, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_PollOnceExportIamPolicyAnalysisAsync_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.PollOnceExportIamPolicyAnalysisAsync(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">PollOnceExportIamPolicyAnalysisAsync(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; PollOnceExportIamPolicyAnalysisAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2532,7 +2532,7 @@ listed. It can only be using project/folder/organization number (such as
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2583,7 +2583,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPolicies(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPolicies(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -2690,7 +2690,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2741,7 +2741,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_System_String_System_String_System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllIamPoliciesAsync(System.String,System.String,System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPoliciesAsync(String, String, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -2848,7 +2848,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -2899,7 +2899,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResources(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResources(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -3022,7 +3022,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3073,7 +3073,7 @@ otherwise the request will be rejected.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_System_String_System_String_System_Collections_Generic_IEnumerable_System_String__System_String_System_Nullable_System_Int32__Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.SearchAllResourcesAsync(System.String,System.String,System.Collections.Generic.IEnumerable{System.String},System.String,System.Nullable{System.Int32},Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResourcesAsync(String, String, IEnumerable&lt;String&gt;, String, Nullable&lt;Int32&gt;, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
@@ -3196,7 +3196,7 @@ page.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync" translate="no">ShutdownDefaultChannelsAsync()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_ShutdownDefaultChannelsAsync" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.ShutdownDefaultChannelsAsync" class="notranslate">ShutdownDefaultChannelsAsync()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task ShutdownDefaultChannelsAsync()</code></pre>
   </div>
@@ -3227,7 +3227,7 @@ affected.</p>
 by another call to this method.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(Feed, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeed(Feed, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3279,7 +3279,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3327,7 +3327,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(Feed, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeedAsync(Feed, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3379,7 +3379,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(Feed, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_Feed_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.Feed,System.Threading.CancellationToken)" class="notranslate">UpdateFeedAsync(Feed, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CancellationToken cancellationToken)</code></pre>
   </div>
@@ -3431,7 +3431,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -3479,7 +3479,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,System.Threading.CancellationToken)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,System.Threading.CancellationToken)" class="notranslate">UpdateFeedAsync(UpdateFeedRequest, CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -110,7 +110,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter">DefaultGrpcAdapter</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter" translate="no">DefaultGrpcAdapter</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override GrpcAdapter DefaultGrpcAdapter { get; }</code></pre>
   </div>
@@ -135,7 +135,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.DefaultGrpcAdapter</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings">Settings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings" translate="no">Settings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Settings { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build">Build()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build" translate="no">Build()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetServiceClient Build()</code></pre>
   </div>
@@ -185,7 +185,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.Build()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync(System.Threading.CancellationToken)">BuildAsync(CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync(System.Threading.CancellationToken)" translate="no">BuildAsync(CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AssetServiceClient&gt; BuildAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -227,7 +227,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.BuildAsync(System.Threading.CancellationToken)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool">GetChannelPool()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool" translate="no">GetChannelPool()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override ChannelPool GetChannelPool()</code></pre>
   </div>
@@ -252,7 +252,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetChannelPool()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint">GetDefaultEndpoint()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint" translate="no">GetDefaultEndpoint()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override string GetDefaultEndpoint()</code></pre>
   </div>
@@ -277,7 +277,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetDefaultEndpoint()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes">GetDefaultScopes()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes" translate="no">GetDefaultScopes()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override IReadOnlyList&lt;string&gt; GetDefaultScopes()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -110,7 +110,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter" translate="no">DefaultGrpcAdapter</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_DefaultGrpcAdapter" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.DefaultGrpcAdapter" class="notranslate">DefaultGrpcAdapter</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override GrpcAdapter DefaultGrpcAdapter { get; }</code></pre>
   </div>
@@ -135,7 +135,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.DefaultGrpcAdapter</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings" translate="no">Settings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Settings" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Settings" class="notranslate">Settings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Settings { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build" translate="no">Build()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_Build" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.Build" class="notranslate">Build()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetServiceClient Build()</code></pre>
   </div>
@@ -185,7 +185,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.Build()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync(System.Threading.CancellationToken)" translate="no">BuildAsync(CancellationToken)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_BuildAsync_System_Threading_CancellationToken_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.BuildAsync(System.Threading.CancellationToken)" class="notranslate">BuildAsync(CancellationToken)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AssetServiceClient&gt; BuildAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
@@ -227,7 +227,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.BuildAsync(System.Threading.CancellationToken)</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool" translate="no">GetChannelPool()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetChannelPool" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetChannelPool" class="notranslate">GetChannelPool()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override ChannelPool GetChannelPool()</code></pre>
   </div>
@@ -252,7 +252,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetChannelPool()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint" translate="no">GetDefaultEndpoint()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultEndpoint" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultEndpoint" class="notranslate">GetDefaultEndpoint()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override string GetDefaultEndpoint()</code></pre>
   </div>
@@ -277,7 +277,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.GetDefaultEndpoint()</span></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes" translate="no">GetDefaultScopes()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientBuilder_GetDefaultScopes" data-uid="Google.Cloud.Asset.V1.AssetServiceClientBuilder.GetDefaultScopes" class="notranslate">GetDefaultScopes()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override IReadOnlyList&lt;string&gt; GetDefaultScopes()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -176,7 +176,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_Google_Cloud_Asset_V1_AssetService_AssetServiceClient_Google_Cloud_Asset_V1_AssetServiceSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor(Google.Cloud.Asset.V1.AssetService.AssetServiceClient,Google.Cloud.Asset.V1.AssetServiceSettings)">AssetServiceClientImpl(AssetService.AssetServiceClient, AssetServiceSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_Google_Cloud_Asset_V1_AssetService_AssetServiceClient_Google_Cloud_Asset_V1_AssetServiceSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor(Google.Cloud.Asset.V1.AssetService.AssetServiceClient,Google.Cloud.Asset.V1.AssetServiceSettings)" translate="no">AssetServiceClientImpl(AssetService.AssetServiceClient, AssetServiceSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClientImpl(AssetService.AssetServiceClient grpcClient, AssetServiceSettings settings)</code></pre>
   </div>
@@ -210,7 +210,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient">ExportAssetsOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient" translate="no">ExportAssetsOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
@@ -235,7 +235,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient">AssetServiceClient.ExportAssetsOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient">ExportIamPolicyAnalysisOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient" translate="no">ExportIamPolicyAnalysisOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
@@ -260,7 +260,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient">AssetServiceClient.ExportIamPolicyAnalysisOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient">GrpcClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient" translate="no">GrpcClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
@@ -287,7 +287,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -338,7 +338,7 @@ which resources.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -389,7 +389,7 @@ which resources.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -445,7 +445,7 @@ error.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -501,7 +501,7 @@ error.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -552,7 +552,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeed(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -603,7 +603,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeedAsync(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -637,7 +637,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeed(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -687,7 +687,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeedAsync(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -746,7 +746,7 @@ finishes within 5 minutes.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssets(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -805,7 +805,7 @@ finishes within 5 minutes.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssetsAsync(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -863,7 +863,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -921,7 +921,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeed(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -971,7 +971,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeed(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1021,7 +1021,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeedAsync(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeeds(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1071,7 +1071,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeeds(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1121,7 +1121,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeedsAsync(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1174,7 +1174,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1227,7 +1227,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1280,7 +1280,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResources(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1333,7 +1333,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1383,7 +1383,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.UpdateFeed(UpdateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -176,7 +176,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_Google_Cloud_Asset_V1_AssetService_AssetServiceClient_Google_Cloud_Asset_V1_AssetServiceSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor(Google.Cloud.Asset.V1.AssetService.AssetServiceClient,Google.Cloud.Asset.V1.AssetServiceSettings)" translate="no">AssetServiceClientImpl(AssetService.AssetServiceClient, AssetServiceSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl__ctor_Google_Cloud_Asset_V1_AssetService_AssetServiceClient_Google_Cloud_Asset_V1_AssetServiceSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.#ctor(Google.Cloud.Asset.V1.AssetService.AssetServiceClient,Google.Cloud.Asset.V1.AssetServiceSettings)" class="notranslate">AssetServiceClientImpl(AssetService.AssetServiceClient, AssetServiceSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClientImpl(AssetService.AssetServiceClient grpcClient, AssetServiceSettings settings)</code></pre>
   </div>
@@ -210,7 +210,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient" translate="no">ExportAssetsOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsOperationsClient" class="notranslate">ExportAssetsOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
@@ -235,7 +235,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsOperationsClient">AssetServiceClient.ExportAssetsOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient" translate="no">ExportIamPolicyAnalysisOperationsClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisOperationsClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisOperationsClient" class="notranslate">ExportIamPolicyAnalysisOperationsClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportIamPolicyAnalysisOperationsClient { get; }</code></pre>
   </div>
@@ -260,7 +260,7 @@
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisOperationsClient">AssetServiceClient.ExportIamPolicyAnalysisOperationsClient</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient" translate="no">GrpcClient</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GrpcClient" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GrpcClient" class="notranslate">GrpcClient</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
@@ -287,7 +287,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicy(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -338,7 +338,7 @@ which resources.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicy_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicy(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.AnalyzeIamPolicyAsync(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -389,7 +389,7 @@ which resources.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_AnalyzeIamPolicyAsync_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistory(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -445,7 +445,7 @@ error.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistory_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistory(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.BatchGetAssetsHistoryAsync(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -501,7 +501,7 @@ error.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_BatchGetAssetsHistoryAsync_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeed(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeed(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeed(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -552,7 +552,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeed_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeed(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.CreateFeedAsync(Google.Cloud.Asset.V1.CreateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">CreateFeedAsync(CreateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -603,7 +603,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateFeedAsync_Google_Cloud_Asset_V1_CreateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.CreateFeedAsync(CreateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeed(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -637,7 +637,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeed(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -687,7 +687,7 @@ asset updates.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeedAsync(DeleteFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssets(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportAssets(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -746,7 +746,7 @@ finishes within 5 minutes.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssets_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssets(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportAssetsAsync(Google.Cloud.Asset.V1.ExportAssetsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportAssetsAsync(ExportAssetsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -805,7 +805,7 @@ finishes within 5 minutes.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportAssetsAsync_Google_Cloud_Asset_V1_ExportAssetsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportAssetsAsync(ExportAssetsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysis(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt; ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -863,7 +863,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysis_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysis(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ExportIamPolicyAnalysisAsync(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportIamPolicyAnalysisResponse, ExportIamPolicyAnalysisRequest&gt;&gt; ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -921,7 +921,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ExportIamPolicyAnalysisAsync_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ExportIamPolicyAnalysisAsync(ExportIamPolicyAnalysisRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeed(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeed(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeed(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -971,7 +971,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeed_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeed(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.GetFeedAsync(Google.Cloud.Asset.V1.GetFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">GetFeedAsync(GetFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1021,7 +1021,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_GetFeedAsync_Google_Cloud_Asset_V1_GetFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.GetFeedAsync(GetFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeeds(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeeds(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeeds(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1071,7 +1071,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeeds_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeeds(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.ListFeedsAsync(Google.Cloud.Asset.V1.ListFeedsRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">ListFeedsAsync(ListFeedsRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1121,7 +1121,7 @@ metadata contains the request to help callers to map responses to requests.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_ListFeedsAsync_Google_Cloud_Asset_V1_ListFeedsRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.ListFeedsAsync(ListFeedsRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPolicies(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1174,7 +1174,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPolicies_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPolicies(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllIamPoliciesAsync(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1227,7 +1227,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllIamPoliciesAsync_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResources(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResources(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1280,7 +1280,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResources_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResources(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.SearchAllResourcesAsync(Google.Cloud.Asset.V1.SearchAllResourcesRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1333,7 +1333,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_SearchAllResourcesAsync_Google_Cloud_Asset_V1_SearchAllResourcesRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.SearchAllResourcesAsync(SearchAllResourcesRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeed(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeed(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
@@ -1383,7 +1383,7 @@ otherwise the request will be rejected.</p>
   <h4 class="overrides">Overrides</h4>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_UpdateFeed_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.UpdateFeed(UpdateFeedRequest, CallSettings)</a></div>
   <a id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" translate="no">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceClientImpl_UpdateFeedAsync_Google_Cloud_Asset_V1_UpdateFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClientImpl.UpdateFeedAsync(Google.Cloud.Asset.V1.UpdateFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">UpdateFeedAsync(UpdateFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -59,7 +59,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor" translate="no">AssetServiceSettings()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor" class="notranslate">AssetServiceSettings()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings()</code></pre>
   </div>
@@ -69,7 +69,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings" translate="no">AnalyzeIamPolicySettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings" class="notranslate">AnalyzeIamPolicySettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicySettings { get; set; }</code></pre>
   </div>
@@ -96,7 +96,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 300 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings" translate="no">BatchGetAssetsHistorySettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings" class="notranslate">BatchGetAssetsHistorySettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings BatchGetAssetsHistorySettings { get; set; }</code></pre>
   </div>
@@ -123,7 +123,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings" translate="no">CreateFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings" class="notranslate">CreateFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings CreateFeedSettings { get; set; }</code></pre>
   </div>
@@ -150,7 +150,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings" translate="no">DeleteFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings" class="notranslate">DeleteFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings DeleteFeedSettings { get; set; }</code></pre>
   </div>
@@ -177,7 +177,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings" translate="no">ExportAssetsOperationsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings" class="notranslate">ExportAssetsOperationsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings ExportAssetsOperationsSettings { get; set; }</code></pre>
   </div>
@@ -205,7 +205,7 @@
 <ul><li>Initial delay: 20 seconds.</li><li>Delay multiplier: 1.5</li><li>Maximum delay: 45 seconds.</li><li>Total timeout: 24 hours.</li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings" translate="no">ExportAssetsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings" class="notranslate">ExportAssetsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ExportAssetsSettings { get; set; }</code></pre>
   </div>
@@ -232,7 +232,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings" translate="no">ExportIamPolicyAnalysisOperationsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings" class="notranslate">ExportIamPolicyAnalysisOperationsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings ExportIamPolicyAnalysisOperationsSettings { get; set; }</code></pre>
   </div>
@@ -260,7 +260,7 @@
 <ul><li>Initial delay: 20 seconds.</li><li>Delay multiplier: 1.5</li><li>Maximum delay: 45 seconds.</li><li>Total timeout: 24 hours.</li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings" translate="no">ExportIamPolicyAnalysisSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings" class="notranslate">ExportIamPolicyAnalysisSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ExportIamPolicyAnalysisSettings { get; set; }</code></pre>
   </div>
@@ -288,7 +288,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings" translate="no">GetFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings" class="notranslate">GetFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings GetFeedSettings { get; set; }</code></pre>
   </div>
@@ -315,7 +315,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings" translate="no">ListFeedsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings" class="notranslate">ListFeedsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ListFeedsSettings { get; set; }</code></pre>
   </div>
@@ -342,7 +342,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings" translate="no">SearchAllIamPoliciesSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings" class="notranslate">SearchAllIamPoliciesSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllIamPoliciesSettings { get; set; }</code></pre>
   </div>
@@ -369,7 +369,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: 5</li><li>Timeout: 15 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings" translate="no">SearchAllResourcesSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings" class="notranslate">SearchAllResourcesSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllResourcesSettings { get; set; }</code></pre>
   </div>
@@ -396,7 +396,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: 5</li><li>Timeout: 15 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings" translate="no">UpdateFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings" class="notranslate">UpdateFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings UpdateFeedSettings { get; set; }</code></pre>
   </div>
@@ -425,7 +425,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone" translate="no">Clone()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone" class="notranslate">Clone()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Clone()</code></pre>
   </div>
@@ -449,7 +449,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault" translate="no">GetDefault()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault" class="notranslate">GetDefault()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceSettings GetDefault()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -59,7 +59,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor">AssetServiceSettings()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings__ctor" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.#ctor" translate="no">AssetServiceSettings()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings()</code></pre>
   </div>
@@ -69,7 +69,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings">AnalyzeIamPolicySettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings" translate="no">AnalyzeIamPolicySettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicySettings { get; set; }</code></pre>
   </div>
@@ -96,7 +96,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 300 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings">BatchGetAssetsHistorySettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_BatchGetAssetsHistorySettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.BatchGetAssetsHistorySettings" translate="no">BatchGetAssetsHistorySettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings BatchGetAssetsHistorySettings { get; set; }</code></pre>
   </div>
@@ -123,7 +123,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings">CreateFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_CreateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.CreateFeedSettings" translate="no">CreateFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings CreateFeedSettings { get; set; }</code></pre>
   </div>
@@ -150,7 +150,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings">DeleteFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_DeleteFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.DeleteFeedSettings" translate="no">DeleteFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings DeleteFeedSettings { get; set; }</code></pre>
   </div>
@@ -177,7 +177,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings">ExportAssetsOperationsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsOperationsSettings" translate="no">ExportAssetsOperationsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings ExportAssetsOperationsSettings { get; set; }</code></pre>
   </div>
@@ -205,7 +205,7 @@
 <ul><li>Initial delay: 20 seconds.</li><li>Delay multiplier: 1.5</li><li>Maximum delay: 45 seconds.</li><li>Total timeout: 24 hours.</li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings">ExportAssetsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportAssetsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportAssetsSettings" translate="no">ExportAssetsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ExportAssetsSettings { get; set; }</code></pre>
   </div>
@@ -232,7 +232,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings">ExportIamPolicyAnalysisOperationsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisOperationsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisOperationsSettings" translate="no">ExportIamPolicyAnalysisOperationsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings ExportIamPolicyAnalysisOperationsSettings { get; set; }</code></pre>
   </div>
@@ -260,7 +260,7 @@
 <ul><li>Initial delay: 20 seconds.</li><li>Delay multiplier: 1.5</li><li>Maximum delay: 45 seconds.</li><li>Total timeout: 24 hours.</li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings">ExportIamPolicyAnalysisSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ExportIamPolicyAnalysisSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ExportIamPolicyAnalysisSettings" translate="no">ExportIamPolicyAnalysisSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ExportIamPolicyAnalysisSettings { get; set; }</code></pre>
   </div>
@@ -288,7 +288,7 @@
   <div class="markdown level1 remarks"><ul><li>This call will not be retried.</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings">GetFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetFeedSettings" translate="no">GetFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings GetFeedSettings { get; set; }</code></pre>
   </div>
@@ -315,7 +315,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings">ListFeedsSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_ListFeedsSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.ListFeedsSettings" translate="no">ListFeedsSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ListFeedsSettings { get; set; }</code></pre>
   </div>
@@ -342,7 +342,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: Unlimited</li><li>Timeout: 60 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings">SearchAllIamPoliciesSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllIamPoliciesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllIamPoliciesSettings" translate="no">SearchAllIamPoliciesSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllIamPoliciesSettings { get; set; }</code></pre>
   </div>
@@ -369,7 +369,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: 5</li><li>Timeout: 15 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings">SearchAllResourcesSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_SearchAllResourcesSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.SearchAllResourcesSettings" translate="no">SearchAllResourcesSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllResourcesSettings { get; set; }</code></pre>
   </div>
@@ -396,7 +396,7 @@
   <div class="markdown level1 remarks"><ul><li>Initial retry delay: 100 milliseconds.</li><li>Retry delay multiplier: 1.3</li><li>Retry maximum delay: 60000 milliseconds.</li><li>Maximum attempts: 5</li><li>Timeout: 15 seconds.</li></ul>
 </div>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings">UpdateFeedSettings</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_UpdateFeedSettings" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.UpdateFeedSettings" translate="no">UpdateFeedSettings</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings UpdateFeedSettings { get; set; }</code></pre>
   </div>
@@ -425,7 +425,7 @@
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone">Clone()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_Clone" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.Clone" translate="no">Clone()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Clone()</code></pre>
   </div>
@@ -449,7 +449,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault*"></a>
-  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault">GetDefault()</h3>
+  <h3 id="Google_Cloud_Asset_V1_AssetServiceSettings_GetDefault" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.GetDefault" translate="no">GetDefault()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceSettings GetDefault()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor" translate="no">BatchGetAssetsHistoryRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor" class="notranslate">BatchGetAssetsHistoryRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)" translate="no">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)" class="notranslate">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames" translate="no">AssetNames</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames" class="notranslate">AssetNames</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ size of the asset name list is 100 in one request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType" translate="no">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType" class="notranslate">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ size of the asset name list is 100 in one request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent" translate="no">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent" class="notranslate">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -159,7 +159,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName" translate="no">ParentAsResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName" class="notranslate">ParentAsResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
@@ -182,7 +182,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow" translate="no">ReadTimeWindow</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow" class="notranslate">ReadTimeWindow</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow ReadTimeWindow { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor">BatchGetAssetsHistoryRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor" translate="no">BatchGetAssetsHistoryRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)" translate="no">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames">AssetNames</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_AssetNames" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.AssetNames" translate="no">AssetNames</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ size of the asset name list is 100 in one request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ContentType" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ContentType" translate="no">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ size of the asset name list is 100 in one request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.Parent" translate="no">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -159,7 +159,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName">ParentAsResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ParentAsResourceName" translate="no">ParentAsResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
@@ -182,7 +182,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow">ReadTimeWindow</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_ReadTimeWindow" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.ReadTimeWindow" translate="no">ReadTimeWindow</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow ReadTimeWindow { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor" translate="no">BatchGetAssetsHistoryResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor" class="notranslate">BatchGetAssetsHistoryResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)" translate="no">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)" class="notranslate">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets" translate="no">Assets</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets" class="notranslate">Assets</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;TemporalAsset&gt; Assets { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor">BatchGetAssetsHistoryResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor" translate="no">BatchGetAssetsHistoryResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)" translate="no">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets">Assets</h3>
+  <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_Assets" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.Assets" translate="no">Assets</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;TemporalAsset&gt; Assets { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor">BigQueryDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor" translate="no">BigQueryDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)">BigQueryDestination(BigQueryDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)" translate="no">BigQueryDestination(BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(BigQueryDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset">Dataset</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset" translate="no">Dataset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Force_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Force" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force">Force</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Force" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force" translate="no">Force</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Force { get; set; }</code></pre>
   </div>
@@ -135,7 +135,7 @@ call returns an INVALID_ARGUMEMT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Table_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Table" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table">Table</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Table" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table" translate="no">Table</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Table { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor" translate="no">BigQueryDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor" class="notranslate">BigQueryDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)" translate="no">BigQueryDestination(BigQueryDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)" class="notranslate">BigQueryDestination(BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(BigQueryDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset" translate="no">Dataset</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Dataset" class="notranslate">Dataset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Force_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Force" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force" translate="no">Force</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Force" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Force" class="notranslate">Force</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Force { get; set; }</code></pre>
   </div>
@@ -135,7 +135,7 @@ call returns an INVALID_ARGUMEMT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination_Table_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table*"></a>
-  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Table" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table" translate="no">Table</h3>
+  <h3 id="Google_Cloud_Asset_V1_BigQueryDestination_Table" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.Table" class="notranslate">Table</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Table { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor" translate="no">CreateFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor" class="notranslate">CreateFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)" translate="no">CreateFeedRequest(CreateFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)" class="notranslate">CreateFeedRequest(CreateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest(CreateFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed" translate="no">Feed</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed" class="notranslate">Feed</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId" translate="no">FeedId</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId" class="notranslate">FeedId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ be unique under a specific parent project/folder/organization.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent" translate="no">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent" class="notranslate">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor">CreateFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor" translate="no">CreateFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)">CreateFeedRequest(CreateFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)" translate="no">CreateFeedRequest(CreateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest(CreateFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed">Feed</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Feed" translate="no">Feed</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ organizations/organization_number/feeds/feed_id</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId">FeedId</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_FeedId" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.FeedId" translate="no">FeedId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ be unique under a specific parent project/folder/organization.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest_Parent" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.Parent" translate="no">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -49,14 +49,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor">DeleteFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor" translate="no">DeleteFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)">DeleteFeedRequest(DeleteFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)" translate="no">DeleteFeedRequest(DeleteFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest(DeleteFeedRequest other)</code></pre>
   </div>
@@ -82,7 +82,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName" translate="no">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -49,14 +49,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor" translate="no">DeleteFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor" class="notranslate">DeleteFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)" translate="no">DeleteFeedRequest(DeleteFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)" class="notranslate">DeleteFeedRequest(DeleteFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest(DeleteFeedRequest other)</code></pre>
   </div>
@@ -82,7 +82,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName" translate="no">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.FeedName" class="notranslate">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor" translate="no">ExportAssetsRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor" class="notranslate">ExportAssetsRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)" translate="no">ExportAssetsRequest(ExportAssetsRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)" class="notranslate">ExportAssetsRequest(ExportAssetsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest(ExportAssetsRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes" translate="no">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes" class="notranslate">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -121,7 +121,7 @@ for all supported asset types.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType" translate="no">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType" class="notranslate">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -145,7 +145,7 @@ returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig" translate="no">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig" class="notranslate">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
@@ -168,7 +168,7 @@ returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent" translate="no">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent" class="notranslate">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -194,7 +194,7 @@ or a folder number (such as &quot;folders/123&quot;).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName" translate="no">ParentAsResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName" class="notranslate">ParentAsResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
@@ -217,7 +217,7 @@ or a folder number (such as &quot;folders/123&quot;).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime" translate="no">ReadTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime" class="notranslate">ReadTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor">ExportAssetsRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor" translate="no">ExportAssetsRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)">ExportAssetsRequest(ExportAssetsRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)" translate="no">ExportAssetsRequest(ExportAssetsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest(ExportAssetsRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.AssetTypes" translate="no">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -121,7 +121,7 @@ for all supported asset types.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ContentType" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ContentType" translate="no">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -145,7 +145,7 @@ returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.OutputConfig" translate="no">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
@@ -168,7 +168,7 @@ returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.Parent" translate="no">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -194,7 +194,7 @@ or a folder number (such as &quot;folders/123&quot;).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName">ParentAsResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ParentAsResourceName" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ParentAsResourceName" translate="no">ParentAsResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
@@ -217,7 +217,7 @@ or a folder number (such as &quot;folders/123&quot;).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime">ReadTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.ReadTime" translate="no">ReadTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -52,14 +52,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor" translate="no">ExportAssetsResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor" class="notranslate">ExportAssetsResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)" translate="no">ExportAssetsResponse(ExportAssetsResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)" class="notranslate">ExportAssetsResponse(ExportAssetsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse(ExportAssetsResponse other)</code></pre>
   </div>
@@ -85,7 +85,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig" translate="no">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig" class="notranslate">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult" translate="no">OutputResult</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult" class="notranslate">OutputResult</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult OutputResult { get; set; }</code></pre>
   </div>
@@ -135,7 +135,7 @@ once it exceeds a single Google Cloud Storage object limit.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime" translate="no">ReadTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime" class="notranslate">ReadTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -52,14 +52,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor">ExportAssetsResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor" translate="no">ExportAssetsResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)">ExportAssetsResponse(ExportAssetsResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)" translate="no">ExportAssetsResponse(ExportAssetsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse(ExportAssetsResponse other)</code></pre>
   </div>
@@ -85,7 +85,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputConfig" translate="no">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult">OutputResult</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_OutputResult" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.OutputResult" translate="no">OutputResult</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult OutputResult { get; set; }</code></pre>
   </div>
@@ -135,7 +135,7 @@ once it exceeds a single Google Cloud Storage object limit.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime">ReadTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse_ReadTime" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.ReadTime" translate="no">ReadTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor" translate="no">ExportIamPolicyAnalysisRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor" class="notranslate">ExportIamPolicyAnalysisRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)" translate="no">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)" class="notranslate">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery" translate="no">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery" class="notranslate">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig" translate="no">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig" class="notranslate">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig OutputConfig { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor">ExportIamPolicyAnalysisRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor" translate="no">ExportIamPolicyAnalysisRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)" translate="no">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery">AnalysisQuery</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_AnalysisQuery" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.AnalysisQuery" translate="no">AnalysisQuery</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig">OutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_OutputConfig" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.OutputConfig" translate="no">OutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig OutputConfig { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor" translate="no">ExportIamPolicyAnalysisResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor" class="notranslate">ExportIamPolicyAnalysisResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)" translate="no">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)" class="notranslate">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse other)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor">ExportIamPolicyAnalysisResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor" translate="no">ExportIamPolicyAnalysisResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)" translate="no">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse other)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -54,14 +54,14 @@ Pub/Sub topics.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed__ctor" data-uid="Google.Cloud.Asset.V1.Feed.#ctor" translate="no">Feed()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed__ctor" data-uid="Google.Cloud.Asset.V1.Feed.#ctor" class="notranslate">Feed()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)" translate="no">Feed(Feed)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)" class="notranslate">Feed(Feed)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed(Feed other)</code></pre>
   </div>
@@ -87,7 +87,7 @@ Pub/Sub topics.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed_AssetNames_" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_AssetNames" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames" translate="no">AssetNames</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_AssetNames" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames" class="notranslate">AssetNames</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
@@ -117,7 +117,7 @@ for more info.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_AssetTypes_" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_AssetTypes" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes" translate="no">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_AssetTypes" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes" class="notranslate">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -146,7 +146,7 @@ for a list of all supported asset types.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Condition_" data-uid="Google.Cloud.Asset.V1.Feed.Condition*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_Condition" data-uid="Google.Cloud.Asset.V1.Feed.Condition" translate="no">Condition</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_Condition" data-uid="Google.Cloud.Asset.V1.Feed.Condition" class="notranslate">Condition</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Expr Condition { get; set; }</code></pre>
   </div>
@@ -178,7 +178,7 @@ for detailed instructions.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_ContentType_" data-uid="Google.Cloud.Asset.V1.Feed.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_ContentType" data-uid="Google.Cloud.Asset.V1.Feed.ContentType" translate="no">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_ContentType" data-uid="Google.Cloud.Asset.V1.Feed.ContentType" class="notranslate">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -202,7 +202,7 @@ type will be returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedName_" data-uid="Google.Cloud.Asset.V1.Feed.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_FeedName" data-uid="Google.Cloud.Asset.V1.Feed.FeedName" translate="no">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_FeedName" data-uid="Google.Cloud.Asset.V1.Feed.FeedName" class="notranslate">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -225,7 +225,7 @@ type will be returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig" translate="no">FeedOutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig" class="notranslate">FeedOutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig FeedOutputConfig { get; set; }</code></pre>
   </div>
@@ -249,7 +249,7 @@ published to.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Name_" data-uid="Google.Cloud.Asset.V1.Feed.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_Name" data-uid="Google.Cloud.Asset.V1.Feed.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_Name" data-uid="Google.Cloud.Asset.V1.Feed.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -54,14 +54,14 @@ Pub/Sub topics.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed__ctor" data-uid="Google.Cloud.Asset.V1.Feed.#ctor">Feed()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed__ctor" data-uid="Google.Cloud.Asset.V1.Feed.#ctor" translate="no">Feed()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)">Feed(Feed)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)" translate="no">Feed(Feed)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed(Feed other)</code></pre>
   </div>
@@ -87,7 +87,7 @@ Pub/Sub topics.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Feed_AssetNames_" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_AssetNames" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames">AssetNames</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_AssetNames" data-uid="Google.Cloud.Asset.V1.Feed.AssetNames" translate="no">AssetNames</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
@@ -117,7 +117,7 @@ for more info.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_AssetTypes_" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_AssetTypes" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_AssetTypes" data-uid="Google.Cloud.Asset.V1.Feed.AssetTypes" translate="no">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -146,7 +146,7 @@ for a list of all supported asset types.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Condition_" data-uid="Google.Cloud.Asset.V1.Feed.Condition*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_Condition" data-uid="Google.Cloud.Asset.V1.Feed.Condition">Condition</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_Condition" data-uid="Google.Cloud.Asset.V1.Feed.Condition" translate="no">Condition</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Expr Condition { get; set; }</code></pre>
   </div>
@@ -178,7 +178,7 @@ for detailed instructions.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_ContentType_" data-uid="Google.Cloud.Asset.V1.Feed.ContentType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_ContentType" data-uid="Google.Cloud.Asset.V1.Feed.ContentType">ContentType</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_ContentType" data-uid="Google.Cloud.Asset.V1.Feed.ContentType" translate="no">ContentType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
@@ -202,7 +202,7 @@ type will be returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedName_" data-uid="Google.Cloud.Asset.V1.Feed.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_FeedName" data-uid="Google.Cloud.Asset.V1.Feed.FeedName">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_FeedName" data-uid="Google.Cloud.Asset.V1.Feed.FeedName" translate="no">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -225,7 +225,7 @@ type will be returned.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig">FeedOutputConfig</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_FeedOutputConfig" data-uid="Google.Cloud.Asset.V1.Feed.FeedOutputConfig" translate="no">FeedOutputConfig</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig FeedOutputConfig { get; set; }</code></pre>
   </div>
@@ -249,7 +249,7 @@ published to.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Feed_Name_" data-uid="Google.Cloud.Asset.V1.Feed.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Feed_Name" data-uid="Google.Cloud.Asset.V1.Feed.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_Feed_Name" data-uid="Google.Cloud.Asset.V1.Feed.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -42,7 +42,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName__ctor_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName__ctor_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor(System.String,System.String)" translate="no">FeedName(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName__ctor_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor(System.String,System.String)" class="notranslate">FeedName(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName(string projectId, string feedId)</code></pre>
   </div>
@@ -77,7 +77,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_FeedId_" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FeedId" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId" translate="no">FeedId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FeedId" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId" class="notranslate">FeedId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; }</code></pre>
   </div>
@@ -100,7 +100,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FolderId_" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FolderId" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId" translate="no">FolderId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FolderId" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId" class="notranslate">FolderId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FolderId { get; }</code></pre>
   </div>
@@ -123,7 +123,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern_" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern" translate="no">IsKnownPattern</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern" class="notranslate">IsKnownPattern</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool IsKnownPattern { get; }</code></pre>
   </div>
@@ -146,7 +146,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_OrganizationId_" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_OrganizationId" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId" translate="no">OrganizationId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_OrganizationId" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId" class="notranslate">OrganizationId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrganizationId { get; }</code></pre>
   </div>
@@ -170,7 +170,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_ProjectId_" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_ProjectId" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId" translate="no">ProjectId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_ProjectId" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId" class="notranslate">ProjectId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ProjectId { get; }</code></pre>
   </div>
@@ -193,7 +193,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_Type_" data-uid="Google.Cloud.Asset.V1.FeedName.Type*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Type" data-uid="Google.Cloud.Asset.V1.FeedName.Type" translate="no">Type</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Type" data-uid="Google.Cloud.Asset.V1.FeedName.Type" class="notranslate">Type</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName.ResourceNameType Type { get; }</code></pre>
   </div>
@@ -216,7 +216,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_UnparsedResource_" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_UnparsedResource" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource" translate="no">UnparsedResource</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_UnparsedResource" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource" class="notranslate">UnparsedResource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnparsedResourceName UnparsedResource { get; }</code></pre>
   </div>
@@ -242,7 +242,7 @@ unparsed resource name.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_Format_" data-uid="Google.Cloud.Asset.V1.FeedName.Format*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Format_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Format(System.String,System.String)" translate="no">Format(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Format_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Format(System.String,System.String)" class="notranslate">Format(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string Format(string projectId, string feedId)</code></pre>
   </div>
@@ -292,7 +292,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed(System.String,System.String)" translate="no">FormatFolderFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed(System.String,System.String)" class="notranslate">FormatFolderFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatFolderFeed(string folderId, string feedId)</code></pre>
   </div>
@@ -341,7 +341,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed(System.String,System.String)" translate="no">FormatOrganizationFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed(System.String,System.String)" class="notranslate">FormatOrganizationFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
@@ -391,7 +391,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed(System.String,System.String)" translate="no">FormatProjectFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed(System.String,System.String)" class="notranslate">FormatProjectFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatProjectFeed(string projectId, string feedId)</code></pre>
   </div>
@@ -441,7 +441,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed(System.String,System.String)" translate="no">FromFolderFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed(System.String,System.String)" class="notranslate">FromFolderFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromFolderFeed(string folderId, string feedId)</code></pre>
   </div>
@@ -489,7 +489,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed(System.String,System.String)" translate="no">FromOrganizationFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed(System.String,System.String)" class="notranslate">FromOrganizationFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
@@ -537,7 +537,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed(System.String,System.String)" translate="no">FromProjectFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed(System.String,System.String)" class="notranslate">FromProjectFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromProjectFeed(string projectId, string feedId)</code></pre>
   </div>
@@ -585,7 +585,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_Google_Api_Gax_UnparsedResourceName_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed(Google.Api.Gax.UnparsedResourceName)" translate="no">FromUnparsed(UnparsedResourceName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_Google_Api_Gax_UnparsedResourceName_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed(Google.Api.Gax.UnparsedResourceName)" class="notranslate">FromUnparsed(UnparsedResourceName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromUnparsed(UnparsedResourceName unparsedResourceName)</code></pre>
   </div>
@@ -627,7 +627,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_GetHashCode_" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_GetHashCode" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode" translate="no">GetHashCode()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_GetHashCode" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode" class="notranslate">GetHashCode()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override int GetHashCode()</code></pre>
   </div>
@@ -652,7 +652,7 @@ unparsed resource name.</p>
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">System.Object.GetHashCode()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)" translate="no">Parse(String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)" class="notranslate">Parse(String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName)</code></pre>
   </div>
@@ -698,7 +698,7 @@ unparsed resource name.</p>
 <ul><li><code>projects/{project}/feeds/{feed}</code></li><li><code>folders/{folder}/feeds/{feed}</code></li><li><code>organizations/{organization}/feeds/{feed}</code></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_System_Boolean_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String,System.Boolean)" translate="no">Parse(String, Boolean)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_System_Boolean_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String,System.Boolean)" class="notranslate">Parse(String, Boolean)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName, bool allowUnparsed)</code></pre>
   </div>
@@ -754,7 +754,7 @@ specified.</p>
 Or may be in any format if <code data-dev-comment-type="paramref" class="paramref">allowUnparsed</code> is <code>true</code>.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_ToString_" data-uid="Google.Cloud.Asset.V1.FeedName.ToString*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_ToString" data-uid="Google.Cloud.Asset.V1.FeedName.ToString" translate="no">ToString()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_ToString" data-uid="Google.Cloud.Asset.V1.FeedName.ToString" class="notranslate">ToString()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override string ToString()</code></pre>
   </div>
@@ -780,7 +780,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">System.Object.ToString()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)" translate="no">TryParse(String, out FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)" class="notranslate">TryParse(String, out FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, out FeedName result)</code></pre>
   </div>
@@ -832,7 +832,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
 <ul><li><code>projects/{project}/feeds/{feed}</code></li><li><code>folders/{folder}/feeds/{feed}</code></li><li><code>organizations/{organization}/feeds/{feed}</code></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_System_Boolean_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,System.Boolean,Google.Cloud.Asset.V1.FeedName@)" translate="no">TryParse(String, Boolean, out FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_System_Boolean_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,System.Boolean,Google.Cloud.Asset.V1.FeedName@)" class="notranslate">TryParse(String, Boolean, out FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, bool allowUnparsed, out FeedName result)</code></pre>
   </div>
@@ -896,7 +896,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <h2 id="operators">Operators
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Equality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Equality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" translate="no">Equality(FeedName, FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Equality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" class="notranslate">Equality(FeedName, FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator ==(FeedName a, FeedName b)</code></pre>
   </div>
@@ -940,7 +940,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Inequality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Inequality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" translate="no">Inequality(FeedName, FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Inequality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" class="notranslate">Inequality(FeedName, FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator !=(FeedName a, FeedName b)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -42,7 +42,7 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName__ctor_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName__ctor_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor(System.String,System.String)">FeedName(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName__ctor_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.#ctor(System.String,System.String)" translate="no">FeedName(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName(string projectId, string feedId)</code></pre>
   </div>
@@ -77,7 +77,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_FeedId_" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FeedId" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId">FeedId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FeedId" data-uid="Google.Cloud.Asset.V1.FeedName.FeedId" translate="no">FeedId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; }</code></pre>
   </div>
@@ -100,7 +100,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FolderId_" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FolderId" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId">FolderId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FolderId" data-uid="Google.Cloud.Asset.V1.FeedName.FolderId" translate="no">FolderId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FolderId { get; }</code></pre>
   </div>
@@ -123,7 +123,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern_" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern">IsKnownPattern</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_IsKnownPattern" data-uid="Google.Cloud.Asset.V1.FeedName.IsKnownPattern" translate="no">IsKnownPattern</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool IsKnownPattern { get; }</code></pre>
   </div>
@@ -146,7 +146,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_OrganizationId_" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_OrganizationId" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId">OrganizationId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_OrganizationId" data-uid="Google.Cloud.Asset.V1.FeedName.OrganizationId" translate="no">OrganizationId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrganizationId { get; }</code></pre>
   </div>
@@ -170,7 +170,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_ProjectId_" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_ProjectId" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId">ProjectId</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_ProjectId" data-uid="Google.Cloud.Asset.V1.FeedName.ProjectId" translate="no">ProjectId</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ProjectId { get; }</code></pre>
   </div>
@@ -193,7 +193,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_Type_" data-uid="Google.Cloud.Asset.V1.FeedName.Type*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Type" data-uid="Google.Cloud.Asset.V1.FeedName.Type">Type</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Type" data-uid="Google.Cloud.Asset.V1.FeedName.Type" translate="no">Type</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName.ResourceNameType Type { get; }</code></pre>
   </div>
@@ -216,7 +216,7 @@ instance.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_UnparsedResource_" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_UnparsedResource" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource">UnparsedResource</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_UnparsedResource" data-uid="Google.Cloud.Asset.V1.FeedName.UnparsedResource" translate="no">UnparsedResource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnparsedResourceName UnparsedResource { get; }</code></pre>
   </div>
@@ -242,7 +242,7 @@ unparsed resource name.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_Format_" data-uid="Google.Cloud.Asset.V1.FeedName.Format*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Format_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Format(System.String,System.String)">Format(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Format_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Format(System.String,System.String)" translate="no">Format(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string Format(string projectId, string feedId)</code></pre>
   </div>
@@ -292,7 +292,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed(System.String,System.String)">FormatFolderFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatFolderFeed(System.String,System.String)" translate="no">FormatFolderFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatFolderFeed(string folderId, string feedId)</code></pre>
   </div>
@@ -341,7 +341,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed(System.String,System.String)">FormatOrganizationFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatOrganizationFeed(System.String,System.String)" translate="no">FormatOrganizationFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
@@ -391,7 +391,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed(System.String,System.String)">FormatProjectFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FormatProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FormatProjectFeed(System.String,System.String)" translate="no">FormatProjectFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatProjectFeed(string projectId, string feedId)</code></pre>
   </div>
@@ -441,7 +441,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed(System.String,System.String)">FromFolderFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromFolderFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromFolderFeed(System.String,System.String)" translate="no">FromFolderFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromFolderFeed(string folderId, string feedId)</code></pre>
   </div>
@@ -489,7 +489,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed(System.String,System.String)">FromOrganizationFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromOrganizationFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromOrganizationFeed(System.String,System.String)" translate="no">FromOrganizationFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
@@ -537,7 +537,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed(System.String,System.String)">FromProjectFeed(String, String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromProjectFeed_System_String_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.FromProjectFeed(System.String,System.String)" translate="no">FromProjectFeed(String, String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromProjectFeed(string projectId, string feedId)</code></pre>
   </div>
@@ -585,7 +585,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_Google_Api_Gax_UnparsedResourceName_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed(Google.Api.Gax.UnparsedResourceName)">FromUnparsed(UnparsedResourceName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_FromUnparsed_Google_Api_Gax_UnparsedResourceName_" data-uid="Google.Cloud.Asset.V1.FeedName.FromUnparsed(Google.Api.Gax.UnparsedResourceName)" translate="no">FromUnparsed(UnparsedResourceName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromUnparsed(UnparsedResourceName unparsedResourceName)</code></pre>
   </div>
@@ -627,7 +627,7 @@ unparsed resource name.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_GetHashCode_" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_GetHashCode" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode">GetHashCode()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_GetHashCode" data-uid="Google.Cloud.Asset.V1.FeedName.GetHashCode" translate="no">GetHashCode()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override int GetHashCode()</code></pre>
   </div>
@@ -652,7 +652,7 @@ unparsed resource name.</p>
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">System.Object.GetHashCode()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)">Parse(String)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String)" translate="no">Parse(String)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName)</code></pre>
   </div>
@@ -698,7 +698,7 @@ unparsed resource name.</p>
 <ul><li><code>projects/{project}/feeds/{feed}</code></li><li><code>folders/{folder}/feeds/{feed}</code></li><li><code>organizations/{organization}/feeds/{feed}</code></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_Parse_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_System_Boolean_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String,System.Boolean)">Parse(String, Boolean)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_Parse_System_String_System_Boolean_" data-uid="Google.Cloud.Asset.V1.FeedName.Parse(System.String,System.Boolean)" translate="no">Parse(String, Boolean)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName, bool allowUnparsed)</code></pre>
   </div>
@@ -754,7 +754,7 @@ specified.</p>
 Or may be in any format if <code data-dev-comment-type="paramref" class="paramref">allowUnparsed</code> is <code>true</code>.</p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_ToString_" data-uid="Google.Cloud.Asset.V1.FeedName.ToString*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_ToString" data-uid="Google.Cloud.Asset.V1.FeedName.ToString">ToString()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_ToString" data-uid="Google.Cloud.Asset.V1.FeedName.ToString" translate="no">ToString()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override string ToString()</code></pre>
   </div>
@@ -780,7 +780,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <h4 class="overrides">Overrides</h4>
   <div><span class="xref">System.Object.ToString()</span></div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)">TryParse(String, out FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,Google.Cloud.Asset.V1.FeedName@)" translate="no">TryParse(String, out FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, out FeedName result)</code></pre>
   </div>
@@ -832,7 +832,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
 <ul><li><code>projects/{project}/feeds/{feed}</code></li><li><code>folders/{folder}/feeds/{feed}</code></li><li><code>organizations/{organization}/feeds/{feed}</code></li></ul></p>
 </div>
   <a id="Google_Cloud_Asset_V1_FeedName_TryParse_" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_System_Boolean_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,System.Boolean,Google.Cloud.Asset.V1.FeedName@)">TryParse(String, Boolean, out FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_TryParse_System_String_System_Boolean_Google_Cloud_Asset_V1_FeedName__" data-uid="Google.Cloud.Asset.V1.FeedName.TryParse(System.String,System.Boolean,Google.Cloud.Asset.V1.FeedName@)" translate="no">TryParse(String, Boolean, out FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, bool allowUnparsed, out FeedName result)</code></pre>
   </div>
@@ -896,7 +896,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <h2 id="operators">Operators
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Equality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Equality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)">Equality(FeedName, FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Equality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Equality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" translate="no">Equality(FeedName, FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator ==(FeedName a, FeedName b)</code></pre>
   </div>
@@ -940,7 +940,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedName_op_Inequality_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Inequality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)">Inequality(FeedName, FeedName)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedName_op_Inequality_Google_Cloud_Asset_V1_FeedName_Google_Cloud_Asset_V1_FeedName_" data-uid="Google.Cloud.Asset.V1.FeedName.op_Inequality(Google.Cloud.Asset.V1.FeedName,Google.Cloud.Asset.V1.FeedName)" translate="no">Inequality(FeedName, FeedName)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator !=(FeedName a, FeedName b)</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor" translate="no">FeedOutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor" class="notranslate">FeedOutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)" translate="no">FeedOutputConfig(FeedOutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)" class="notranslate">FeedOutputConfig(FeedOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig(FeedOutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase" translate="no">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase" class="notranslate">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination" translate="no">PubsubDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination" class="notranslate">PubsubDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination PubsubDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor">FeedOutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor" translate="no">FeedOutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)">FeedOutputConfig(FeedOutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)" translate="no">FeedOutputConfig(FeedOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig(FeedOutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.DestinationCase" translate="no">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination">PubsubDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig_PubsubDestination" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.PubsubDestination" translate="no">PubsubDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination PubsubDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor">GcsDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor" translate="no">GcsDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)">GcsDestination(GcsDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)" translate="no">GcsDestination(GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(GcsDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase_" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase">ObjectUriCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase" translate="no">ObjectUriCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination.ObjectUriOneofCase ObjectUriCase { get; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri">Uri</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri" translate="no">Uri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>
@@ -132,7 +132,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix_" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix">UriPrefix</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix" translate="no">UriPrefix</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string UriPrefix { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor" translate="no">GcsDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor" class="notranslate">GcsDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)" translate="no">GcsDestination(GcsDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)" class="notranslate">GcsDestination(GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(GcsDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase_" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase" translate="no">ObjectUriCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriCase" data-uid="Google.Cloud.Asset.V1.GcsDestination.ObjectUriCase" class="notranslate">ObjectUriCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination.ObjectUriOneofCase ObjectUriCase { get; }</code></pre>
   </div>
@@ -105,7 +105,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri" translate="no">Uri</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.GcsDestination.Uri" class="notranslate">Uri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>
@@ -132,7 +132,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix_" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix" translate="no">UriPrefix</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsDestination_UriPrefix" data-uid="Google.Cloud.Asset.V1.GcsDestination.UriPrefix" class="notranslate">UriPrefix</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string UriPrefix { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor">GcsOutputResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor" translate="no">GcsOutputResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)">GcsOutputResult(GcsOutputResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)" translate="no">GcsOutputResult(GcsOutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult(GcsOutputResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult_Uris_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult_Uris" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris">Uris</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult_Uris" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris" translate="no">Uris</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Uris { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor" translate="no">GcsOutputResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor" class="notranslate">GcsOutputResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)" translate="no">GcsOutputResult(GcsOutputResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)" class="notranslate">GcsOutputResult(GcsOutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult(GcsOutputResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult_Uris_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult_Uris" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris" translate="no">Uris</h3>
+  <h3 id="Google_Cloud_Asset_V1_GcsOutputResult_Uris" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.Uris" class="notranslate">Uris</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Uris { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor" translate="no">GetFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor" class="notranslate">GetFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)" translate="no">GetFeedRequest(GetFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)" class="notranslate">GetFeedRequest(GetFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest(GetFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName" translate="no">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName" class="notranslate">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor">GetFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor" translate="no">GetFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)">GetFeedRequest(GetFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)" translate="no">GetFeedRequest(GetFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest(GetFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName">FeedName</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_FeedName" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.FeedName" translate="no">FeedName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest_Name_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_GetFeedRequest_Name" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor" translate="no">BigQueryDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor" class="notranslate">BigQueryDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)" translate="no">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)" class="notranslate">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset" translate="no">Dataset</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset" class="notranslate">Dataset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey" translate="no">PartitionKey</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey" class="notranslate">PartitionKey</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey PartitionKey { get; set; }</code></pre>
   </div>
@@ -131,7 +131,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix" translate="no">TablePrefix</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix" class="notranslate">TablePrefix</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TablePrefix { get; set; }</code></pre>
   </div>
@@ -162,7 +162,7 @@ on the [partition_key].</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode" translate="no">WriteMode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode" class="notranslate">WriteMode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode WriteMode { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor">BigQueryDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor" translate="no">BigQueryDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)" translate="no">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset">Dataset</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Dataset" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Dataset" translate="no">Dataset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey">PartitionKey</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_PartitionKey" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.PartitionKey" translate="no">PartitionKey</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey PartitionKey { get; set; }</code></pre>
   </div>
@@ -131,7 +131,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix">TablePrefix</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_TablePrefix" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.TablePrefix" translate="no">TablePrefix</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TablePrefix { get; set; }</code></pre>
   </div>
@@ -162,7 +162,7 @@ on the [partition_key].</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode">WriteMode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_WriteMode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.WriteMode" translate="no">WriteMode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode WriteMode { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor">GcsDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor" translate="no">GcsDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)" translate="no">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri">Uri</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri" translate="no">Uri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor" translate="no">GcsDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor" class="notranslate">GcsDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)" translate="no">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)" class="notranslate">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri" translate="no">Uri</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_Uri" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.Uri" class="notranslate">Uri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor" translate="no">IamPolicyAnalysisOutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor" class="notranslate">IamPolicyAnalysisOutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)" translate="no">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)" class="notranslate">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination" translate="no">BigqueryDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination" class="notranslate">BigqueryDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase" translate="no">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase" class="notranslate">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -128,7 +128,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination" translate="no">GcsDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination" class="notranslate">GcsDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.GcsDestination GcsDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor">IamPolicyAnalysisOutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor" translate="no">IamPolicyAnalysisOutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)" translate="no">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination">BigqueryDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.BigqueryDestination" translate="no">BigqueryDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationCase" translate="no">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -128,7 +128,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination">GcsDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.GcsDestination" translate="no">GcsDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.GcsDestination GcsDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -53,14 +53,14 @@ any of them.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor" translate="no">AccessSelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor" class="notranslate">AccessSelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)" translate="no">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)" class="notranslate">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector other)</code></pre>
   </div>
@@ -86,7 +86,7 @@ any of them.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions" translate="no">Permissions</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions" class="notranslate">Permissions</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ any of them.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles" translate="no">Roles</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles" class="notranslate">Roles</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Roles { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -53,14 +53,14 @@ any of them.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor">AccessSelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor" translate="no">AccessSelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)" translate="no">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector other)</code></pre>
   </div>
@@ -86,7 +86,7 @@ any of them.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions">Permissions</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Permissions" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Permissions" translate="no">Permissions</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ any of them.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles">Roles</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_Roles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.Roles" translate="no">Roles</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Roles { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -52,14 +52,14 @@ directly or indirectly.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor" translate="no">IdentitySelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor" class="notranslate">IdentitySelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)" translate="no">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)" class="notranslate">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ directly or indirectly.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity" translate="no">Identity</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity" class="notranslate">Identity</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Identity { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -52,14 +52,14 @@ directly or indirectly.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor">IdentitySelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor" translate="no">IdentitySelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)" translate="no">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ directly or indirectly.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity">Identity</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_Identity" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.Identity" translate="no">Identity</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Identity { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor">Options()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor" translate="no">Options()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)" translate="no">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options(IamPolicyAnalysisQuery.Types.Options other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation">AnalyzeServiceAccountImpersonation</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation" translate="no">AnalyzeServiceAccountImpersonation</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool AnalyzeServiceAccountImpersonation { get; set; }</code></pre>
   </div>
@@ -126,7 +126,7 @@ F. And those advanced analysis results will be included in
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups">ExpandGroups</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups" translate="no">ExpandGroups</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandGroups { get; set; }</code></pre>
   </div>
@@ -155,7 +155,7 @@ selector, and this flag is not allowed to set.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources">ExpandResources</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources" translate="no">ExpandResources</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandResources { get; set; }</code></pre>
   </div>
@@ -194,7 +194,7 @@ who have permission P on that folder or any lower resource(ex. project).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles">ExpandRoles</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles" translate="no">ExpandRoles</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandRoles { get; set; }</code></pre>
   </div>
@@ -223,7 +223,7 @@ selector, and this flag is not allowed to set.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup">MaxFanoutsPerGroup</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup" translate="no">MaxFanoutsPerGroup</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MaxFanoutsPerGroup { get; set; }</code></pre>
   </div>
@@ -248,7 +248,7 @@ proper value, and won&apos;t be public in the future.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource">MaxFanoutsPerResource</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource" translate="no">MaxFanoutsPerResource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MaxFanoutsPerResource { get; set; }</code></pre>
   </div>
@@ -274,7 +274,7 @@ public in the future.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges">OutputGroupEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges" translate="no">OutputGroupEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputGroupEdges { get; set; }</code></pre>
   </div>
@@ -299,7 +299,7 @@ Default is false.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges">OutputResourceEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges" translate="no">OutputResourceEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputResourceEdges { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor" translate="no">Options()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor" class="notranslate">Options()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)" translate="no">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)" class="notranslate">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options(IamPolicyAnalysisQuery.Types.Options other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation" translate="no">AnalyzeServiceAccountImpersonation</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_AnalyzeServiceAccountImpersonation" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.AnalyzeServiceAccountImpersonation" class="notranslate">AnalyzeServiceAccountImpersonation</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool AnalyzeServiceAccountImpersonation { get; set; }</code></pre>
   </div>
@@ -126,7 +126,7 @@ F. And those advanced analysis results will be included in
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups" translate="no">ExpandGroups</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandGroups" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandGroups" class="notranslate">ExpandGroups</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandGroups { get; set; }</code></pre>
   </div>
@@ -155,7 +155,7 @@ selector, and this flag is not allowed to set.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources" translate="no">ExpandResources</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandResources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandResources" class="notranslate">ExpandResources</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandResources { get; set; }</code></pre>
   </div>
@@ -194,7 +194,7 @@ who have permission P on that folder or any lower resource(ex. project).</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles" translate="no">ExpandRoles</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_ExpandRoles" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.ExpandRoles" class="notranslate">ExpandRoles</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandRoles { get; set; }</code></pre>
   </div>
@@ -223,7 +223,7 @@ selector, and this flag is not allowed to set.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup" translate="no">MaxFanoutsPerGroup</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerGroup" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerGroup" class="notranslate">MaxFanoutsPerGroup</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MaxFanoutsPerGroup { get; set; }</code></pre>
   </div>
@@ -248,7 +248,7 @@ proper value, and won&apos;t be public in the future.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource" translate="no">MaxFanoutsPerResource</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_MaxFanoutsPerResource" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.MaxFanoutsPerResource" class="notranslate">MaxFanoutsPerResource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int MaxFanoutsPerResource { get; set; }</code></pre>
   </div>
@@ -274,7 +274,7 @@ public in the future.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges" translate="no">OutputGroupEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputGroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputGroupEdges" class="notranslate">OutputGroupEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputGroupEdges { get; set; }</code></pre>
   </div>
@@ -299,7 +299,7 @@ Default is false.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges" translate="no">OutputResourceEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_OutputResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.OutputResourceEdges" class="notranslate">OutputResourceEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputResourceEdges { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -52,14 +52,14 @@ projects.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor">ResourceSelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor" translate="no">ResourceSelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)" translate="no">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ projects.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName">FullResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName" translate="no">FullResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -52,14 +52,14 @@ projects.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor" translate="no">ResourceSelector()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor" class="notranslate">ResourceSelector()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)" translate="no">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)" class="notranslate">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ projects.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName" translate="no">FullResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.FullResourceName" class="notranslate">FullResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor">IamPolicyAnalysisQuery()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor" translate="no">IamPolicyAnalysisQuery()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)" translate="no">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery(IamPolicyAnalysisQuery other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector">AccessSelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector" translate="no">AccessSelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.AccessSelector AccessSelector { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector">IdentitySelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector" translate="no">IdentitySelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.IdentitySelector IdentitySelector { get; set; }</code></pre>
   </div>
@@ -129,7 +129,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options">Options</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options" translate="no">Options</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.Options Options { get; set; }</code></pre>
   </div>
@@ -152,7 +152,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector">ResourceSelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector" translate="no">ResourceSelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.ResourceSelector ResourceSelector { get; set; }</code></pre>
   </div>
@@ -175,7 +175,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope" translate="no">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor" translate="no">IamPolicyAnalysisQuery()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor" class="notranslate">IamPolicyAnalysisQuery()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)" translate="no">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)" class="notranslate">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery(IamPolicyAnalysisQuery other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector" translate="no">AccessSelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_AccessSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.AccessSelector" class="notranslate">AccessSelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.AccessSelector AccessSelector { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector" translate="no">IdentitySelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_IdentitySelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.IdentitySelector" class="notranslate">IdentitySelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.IdentitySelector IdentitySelector { get; set; }</code></pre>
   </div>
@@ -129,7 +129,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options" translate="no">Options</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Options" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Options" class="notranslate">Options</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.Options Options { get; set; }</code></pre>
   </div>
@@ -152,7 +152,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector" translate="no">ResourceSelector</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_ResourceSelector" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.ResourceSelector" class="notranslate">ResourceSelector</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.ResourceSelector ResourceSelector { get; set; }</code></pre>
   </div>
@@ -175,7 +175,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope" translate="no">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Scope" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Scope" class="notranslate">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor">Access()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor" translate="no">Access()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)">Access(IamPolicyAnalysisResult.Types.Access)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)" translate="no">Access(IamPolicyAnalysisResult.Types.Access)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access(IamPolicyAnalysisResult.Types.Access other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState" translate="no">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase">OneofAccessCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase" translate="no">OneofAccessCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase OneofAccessCase { get; }</code></pre>
   </div>
@@ -128,7 +128,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission">Permission</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission" translate="no">Permission</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Permission { get; set; }</code></pre>
   </div>
@@ -151,7 +151,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role">Role</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role" translate="no">Role</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Role { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor" translate="no">Access()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor" class="notranslate">Access()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)" translate="no">Access(IamPolicyAnalysisResult.Types.Access)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)" class="notranslate">Access(IamPolicyAnalysisResult.Types.Access)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access(IamPolicyAnalysisResult.Types.Access other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState" translate="no">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.AnalysisState" class="notranslate">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase" translate="no">OneofAccessCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessCase" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessCase" class="notranslate">OneofAccessCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase OneofAccessCase { get; }</code></pre>
   </div>
@@ -128,7 +128,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission" translate="no">Permission</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Permission" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Permission" class="notranslate">Permission</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Permission { get; set; }</code></pre>
   </div>
@@ -151,7 +151,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role" translate="no">Role</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_Role" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.Role" class="notranslate">Role</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Role { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -65,14 +65,14 @@ combinations.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor" translate="no">AccessControlList()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor" class="notranslate">AccessControlList()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)" translate="no">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)" class="notranslate">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList other)</code></pre>
   </div>
@@ -98,7 +98,7 @@ combinations.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses" translate="no">Accesses</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses" class="notranslate">Accesses</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Access&gt; Accesses { get; }</code></pre>
   </div>
@@ -125,7 +125,7 @@ combinations.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges" translate="no">ResourceEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges" class="notranslate">ResourceEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; ResourceEdges { get; }</code></pre>
   </div>
@@ -152,7 +152,7 @@ present only if the output_resource_edges option is enabled in request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources" translate="no">Resources</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources" class="notranslate">Resources</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Resource&gt; Resources { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -65,14 +65,14 @@ combinations.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor">AccessControlList()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor" translate="no">AccessControlList()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)" translate="no">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList other)</code></pre>
   </div>
@@ -98,7 +98,7 @@ combinations.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses">Accesses</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Accesses" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Accesses" translate="no">Accesses</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Access&gt; Accesses { get; }</code></pre>
   </div>
@@ -125,7 +125,7 @@ combinations.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges">ResourceEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_ResourceEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.ResourceEdges" translate="no">ResourceEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; ResourceEdges { get; }</code></pre>
   </div>
@@ -152,7 +152,7 @@ present only if the output_resource_edges option is enabled in request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources">Resources</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_Resources" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.Resources" translate="no">Resources</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Resource&gt; Resources { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor">Edge()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor" translate="no">Edge()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)" translate="no">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge(IamPolicyAnalysisResult.Types.Edge other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode">SourceNode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode" translate="no">SourceNode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string SourceNode { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ name for a resource node or an email of an identity.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode">TargetNode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode" translate="no">TargetNode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TargetNode { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor" translate="no">Edge()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor" class="notranslate">Edge()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)" translate="no">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)" class="notranslate">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge(IamPolicyAnalysisResult.Types.Edge other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode" translate="no">SourceNode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_SourceNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.SourceNode" class="notranslate">SourceNode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string SourceNode { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ name for a resource node or an email of an identity.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode" translate="no">TargetNode</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_TargetNode" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.TargetNode" class="notranslate">TargetNode</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TargetNode { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -52,14 +52,14 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor" translate="no">Identity()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor" class="notranslate">Identity()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)" translate="no">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)" class="notranslate">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity(IamPolicyAnalysisResult.Types.Identity other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState" translate="no">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState" class="notranslate">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -52,14 +52,14 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor">Identity()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor" translate="no">Identity()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)" translate="no">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity(IamPolicyAnalysisResult.Types.Identity other)</code></pre>
   </div>
@@ -85,7 +85,7 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.AnalysisState" translate="no">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -108,7 +108,7 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_Name" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor" translate="no">IdentityList()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor" class="notranslate">IdentityList()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)" translate="no">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)" class="notranslate">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList(IamPolicyAnalysisResult.Types.IdentityList other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges" translate="no">GroupEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges" class="notranslate">GroupEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; GroupEdges { get; }</code></pre>
   </div>
@@ -112,7 +112,7 @@ request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities" translate="no">Identities</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities" class="notranslate">Identities</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Identity&gt; Identities { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor">IdentityList()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor" translate="no">IdentityList()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)" translate="no">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList(IamPolicyAnalysisResult.Types.IdentityList other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges">GroupEdges</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_GroupEdges" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.GroupEdges" translate="no">GroupEdges</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; GroupEdges { get; }</code></pre>
   </div>
@@ -112,7 +112,7 @@ request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities">Identities</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_Identities" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.Identities" translate="no">Identities</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Identity&gt; Identities { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor">Resource()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor" translate="no">Resource()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)" translate="no">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(IamPolicyAnalysisResult.Types.Resource other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState" translate="no">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName">FullResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName" translate="no">FullResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor" translate="no">Resource()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor" class="notranslate">Resource()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)" translate="no">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)" class="notranslate">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(IamPolicyAnalysisResult.Types.Resource other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState" translate="no">AnalysisState</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_AnalysisState" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.AnalysisState" class="notranslate">AnalysisState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName" translate="no">FullResourceName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_FullResourceName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.FullResourceName" class="notranslate">FullResourceName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -51,14 +51,14 @@ access control lists.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor">IamPolicyAnalysisResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor" translate="no">IamPolicyAnalysisResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)" translate="no">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult(IamPolicyAnalysisResult other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ access control lists.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists">AccessControlLists</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists" translate="no">AccessControlLists</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.AccessControlList&gt; AccessControlLists { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName">AttachedResourceFullName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName" translate="no">AttachedResourceFullName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AttachedResourceFullName { get; set; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored" translate="no">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -161,7 +161,7 @@ successfully finished.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding">IamBinding</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding" translate="no">IamBinding</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Binding IamBinding { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ successfully finished.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList">IdentityList</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList" translate="no">IdentityList</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.IdentityList IdentityList { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -51,14 +51,14 @@ access control lists.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor" translate="no">IamPolicyAnalysisResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor" class="notranslate">IamPolicyAnalysisResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)" translate="no">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)" class="notranslate">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult(IamPolicyAnalysisResult other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ access control lists.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists" translate="no">AccessControlLists</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AccessControlLists" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AccessControlLists" class="notranslate">AccessControlLists</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.AccessControlList&gt; AccessControlLists { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ request.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName" translate="no">AttachedResourceFullName</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_AttachedResourceFullName" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.AttachedResourceFullName" class="notranslate">AttachedResourceFullName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AttachedResourceFullName { get; set; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored" translate="no">FullyExplored</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_FullyExplored" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.FullyExplored" class="notranslate">FullyExplored</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
@@ -161,7 +161,7 @@ successfully finished.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding" translate="no">IamBinding</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IamBinding" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IamBinding" class="notranslate">IamBinding</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Binding IamBinding { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ successfully finished.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList" translate="no">IdentityList</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_IdentityList" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.IdentityList" class="notranslate">IdentityList</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.IdentityList IdentityList { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -51,14 +51,14 @@ resource, an identity or an access.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor" translate="no">IamPolicyAnalysisState()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor" class="notranslate">IamPolicyAnalysisState()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)" translate="no">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)" class="notranslate">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState(IamPolicyAnalysisState other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ resource, an identity or an access.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause" translate="no">Cause</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause" class="notranslate">Cause</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Cause { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ resource, an identity or an access.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code" translate="no">Code</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code" class="notranslate">Code</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Code Code { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -51,14 +51,14 @@ resource, an identity or an access.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor">IamPolicyAnalysisState()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor" translate="no">IamPolicyAnalysisState()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)" translate="no">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState(IamPolicyAnalysisState other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ resource, an identity or an access.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause">Cause</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Cause" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Cause" translate="no">Cause</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Cause { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ resource, an identity or an access.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code">Code</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState_Code" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.Code" translate="no">Code</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Code Code { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor" translate="no">Permissions()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor" class="notranslate">Permissions()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)" translate="no">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)" class="notranslate">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions__" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_" translate="no">Permissions_</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_" class="notranslate">Permissions_</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions_ { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor">Permissions()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor" translate="no">Permissions()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)" translate="no">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions__" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_">Permissions_</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.Permissions_" translate="no">Permissions_</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions_ { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor">Explanation()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor" translate="no">Explanation()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)" translate="no">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation(IamPolicySearchResult.Types.Explanation other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions">MatchedPermissions</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions" translate="no">MatchedPermissions</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, IamPolicySearchResult.Types.Explanation.Types.Permissions&gt; MatchedPermissions { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor" translate="no">Explanation()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor" class="notranslate">Explanation()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)" translate="no">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)" class="notranslate">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation(IamPolicySearchResult.Types.Explanation other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions" translate="no">MatchedPermissions</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_MatchedPermissions" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.MatchedPermissions" class="notranslate">MatchedPermissions</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, IamPolicySearchResult.Types.Explanation.Types.Permissions&gt; MatchedPermissions { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor">IamPolicySearchResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor" translate="no">IamPolicySearchResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)">IamPolicySearchResult(IamPolicySearchResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)" translate="no">IamPolicySearchResult(IamPolicySearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult(IamPolicySearchResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation">Explanation</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation" translate="no">Explanation</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult.Types.Explanation Explanation { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ information to explain why the search result matches the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy">Policy</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy" translate="no">Policy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy Policy { get; set; }</code></pre>
   </div>
@@ -143,7 +143,7 @@ policies (e.g., an empty query), this contains all the bindings.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project">Project</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project" translate="no">Project</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>
@@ -174,7 +174,7 @@ orgnization, the project field will be empty.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource">Resource</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource" translate="no">Resource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Resource { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor" translate="no">IamPolicySearchResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor" class="notranslate">IamPolicySearchResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)" translate="no">IamPolicySearchResult(IamPolicySearchResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)" class="notranslate">IamPolicySearchResult(IamPolicySearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult(IamPolicySearchResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation" translate="no">Explanation</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Explanation" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Explanation" class="notranslate">Explanation</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult.Types.Explanation Explanation { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ information to explain why the search result matches the query.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy" translate="no">Policy</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Policy" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Policy" class="notranslate">Policy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy Policy { get; set; }</code></pre>
   </div>
@@ -143,7 +143,7 @@ policies (e.g., an empty query), this contains all the bindings.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project" translate="no">Project</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Project" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Project" class="notranslate">Project</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>
@@ -174,7 +174,7 @@ orgnization, the project field will be empty.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource*"></a>
-  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource" translate="no">Resource</h3>
+  <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Resource" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Resource" class="notranslate">Resource</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Resource { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor" translate="no">ListFeedsRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor" class="notranslate">ListFeedsRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)" translate="no">ListFeedsRequest(ListFeedsRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)" class="notranslate">ListFeedsRequest(ListFeedsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest(ListFeedsRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent" translate="no">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent" class="notranslate">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor">ListFeedsRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor" translate="no">ListFeedsRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)">ListFeedsRequest(ListFeedsRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)" translate="no">ListFeedsRequest(ListFeedsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest(ListFeedsRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest_Parent" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.Parent" translate="no">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -49,14 +49,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor" translate="no">ListFeedsResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor" class="notranslate">ListFeedsResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)" translate="no">ListFeedsResponse(ListFeedsResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)" class="notranslate">ListFeedsResponse(ListFeedsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse(ListFeedsResponse other)</code></pre>
   </div>
@@ -82,7 +82,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds" translate="no">Feeds</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds" class="notranslate">Feeds</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Feed&gt; Feeds { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -49,14 +49,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor">ListFeedsResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor" translate="no">ListFeedsResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)">ListFeedsResponse(ListFeedsResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)" translate="no">ListFeedsResponse(ListFeedsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse(ListFeedsResponse other)</code></pre>
   </div>
@@ -82,7 +82,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds">Feeds</h3>
+  <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse_Feeds" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.Feeds" translate="no">Feeds</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Feed&gt; Feeds { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor" translate="no">OutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor" class="notranslate">OutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)" translate="no">OutputConfig(OutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)" class="notranslate">OutputConfig(OutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig(OutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination" translate="no">BigqueryDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination" class="notranslate">BigqueryDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ proto as columns in BigQuery.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase" translate="no">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase" class="notranslate">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -129,7 +129,7 @@ proto as columns in BigQuery.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination" translate="no">GcsDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination" class="notranslate">GcsDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination GcsDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor">OutputConfig()</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor" translate="no">OutputConfig()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)">OutputConfig(OutputConfig)</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)" translate="no">OutputConfig(OutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig(OutputConfig other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination">BigqueryDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_BigqueryDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.BigqueryDestination" translate="no">BigqueryDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ proto as columns in BigQuery.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase_" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase">DestinationCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_DestinationCase" data-uid="Google.Cloud.Asset.V1.OutputConfig.DestinationCase" translate="no">DestinationCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
@@ -129,7 +129,7 @@ proto as columns in BigQuery.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination_" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination">GcsDestination</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputConfig_GcsDestination" data-uid="Google.Cloud.Asset.V1.OutputConfig.GcsDestination" translate="no">GcsDestination</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination GcsDestination { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor">OutputResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor" translate="no">OutputResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)">OutputResult(OutputResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)" translate="no">OutputResult(OutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult(OutputResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult_GcsResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult_GcsResult" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult">GcsResult</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult_GcsResult" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult" translate="no">GcsResult</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult GcsResult { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputResult_ResultCase_" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult_ResultCase" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase">ResultCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult_ResultCase" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase" translate="no">ResultCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult.ResultOneofCase ResultCase { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor" translate="no">OutputResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor" class="notranslate">OutputResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)" translate="no">OutputResult(OutputResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)" class="notranslate">OutputResult(OutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult(OutputResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_OutputResult_GcsResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult_GcsResult" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult" translate="no">GcsResult</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult_GcsResult" data-uid="Google.Cloud.Asset.V1.OutputResult.GcsResult" class="notranslate">GcsResult</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult GcsResult { get; set; }</code></pre>
   </div>
@@ -106,7 +106,7 @@
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_OutputResult_ResultCase_" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase*"></a>
-  <h3 id="Google_Cloud_Asset_V1_OutputResult_ResultCase" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase" translate="no">ResultCase</h3>
+  <h3 id="Google_Cloud_Asset_V1_OutputResult_ResultCase" data-uid="Google.Cloud.Asset.V1.OutputResult.ResultCase" class="notranslate">ResultCase</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult.ResultOneofCase ResultCase { get; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor">PubsubDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor" translate="no">PubsubDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)">PubsubDestination(PubsubDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)" translate="no">PubsubDestination(PubsubDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination(PubsubDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination_Topic_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination_Topic" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic">Topic</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination_Topic" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic" translate="no">Topic</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Topic { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor" translate="no">PubsubDestination()</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor" class="notranslate">PubsubDestination()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)" translate="no">PubsubDestination(PubsubDestination)</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)" class="notranslate">PubsubDestination(PubsubDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination(PubsubDestination other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_PubsubDestination_Topic_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic*"></a>
-  <h3 id="Google_Cloud_Asset_V1_PubsubDestination_Topic" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic" translate="no">Topic</h3>
+  <h3 id="Google_Cloud_Asset_V1_PubsubDestination_Topic" data-uid="Google.Cloud.Asset.V1.PubsubDestination.Topic" class="notranslate">Topic</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Topic { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource__ctor" data-uid="Google.Cloud.Asset.V1.Resource.#ctor">Resource()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource__ctor" data-uid="Google.Cloud.Asset.V1.Resource.#ctor" translate="no">Resource()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)">Resource(Resource)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)" translate="no">Resource(Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(Resource other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource_Data_" data-uid="Google.Cloud.Asset.V1.Resource.Data*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Data" data-uid="Google.Cloud.Asset.V1.Resource.Data">Data</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Data" data-uid="Google.Cloud.Asset.V1.Resource.Data" translate="no">Data</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct Data { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ and may not be present.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri">DiscoveryDocumentUri</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri" translate="no">DiscoveryDocumentUri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryDocumentUri { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ discovery document, such as Cloud Bigtable.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryName_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryName" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName">DiscoveryName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryName" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName" translate="no">DiscoveryName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryName { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@ discovery document, such as Cloud Bigtable.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Location_" data-uid="Google.Cloud.Asset.V1.Resource.Location*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Location" data-uid="Google.Cloud.Asset.V1.Resource.Location">Location</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Location" data-uid="Google.Cloud.Asset.V1.Resource.Location" translate="no">Location</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ For more information, see <a href="https://cloud.google.com/about/locations/">ht
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Parent_" data-uid="Google.Cloud.Asset.V1.Resource.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Parent" data-uid="Google.Cloud.Asset.V1.Resource.Parent">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Parent" data-uid="Google.Cloud.Asset.V1.Resource.Parent" translate="no">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -216,7 +216,7 @@ Example:
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_ResourceUrl_" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_ResourceUrl" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl">ResourceUrl</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_ResourceUrl" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl" translate="no">ResourceUrl</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ResourceUrl { get; set; }</code></pre>
   </div>
@@ -242,7 +242,7 @@ URL returns the resource itself. Example:
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Version_" data-uid="Google.Cloud.Asset.V1.Resource.Version*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Version" data-uid="Google.Cloud.Asset.V1.Resource.Version">Version</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Version" data-uid="Google.Cloud.Asset.V1.Resource.Version" translate="no">Version</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Version { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource__ctor" data-uid="Google.Cloud.Asset.V1.Resource.#ctor" translate="no">Resource()</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource__ctor" data-uid="Google.Cloud.Asset.V1.Resource.#ctor" class="notranslate">Resource()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)" translate="no">Resource(Resource)</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)" class="notranslate">Resource(Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(Resource other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_Resource_Data_" data-uid="Google.Cloud.Asset.V1.Resource.Data*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Data" data-uid="Google.Cloud.Asset.V1.Resource.Data" translate="no">Data</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Data" data-uid="Google.Cloud.Asset.V1.Resource.Data" class="notranslate">Data</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct Data { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ and may not be present.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri" translate="no">DiscoveryDocumentUri</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryDocumentUri" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryDocumentUri" class="notranslate">DiscoveryDocumentUri</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryDocumentUri { get; set; }</code></pre>
   </div>
@@ -134,7 +134,7 @@ discovery document, such as Cloud Bigtable.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_DiscoveryName_" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryName" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName" translate="no">DiscoveryName</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_DiscoveryName" data-uid="Google.Cloud.Asset.V1.Resource.DiscoveryName" class="notranslate">DiscoveryName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryName { get; set; }</code></pre>
   </div>
@@ -160,7 +160,7 @@ discovery document, such as Cloud Bigtable.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Location_" data-uid="Google.Cloud.Asset.V1.Resource.Location*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Location" data-uid="Google.Cloud.Asset.V1.Resource.Location" translate="no">Location</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Location" data-uid="Google.Cloud.Asset.V1.Resource.Location" class="notranslate">Location</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ For more information, see <a href="https://cloud.google.com/about/locations/">ht
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Parent_" data-uid="Google.Cloud.Asset.V1.Resource.Parent*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Parent" data-uid="Google.Cloud.Asset.V1.Resource.Parent" translate="no">Parent</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Parent" data-uid="Google.Cloud.Asset.V1.Resource.Parent" class="notranslate">Parent</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
@@ -216,7 +216,7 @@ Example:
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_ResourceUrl_" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_ResourceUrl" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl" translate="no">ResourceUrl</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_ResourceUrl" data-uid="Google.Cloud.Asset.V1.Resource.ResourceUrl" class="notranslate">ResourceUrl</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ResourceUrl { get; set; }</code></pre>
   </div>
@@ -242,7 +242,7 @@ URL returns the resource itself. Example:
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_Resource_Version_" data-uid="Google.Cloud.Asset.V1.Resource.Version*"></a>
-  <h3 id="Google_Cloud_Asset_V1_Resource_Version" data-uid="Google.Cloud.Asset.V1.Resource.Version" translate="no">Version</h3>
+  <h3 id="Google_Cloud_Asset_V1_Resource_Version" data-uid="Google.Cloud.Asset.V1.Resource.Version" class="notranslate">Version</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Version { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor" translate="no">ResourceSearchResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor" class="notranslate">ResourceSearchResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)" translate="no">ResourceSearchResult(ResourceSearchResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)" class="notranslate">ResourceSearchResult(ResourceSearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult(ResourceSearchResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes" translate="no">AdditionalAttributes</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes" class="notranslate">AdditionalAttributes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct AdditionalAttributes { get; set; }</code></pre>
   </div>
@@ -123,7 +123,7 @@ version.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType" translate="no">AssetType</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType" class="notranslate">AssetType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
@@ -150,7 +150,7 @@ version.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Description_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Description" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description" translate="no">Description</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Description" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description" class="notranslate">Description</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Description { get; set; }</code></pre>
   </div>
@@ -179,7 +179,7 @@ could be up to 1M bytes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName" translate="no">DisplayName</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName" class="notranslate">DisplayName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DisplayName { get; set; }</code></pre>
   </div>
@@ -207,7 +207,7 @@ could be up to 1M bytes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels" translate="no">Labels</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels" class="notranslate">Labels</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, string&gt; Labels { get; }</code></pre>
   </div>
@@ -240,7 +240,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Location_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Location" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location" translate="no">Location</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Location" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location" class="notranslate">Location</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
@@ -269,7 +269,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Name_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Name" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name" translate="no">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Name" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name" class="notranslate">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
@@ -301,7 +301,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags" translate="no">NetworkTags</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags" class="notranslate">NetworkTags</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; NetworkTags { get; }</code></pre>
   </div>
@@ -332,7 +332,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Project_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Project" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project" translate="no">Project</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Project" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project" class="notranslate">Project</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor">ResourceSearchResult()</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor" translate="no">ResourceSearchResult()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)">ResourceSearchResult(ResourceSearchResult)</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)" translate="no">ResourceSearchResult(ResourceSearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult(ResourceSearchResult other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes">AdditionalAttributes</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AdditionalAttributes" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AdditionalAttributes" translate="no">AdditionalAttributes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct AdditionalAttributes { get; set; }</code></pre>
   </div>
@@ -123,7 +123,7 @@ version.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType">AssetType</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_AssetType" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.AssetType" translate="no">AssetType</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
@@ -150,7 +150,7 @@ version.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Description_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Description" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description">Description</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Description" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Description" translate="no">Description</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Description { get; set; }</code></pre>
   </div>
@@ -179,7 +179,7 @@ could be up to 1M bytes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName">DisplayName</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_DisplayName" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.DisplayName" translate="no">DisplayName</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DisplayName { get; set; }</code></pre>
   </div>
@@ -207,7 +207,7 @@ could be up to 1M bytes.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels">Labels</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Labels" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Labels" translate="no">Labels</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, string&gt; Labels { get; }</code></pre>
   </div>
@@ -240,7 +240,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Location_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Location" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location">Location</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Location" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Location" translate="no">Location</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
@@ -269,7 +269,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Name_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Name" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name">Name</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Name" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Name" translate="no">Name</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
@@ -301,7 +301,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags">NetworkTags</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_NetworkTags" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.NetworkTags" translate="no">NetworkTags</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; NetworkTags { get; }</code></pre>
   </div>
@@ -332,7 +332,7 @@ for more information.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult_Project_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project*"></a>
-  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Project" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project">Project</h3>
+  <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult_Project" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.Project" translate="no">Project</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor">SearchAllIamPoliciesRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor" translate="no">SearchAllIamPoliciesRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)" translate="no">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize">PageSize</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize" translate="no">PageSize</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken">PageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken" translate="no">PageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
@@ -136,7 +136,7 @@ identical to those in the previous call.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query">Query</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query" translate="no">Query</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope" translate="no">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor" translate="no">SearchAllIamPoliciesRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor" class="notranslate">SearchAllIamPoliciesRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)" translate="no">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)" class="notranslate">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize" translate="no">PageSize</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageSize" class="notranslate">PageSize</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken" translate="no">PageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.PageToken" class="notranslate">PageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
@@ -136,7 +136,7 @@ identical to those in the previous call.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query" translate="no">Query</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Query" class="notranslate">Query</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
@@ -184,7 +184,7 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope" translate="no">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.Scope" class="notranslate">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -53,14 +53,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor">SearchAllIamPoliciesResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor" translate="no">SearchAllIamPoliciesResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)" translate="no">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse other)</code></pre>
   </div>
@@ -86,7 +86,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken">NextPageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken" translate="no">NextPageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ the next set of results, call this method again, using this value as the
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results">Results</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results" translate="no">Results</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicySearchResult&gt; Results { get; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ as the associated resource is returned along with the policy.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator">GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator" translate="no">GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;IamPolicySearchResult&gt; GetEnumerator()</code></pre>
   </div>
@@ -162,7 +162,7 @@ as the associated resource is returned along with the policy.</p>
   <h2 id="eii">Explicit Interface Implementations
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator" translate="no">IEnumerable.GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -53,14 +53,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor" translate="no">SearchAllIamPoliciesResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor" class="notranslate">SearchAllIamPoliciesResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)" translate="no">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)" class="notranslate">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse other)</code></pre>
   </div>
@@ -86,7 +86,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken" translate="no">NextPageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.NextPageToken" class="notranslate">NextPageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ the next set of results, call this method again, using this value as the
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results" translate="no">Results</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.Results" class="notranslate">Results</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicySearchResult&gt; Results { get; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ as the associated resource is returned along with the policy.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator" translate="no">GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.GetEnumerator" class="notranslate">GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;IamPolicySearchResult&gt; GetEnumerator()</code></pre>
   </div>
@@ -162,7 +162,7 @@ as the associated resource is returned along with the policy.</p>
   <h2 id="eii">Explicit Interface Implementations
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator" translate="no">IEnumerable.GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.System#Collections#IEnumerable#GetEnumerator" class="notranslate">IEnumerable.GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor" translate="no">SearchAllResourcesRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor" class="notranslate">SearchAllResourcesRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)" translate="no">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)" class="notranslate">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest(SearchAllResourcesRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes" translate="no">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes" class="notranslate">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ types</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy" translate="no">OrderBy</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy" class="notranslate">OrderBy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrderBy { get; set; }</code></pre>
   </div>
@@ -139,7 +139,7 @@ are not supported.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize" translate="no">PageSize</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize" class="notranslate">PageSize</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
@@ -165,7 +165,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken" translate="no">PageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken" class="notranslate">PageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
@@ -191,7 +191,7 @@ identical to those in the previous call.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query" translate="no">Query</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query" class="notranslate">Query</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
@@ -248,7 +248,7 @@ location.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope" translate="no">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope" class="notranslate">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -51,14 +51,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor">SearchAllResourcesRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor" translate="no">SearchAllResourcesRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)" translate="no">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest(SearchAllResourcesRequest other)</code></pre>
   </div>
@@ -84,7 +84,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes">AssetTypes</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_AssetTypes" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.AssetTypes" translate="no">AssetTypes</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
@@ -109,7 +109,7 @@ types</a>.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy">OrderBy</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_OrderBy" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.OrderBy" translate="no">OrderBy</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrderBy { get; set; }</code></pre>
   </div>
@@ -139,7 +139,7 @@ are not supported.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize">PageSize</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageSize" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageSize" translate="no">PageSize</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
@@ -165,7 +165,7 @@ there could be more results as long as <code>next_page_token</code> is returned.
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken">PageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_PageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.PageToken" translate="no">PageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
@@ -191,7 +191,7 @@ identical to those in the previous call.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query">Query</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Query" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Query" translate="no">Query</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
@@ -248,7 +248,7 @@ location.</li>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope">Scope</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest_Scope" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.Scope" translate="no">Scope</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -53,14 +53,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor">SearchAllResourcesResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor" translate="no">SearchAllResourcesResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)" translate="no">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse(SearchAllResourcesResponse other)</code></pre>
   </div>
@@ -86,7 +86,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken">NextPageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken" translate="no">NextPageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ method again using the value of <code>next_page_token</code> as <code>page_token
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results">Results</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results" translate="no">Results</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;ResourceSearchResult&gt; Results { get; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ standard metadata information.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator">GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator" translate="no">GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;ResourceSearchResult&gt; GetEnumerator()</code></pre>
   </div>
@@ -162,7 +162,7 @@ standard metadata information.</p>
   <h2 id="eii">Explicit Interface Implementations
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator">IEnumerable.GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator" translate="no">IEnumerable.GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -53,14 +53,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor" translate="no">SearchAllResourcesResponse()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor" class="notranslate">SearchAllResourcesResponse()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)" translate="no">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)" class="notranslate">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse(SearchAllResourcesResponse other)</code></pre>
   </div>
@@ -86,7 +86,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken" translate="no">NextPageToken</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_NextPageToken" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.NextPageToken" class="notranslate">NextPageToken</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
@@ -111,7 +111,7 @@ method again using the value of <code>next_page_token</code> as <code>page_token
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results" translate="no">Results</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_Results" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.Results" class="notranslate">Results</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;ResourceSearchResult&gt; Results { get; }</code></pre>
   </div>
@@ -137,7 +137,7 @@ standard metadata information.</p>
   <h2 id="methods">Methods
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator" translate="no">GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.GetEnumerator" class="notranslate">GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;ResourceSearchResult&gt; GetEnumerator()</code></pre>
   </div>
@@ -162,7 +162,7 @@ standard metadata information.</p>
   <h2 id="eii">Explicit Interface Implementations
   </h2>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator*"></a>
-  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator" translate="no">IEnumerable.GetEnumerator()</h3>
+  <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse_System_Collections_IEnumerable_GetEnumerator" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.System#Collections#IEnumerable#GetEnumerator" class="notranslate">IEnumerable.GetEnumerator()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -51,14 +51,14 @@ when it was observed and its status during that window.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor">TemporalAsset()</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor" translate="no">TemporalAsset()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)">TemporalAsset(TemporalAsset)</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)" translate="no">TemporalAsset(TemporalAsset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset(TemporalAsset other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ when it was observed and its status during that window.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Asset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Asset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset">Asset</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Asset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset" translate="no">Asset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset Asset { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ when it was observed and its status during that window.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Deleted_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Deleted" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted">Deleted</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Deleted" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted" translate="no">Deleted</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Deleted { get; set; }</code></pre>
   </div>
@@ -130,7 +130,7 @@ when it was observed and its status during that window.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset">PriorAsset</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset" translate="no">PriorAsset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset PriorAsset { get; set; }</code></pre>
   </div>
@@ -154,7 +154,7 @@ Currently this is only set for responses in Real-Time Feed.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState">PriorAssetState</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState" translate="no">PriorAssetState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset.Types.PriorAssetState PriorAssetState { get; set; }</code></pre>
   </div>
@@ -177,7 +177,7 @@ Currently this is only set for responses in Real-Time Feed.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Window_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Window" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window">Window</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Window" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window" translate="no">Window</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow Window { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -51,14 +51,14 @@ when it was observed and its status during that window.</p>
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor" translate="no">TemporalAsset()</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor" class="notranslate">TemporalAsset()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)" translate="no">TemporalAsset(TemporalAsset)</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)" class="notranslate">TemporalAsset(TemporalAsset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset(TemporalAsset other)</code></pre>
   </div>
@@ -84,7 +84,7 @@ when it was observed and its status during that window.</p>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Asset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Asset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset" translate="no">Asset</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Asset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Asset" class="notranslate">Asset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset Asset { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ when it was observed and its status during that window.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Deleted_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Deleted" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted" translate="no">Deleted</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Deleted" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Deleted" class="notranslate">Deleted</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Deleted { get; set; }</code></pre>
   </div>
@@ -130,7 +130,7 @@ when it was observed and its status during that window.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset" translate="no">PriorAsset</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAsset" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAsset" class="notranslate">PriorAsset</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset PriorAsset { get; set; }</code></pre>
   </div>
@@ -154,7 +154,7 @@ Currently this is only set for responses in Real-Time Feed.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState" translate="no">PriorAssetState</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_PriorAssetState" data-uid="Google.Cloud.Asset.V1.TemporalAsset.PriorAssetState" class="notranslate">PriorAssetState</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset.Types.PriorAssetState PriorAssetState { get; set; }</code></pre>
   </div>
@@ -177,7 +177,7 @@ Currently this is only set for responses in Real-Time Feed.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TemporalAsset_Window_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Window" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window" translate="no">Window</h3>
+  <h3 id="Google_Cloud_Asset_V1_TemporalAsset_Window" data-uid="Google.Cloud.Asset.V1.TemporalAsset.Window" class="notranslate">Window</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow Window { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor" translate="no">TimeWindow()</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor" class="notranslate">TimeWindow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)" translate="no">TimeWindow(TimeWindow)</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)" class="notranslate">TimeWindow(TimeWindow)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow(TimeWindow other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow_EndTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow_EndTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime" translate="no">EndTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow_EndTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime" class="notranslate">EndTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp EndTime { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ timestamp is used instead.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TimeWindow_StartTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow_StartTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime" translate="no">StartTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow_StartTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime" class="notranslate">StartTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp StartTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor">TimeWindow()</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor" translate="no">TimeWindow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)">TimeWindow(TimeWindow)</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)" translate="no">TimeWindow(TimeWindow)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow(TimeWindow other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_TimeWindow_EndTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow_EndTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime">EndTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow_EndTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.EndTime" translate="no">EndTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp EndTime { get; set; }</code></pre>
   </div>
@@ -107,7 +107,7 @@ timestamp is used instead.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_TimeWindow_StartTime_" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime*"></a>
-  <h3 id="Google_Cloud_Asset_V1_TimeWindow_StartTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime">StartTime</h3>
+  <h3 id="Google_Cloud_Asset_V1_TimeWindow_StartTime" data-uid="Google.Cloud.Asset.V1.TimeWindow.StartTime" translate="no">StartTime</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp StartTime { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor">UpdateFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor" translate="no">UpdateFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)">UpdateFeedRequest(UpdateFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)" translate="no">UpdateFeedRequest(UpdateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest(UpdateFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed">Feed</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed" translate="no">Feed</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask">UpdateMask</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask" translate="no">UpdateMask</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask UpdateMask { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -50,14 +50,14 @@
   <h2 id="constructors">Constructors
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor" translate="no">UpdateFeedRequest()</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor" class="notranslate">UpdateFeedRequest()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest()</code></pre>
   </div>
   <div class="markdown level1 summary"></div>
   <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)" translate="no">UpdateFeedRequest(UpdateFeedRequest)</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)" class="notranslate">UpdateFeedRequest(UpdateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest(UpdateFeedRequest other)</code></pre>
   </div>
@@ -83,7 +83,7 @@
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed" translate="no">Feed</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_Feed" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.Feed" class="notranslate">Feed</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
@@ -110,7 +110,7 @@ organizations/organization_number/feeds/feed_id.</p>
     </tbody>
   </table>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask*"></a>
-  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask" translate="no">UpdateMask</h3>
+  <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest_UpdateMask" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.UpdateMask" class="notranslate">UpdateMask</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask UpdateMask { get; set; }</code></pre>
   </div>

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -247,7 +247,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="consts">
   Constants
   </h2>
-        <h3 id="cloud_google_com_go_storage_DeleteAction_SetStorageClassAction" data-uid="cloud.google.com/go/storage.DeleteAction,SetStorageClassAction">DeleteAction, SetStorageClassAction</h3>
+        <h3 id="cloud_google_com_go_storage_DeleteAction_SetStorageClassAction" data-uid="cloud.google.com/go/storage.DeleteAction,SetStorageClassAction" translate="no">DeleteAction, SetStorageClassAction</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 
@@ -263,7 +263,7 @@ These errors can be introspected for more information by type asserting to the r
         <div class="markdown level1 summary"></div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload">NoPayload, JSONPayload</h3>
+        <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload" translate="no">NoPayload, JSONPayload</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Send no payload with notification messages.
@@ -277,7 +277,7 @@ These errors can be introspected for more information by type asserting to the r
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent" translate="no">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Event that occurs when an object is successfully created.
@@ -298,7 +298,7 @@ These errors can be introspected for more information by type asserting to the r
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
+        <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite" translate="no">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// ScopeFullControl grants permissions to manage your
@@ -320,7 +320,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="variables">Variables
   
   </h2>
-        <h3 id="cloud_google_com_go_storage_ErrBucketNotExist_ErrObjectNotExist" data-uid="cloud.google.com/go/storage.ErrBucketNotExist,ErrObjectNotExist">ErrBucketNotExist, ErrObjectNotExist</h3>
+        <h3 id="cloud_google_com_go_storage_ErrBucketNotExist_ErrObjectNotExist" data-uid="cloud.google.com/go/storage.ErrBucketNotExist,ErrObjectNotExist" translate="no">ErrBucketNotExist, ErrObjectNotExist</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">var (
 	// ErrBucketNotExist indicates that the bucket does not exist.
@@ -335,7 +335,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="types">
   Types
   </h2>
-        <h3 id="cloud_google_com_go_storage_ACLEntity" data-uid="cloud.google.com/go/storage.ACLEntity">ACLEntity</h3>
+        <h3 id="cloud_google_com_go_storage_ACLEntity" data-uid="cloud.google.com/go/storage.ACLEntity" translate="no">ACLEntity</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLEntity <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -348,7 +348,7 @@ They are sometimes referred to as grantees.</p>
 </projectid></domain></email></groupid></email></userid></div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers">AllUsers, AllAuthenticatedUsers</h4>
+            <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers" translate="no">AllUsers, AllAuthenticatedUsers</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	AllUsers              <a href="#aclentity">ACLEntity</a> = "allUsers"
@@ -357,7 +357,7 @@ They are sometimes referred to as grantees.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle">ACLHandle</h3>
+                  <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle" translate="no">ACLHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLHandle struct {
 	// contains filtered or unexported fields
@@ -367,7 +367,7 @@ They are sometimes referred to as grantees.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete">func (*ACLHandle) Delete
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete" translate="no">func (*ACLHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -397,7 +397,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List">func (*ACLHandle) List
+            <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List" translate="no">func (*ACLHandle) List
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) List(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (rules []<a href="#aclrule">ACLRule</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -430,7 +430,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set">func (*ACLHandle) Set
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set" translate="no">func (*ACLHandle) Set
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Set(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>, role <a href="#aclrole">ACLRole</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -461,7 +461,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole">ACLRole</h3>
+        <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole" translate="no">ACLRole</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRole <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -469,7 +469,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter">RoleOwner, RoleReader, RoleWriter</h4>
+            <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter" translate="no">RoleOwner, RoleReader, RoleWriter</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	RoleOwner  <a href="#aclrole">ACLRole</a> = "OWNER"
@@ -479,7 +479,7 @@ func main() {
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule">ACLRule</h3>
+                  <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule" translate="no">ACLRule</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRule struct {
 	<a href="#entity">Entity</a>      <a href="#aclentity">ACLEntity</a>
@@ -495,7 +495,7 @@ Google Cloud Storage object or bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs">BucketAttrs</h3>
+        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs" translate="no">BucketAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrs struct {
 	// Name is the name of the bucket.
@@ -609,7 +609,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate">BucketAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate" translate="no">BucketAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrsToUpdate struct {
 	// If set, updates whether the bucket uses versioning.
@@ -676,7 +676,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel">func (*BucketAttrsToUpdate) DeleteLabel
+            <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel" translate="no">func (*BucketAttrsToUpdate) DeleteLabel
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) DeleteLabel(name <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
@@ -685,7 +685,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel">func (*BucketAttrsToUpdate) SetLabel
+                      <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel" translate="no">func (*BucketAttrsToUpdate) SetLabel
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) SetLabel(name, value <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
@@ -694,7 +694,7 @@ call to Bucket.Update.</p>
 in a call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions">BucketConditions</h3>
+                  <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions" translate="no">BucketConditions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketConditions struct {
 	// MetagenerationMatch specifies that the bucket must have the given
@@ -713,7 +713,7 @@ in a call to Bucket.Update.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption">BucketEncryption</h3>
+        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption" translate="no">BucketEncryption</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketEncryption struct {
 	// A Cloud KMS key name, in the form
@@ -727,7 +727,7 @@ in a call to Bucket.Update.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle">BucketHandle</h3>
+        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle" translate="no">BucketHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketHandle struct {
 	// contains filtered or unexported fields
@@ -768,7 +768,7 @@ func main() {
 {% endverbatim %}</code></pre>
         </div>
   
-            <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL">func (*BucketHandle) ACL
+            <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL" translate="no">func (*BucketHandle) ACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -808,7 +808,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification">func (*BucketHandle) AddNotification
+            <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification" translate="no">func (*BucketHandle) AddNotification
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) AddNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, n *<a href="#notification">Notification</a>) (ret *<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -847,7 +847,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs">func (*BucketHandle) Attrs
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs" translate="no">func (*BucketHandle) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -879,7 +879,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create">func (*BucketHandle) Create
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create" translate="no">func (*BucketHandle) Create
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Create(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, attrs *<a href="#bucketattrs">BucketAttrs</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -909,7 +909,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL">func (*BucketHandle) DefaultObjectACL
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL" translate="no">func (*BucketHandle) DefaultObjectACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DefaultObjectACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -949,7 +949,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete">func (*BucketHandle) Delete
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete" translate="no">func (*BucketHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -978,7 +978,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification">func (*BucketHandle) DeleteNotification
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification" translate="no">func (*BucketHandle) DeleteNotification
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DeleteNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, id <a href="https://pkg.go.dev/builtin#string">string</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1013,7 +1013,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM">func (*BucketHandle) IAM
+            <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM" translate="no">func (*BucketHandle) IAM
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) IAM() *<a href="https://pkg.go.dev/cloud.google.com/go/iam">iam</a>.<a href="https://pkg.go.dev/cloud.google.com/go/iam#Handle">Handle</a></code></pre>	
@@ -1051,7 +1051,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If">func (*BucketHandle) If
+            <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If" translate="no">func (*BucketHandle) If
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) If(conds <a href="#bucketconditions">BucketConditions</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1093,7 +1093,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy">func (*BucketHandle) LockRetentionPolicy
+            <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy" translate="no">func (*BucketHandle) LockRetentionPolicy
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) LockRetentionPolicy(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -1137,7 +1137,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications">func (*BucketHandle) Notifications
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications" translate="no">func (*BucketHandle) Notifications
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Notifications(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (n map[<a href="https://pkg.go.dev/builtin#string">string</a>]*<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1173,7 +1173,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object">func (*BucketHandle) Object
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object" translate="no">func (*BucketHandle) Object
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Object(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -1215,7 +1215,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects">func (*BucketHandle) Objects
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects" translate="no">func (*BucketHandle) Objects
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Objects(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, q *<a href="#query">Query</a>) *<a href="#objectiterator">ObjectIterator</a></code></pre>	
@@ -1246,7 +1246,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update">func (*BucketHandle) Update
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update" translate="no">func (*BucketHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1316,7 +1316,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject">func (*BucketHandle) UserProject
+            <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject" translate="no">func (*BucketHandle) UserProject
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) UserProject(projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1357,7 +1357,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator">BucketIterator</h3>
+        <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator" translate="no">BucketIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketIterator struct {
 	// Prefix restricts the iterator to buckets whose names begin with it.
@@ -1370,7 +1370,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next">func (*BucketIterator) Next
+            <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next" translate="no">func (*BucketIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) Next() (*<a href="#bucketattrs">BucketAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1412,7 +1412,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo">func (*BucketIterator) PageInfo
+            <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo" translate="no">func (*BucketIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -1421,7 +1421,7 @@ func main() {
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging">BucketLogging</h3>
+                  <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging" translate="no">BucketLogging</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketLogging struct {
 	// The destination bucket where the current bucket's logs
@@ -1438,7 +1438,7 @@ logs.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly">BucketPolicyOnly</h3>
+        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly" translate="no">BucketPolicyOnly</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketPolicyOnly struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -1454,7 +1454,7 @@ Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite">BucketWebsite</h3>
+        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite" translate="no">BucketWebsite</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketWebsite struct {
 	// If the requested object path is missing, the service will ensure the path has
@@ -1475,7 +1475,7 @@ service behaves when accessing bucket contents as a web site. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS">CORS</h3>
+        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS" translate="no">CORS</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type CORS struct {
 	// MaxAge is the value to return in the Access-Control-Max-Age
@@ -1502,7 +1502,7 @@ service behaves when accessing bucket contents as a web site. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client">Client</h3>
+        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client" translate="no">Client</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Client struct {
 	// contains filtered or unexported fields
@@ -1514,7 +1514,7 @@ The methods of Client are safe for concurrent use by multiple goroutines.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient">func NewClient
+            <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient" translate="no">func NewClient
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func NewClient(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="https://pkg.go.dev/google.golang.org/api/option">option</a>.<a href="https://pkg.go.dev/google.golang.org/api/option#ClientOption">ClientOption</a>) (*<a href="#client">Client</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1578,7 +1578,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket">func (*Client) Bucket
+            <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket" translate="no">func (*Client) Bucket
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Bucket(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1591,7 +1591,7 @@ found at:
   <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets">func (*Client) Buckets
+                      <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets" translate="no">func (*Client) Buckets
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Buckets(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#bucketiterator">BucketIterator</a></code></pre>	
@@ -1623,7 +1623,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close">func (*Client) Close
+            <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close" translate="no">func (*Client) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -1632,7 +1632,7 @@ func main() {
 <p>Close need not be called at program exit.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey">func (*Client) CreateHMACKey
+                      <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey" translate="no">func (*Client) CreateHMACKey
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) CreateHMACKey(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID, serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1665,7 +1665,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle">func (*Client) HMACKeyHandle
+            <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle" translate="no">func (*Client) HMACKeyHandle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) HMACKeyHandle(projectID, accessID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#hmackeyhandle">HMACKeyHandle</a></code></pre>	
@@ -1674,7 +1674,7 @@ func main() {
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys">func (*Client) ListHMACKeys
+                      <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys" translate="no">func (*Client) ListHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ListHMACKeys(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) *<a href="#hmackeysiterator">HMACKeysIterator</a></code></pre>	
@@ -1777,7 +1777,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount">func (*Client) ServiceAccount
+            <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount" translate="no">func (*Client) ServiceAccount
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ServiceAccount(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1785,7 +1785,7 @@ func main() {
             <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer">Composer</h3>
+                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer" translate="no">Composer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Composer struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1807,7 +1807,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run">func (*Composer) Run
+            <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run" translate="no">func (*Composer) Run
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#composer">Composer</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1859,7 +1859,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions">Conditions</h3>
+        <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions" translate="no">Conditions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Conditions struct {
 
@@ -1899,7 +1899,7 @@ for details on how these operate.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier">Copier</h3>
+        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier" translate="no">Copier</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Copier struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1942,7 +1942,7 @@ for details on how these operate.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run">func (*Copier) Run
+            <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run" translate="no">func (*Copier) Run
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#copier">Copier</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2017,7 +2017,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey">HMACKey</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey" translate="no">HMACKey</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKey struct {
 	// The HMAC's secret key.
@@ -2058,7 +2058,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate">HMACKeyAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate" translate="no">HMACKeyAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyAttrsToUpdate struct {
 	// State is required and must be either StateActive or StateInactive.
@@ -2073,7 +2073,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle">HMACKeyHandle</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle" translate="no">HMACKeyHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyHandle struct {
 	// contains filtered or unexported fields
@@ -2084,7 +2084,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete">func (*HMACKeyHandle) Delete
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete" translate="no">func (*HMACKeyHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -2119,7 +2119,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get">func (*HMACKeyHandle) Get
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get" translate="no">func (*HMACKeyHandle) Get
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Get(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2156,7 +2156,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update">func (*HMACKeyHandle) Update
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update" translate="no">func (*HMACKeyHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (h *<a href="#hmackeyhandle">HMACKeyHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, au <a href="#hmackeyattrstoupdate">HMACKeyAttrsToUpdate</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2192,7 +2192,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption">HMACKeyOption</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption" translate="no">HMACKeyOption</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyOption interface {
 	// contains filtered or unexported methods
@@ -2203,7 +2203,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail">func ForHMACKeyServiceAccountEmail
+            <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail" translate="no">func ForHMACKeyServiceAccountEmail
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ForHMACKeyServiceAccountEmail(serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2215,7 +2215,7 @@ of these options are applied, the last email to be set will be used.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys">func ShowDeletedHMACKeys
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys" translate="no">func ShowDeletedHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ShowDeletedHMACKeys() <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2224,7 +2224,7 @@ of these options are applied, the last email to be set will be used.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys">func UserProjectForHMACKeys
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys" translate="no">func UserProjectForHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func UserProjectForHMACKeys(userProjectID <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2235,7 +2235,7 @@ if userProjectID is non-empty.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator">HMACKeysIterator</h3>
+                  <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator" translate="no">HMACKeysIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeysIterator struct {
 	// contains filtered or unexported fields
@@ -2247,7 +2247,7 @@ if userProjectID is non-empty.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next">func (*HMACKeysIterator) Next
+            <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next" translate="no">func (*HMACKeysIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) Next() (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2259,7 +2259,7 @@ calls will return iterator.Done.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo">func (*HMACKeysIterator) PageInfo
+                      <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo" translate="no">func (*HMACKeysIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -2269,7 +2269,7 @@ calls will return iterator.Done.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState">HMACState</h3>
+                  <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState" translate="no">HMACState</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACState <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -2278,7 +2278,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted">Active, Inactive, Deleted</h4>
+            <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted" translate="no">Active, Inactive, Deleted</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// Active is the status for an active key that can be used to sign
@@ -2298,7 +2298,7 @@ calls will return iterator.Done.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle">Lifecycle</h3>
+                  <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle" translate="no">Lifecycle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Lifecycle struct {
 	<a href="#rules">Rules</a> []<a href="#lifecyclerule">LifecycleRule</a>
@@ -2308,7 +2308,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction">LifecycleAction</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction" translate="no">LifecycleAction</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleAction struct {
 	// Type is the type of action to take on matching objects.
@@ -2327,7 +2327,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition">LifecycleCondition</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition" translate="no">LifecycleCondition</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleCondition struct {
 	// AgeInDays is the age of the object in days.
@@ -2384,7 +2384,7 @@ action automatically.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule">LifecycleRule</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule" translate="no">LifecycleRule</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleRule struct {
 	// Action is the action to take when all of the associated conditions are
@@ -2402,7 +2402,7 @@ configured action will automatically be taken on that object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness">Liveness</h3>
+        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness" translate="no">Liveness</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Liveness <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
@@ -2410,7 +2410,7 @@ configured action will automatically be taken on that object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived">LiveAndArchived, Live, Archived</h4>
+            <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived" translate="no">LiveAndArchived, Live, Archived</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// LiveAndArchived includes both live and archived objects.
@@ -2423,7 +2423,7 @@ configured action will automatically be taken on that object.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification">Notification</h3>
+                  <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification" translate="no">Notification</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Notification struct {
 	//The ID of the notification.
@@ -2458,7 +2458,7 @@ events occur in a bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs">ObjectAttrs</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs" translate="no">ObjectAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrs struct {
 	// Bucket is the name of the bucket containing this GCS object.
@@ -2608,7 +2608,7 @@ events occur in a bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate">ObjectAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate" translate="no">ObjectAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrsToUpdate struct {
 	<a href="#eventbasedhold">EventBasedHold</a>     <a href="https://pkg.go.dev/cloud.google.com/go/internal/optional">optional</a>.<a href="https://pkg.go.dev/cloud.google.com/go/internal/optional#Bool">Bool</a>
@@ -2640,7 +2640,7 @@ Metadata, use
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle">ObjectHandle</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle" translate="no">ObjectHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectHandle struct {
 	// contains filtered or unexported fields
@@ -2681,7 +2681,7 @@ func main() {
 {% endverbatim %}</code></pre>
         </div>
   
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL">func (*ObjectHandle) ACL
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL" translate="no">func (*ObjectHandle) ACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -2721,7 +2721,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs">func (*ObjectHandle) Attrs
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs" translate="no">func (*ObjectHandle) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2788,7 +2788,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName">func (*ObjectHandle) BucketName
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName" translate="no">func (*ObjectHandle) BucketName
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) BucketName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -2826,7 +2826,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom">func (*ObjectHandle) ComposerFrom
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom" translate="no">func (*ObjectHandle) ComposerFrom
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) ComposerFrom(srcs ...*<a href="#objecthandle">ObjectHandle</a>) *<a href="#composer">Composer</a></code></pre>	
@@ -2869,7 +2869,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom">func (*ObjectHandle) CopierFrom
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom" translate="no">func (*ObjectHandle) CopierFrom
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) CopierFrom(src *<a href="#objecthandle">ObjectHandle</a>) *<a href="#copier">Copier</a></code></pre>	
@@ -2909,7 +2909,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete">func (*ObjectHandle) Delete
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete" translate="no">func (*ObjectHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -2958,7 +2958,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation">func (*ObjectHandle) Generation
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation" translate="no">func (*ObjectHandle) Generation
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Generation(gen <a href="https://pkg.go.dev/builtin#int64">int64</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3003,7 +3003,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If">func (*ObjectHandle) If
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If" translate="no">func (*ObjectHandle) If
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) If(conds <a href="#conditions">Conditions</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3063,7 +3063,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key">func (*ObjectHandle) Key
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key" translate="no">func (*ObjectHandle) Key
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Key(encryptionKey []<a href="https://pkg.go.dev/builtin#byte">byte</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3103,7 +3103,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader">func (*ObjectHandle) NewRangeReader
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader" translate="no">func (*ObjectHandle) NewRangeReader
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewRangeReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, offset, length <a href="https://pkg.go.dev/builtin#int64">int64</a>) (r *<a href="#reader">Reader</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3215,7 +3215,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader">func (*ObjectHandle) NewReader
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader" translate="no">func (*ObjectHandle) NewReader
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (*<a href="#reader">Reader</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3256,7 +3256,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter">func (*ObjectHandle) NewWriter
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter" translate="no">func (*ObjectHandle) NewWriter
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewWriter(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) *<a href="#writer">Writer</a></code></pre>	
@@ -3295,7 +3295,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName">func (*ObjectHandle) ObjectName
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName" translate="no">func (*ObjectHandle) ObjectName
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ObjectName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3333,7 +3333,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed">func (*ObjectHandle) ReadCompressed
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed" translate="no">func (*ObjectHandle) ReadCompressed
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ReadCompressed(compressed <a href="https://pkg.go.dev/builtin#bool">bool</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3371,7 +3371,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update">func (*ObjectHandle) Update
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update" translate="no">func (*ObjectHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#objectattrstoupdate">ObjectAttrsToUpdate</a>) (oa *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3409,7 +3409,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator">ObjectIterator</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator" translate="no">ObjectIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectIterator struct {
 	// contains filtered or unexported fields
@@ -3420,7 +3420,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next">func (*ObjectIterator) Next
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next" translate="no">func (*ObjectIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) Next() (*<a href="#objectattrs">ObjectAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3471,7 +3471,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo">func (*ObjectIterator) PageInfo
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo" translate="no">func (*ObjectIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -3480,7 +3480,7 @@ func main() {
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields">PolicyV4Fields</h3>
+                  <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields" translate="no">PolicyV4Fields</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PolicyV4Fields struct {
 	// ACL specifies the access control permissions for the object.
@@ -3518,7 +3518,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4">PostPolicyV4</h3>
+        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4" translate="no">PostPolicyV4</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4 struct {
 	// URL is the generated URL that the file upload will be made to.
@@ -3532,7 +3532,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4">func GenerateSignedPostPolicyV4
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4" translate="no">func GenerateSignedPostPolicyV4
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func GenerateSignedPostPolicyV4(bucket, object <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#postpolicyv4options">PostPolicyV4Options</a>) (*<a href="#postpolicyv4">PostPolicyV4</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3616,7 +3616,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition">PostPolicyV4Condition</h3>
+        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition" translate="no">PostPolicyV4Condition</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Condition interface {
 	<a href="https://pkg.go.dev/encoding/json">json</a>.<a href="https://pkg.go.dev/encoding/json#Marshaler">Marshaler</a>
@@ -3628,7 +3628,7 @@ object upload&#39;s multipart form fields will be expected to conform to.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange">func ConditionContentLengthRange
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange" translate="no">func ConditionContentLengthRange
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ConditionContentLengthRange(start, end <a href="https://pkg.go.dev/builtin#uint64">uint64</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
@@ -3637,7 +3637,7 @@ object upload&#39;s multipart form fields will be expected to conform to.</p>
 multipart upload&#39;s range header will be expected to be within.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith">func ConditionStartsWith
+                      <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith" translate="no">func ConditionStartsWith
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ConditionStartsWith(key, value <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
@@ -3646,7 +3646,7 @@ multipart upload&#39;s range header will be expected to be within.</p>
 An empty value will cause this condition to be ignored.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options">PostPolicyV4Options</h3>
+                  <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options" translate="no">PostPolicyV4Options</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Options struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -3721,7 +3721,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam">ProjectTeam</h3>
+        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam" translate="no">ProjectTeam</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ProjectTeam struct {
 	<a href="#projectnumber">ProjectNumber</a> <a href="https://pkg.go.dev/builtin#string">string</a>
@@ -3732,7 +3732,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query">Query</h3>
+        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query" translate="no">Query</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Query struct {
 	// Delimiter returns results in a directory-like fashion.
@@ -3770,7 +3770,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection">func (*Query) SetAttrSelection
+            <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection" translate="no">func (*Query) SetAttrSelection
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (q *<a href="#query">Query</a>) SetAttrSelection(attrs []<a href="https://pkg.go.dev/builtin#string">string</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -3784,7 +3784,7 @@ optimization; for more information, see
 <a href="https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance">https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader">Reader</h3>
+                  <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader" translate="no">Reader</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Reader struct {
 	<a href="#attrs">Attrs</a> <a href="#readerobjectattrs">ReaderObjectAttrs</a>
@@ -3799,7 +3799,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl">func (*Reader) CacheControl
+            <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl" translate="no">func (*Reader) CacheControl
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) CacheControl() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3808,7 +3808,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.CacheControl.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close">func (*Reader) Close
+                      <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close" translate="no">func (*Reader) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -3816,7 +3816,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
             <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding">func (*Reader) ContentEncoding
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding" translate="no">func (*Reader) ContentEncoding
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentEncoding() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3825,7 +3825,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.ContentEncoding.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType">func (*Reader) ContentType
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType" translate="no">func (*Reader) ContentType
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentType() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3834,7 +3834,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.ContentType.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified">func (*Reader) LastModified
+                      <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified" translate="no">func (*Reader) LastModified
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) LastModified() (<a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3843,14 +3843,14 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.LastModified.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read">func (*Reader) Read
+                      <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read" translate="no">func (*Reader) Read
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Read(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (<a href="https://pkg.go.dev/builtin#int">int</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain">func (*Reader) Remain
+                      <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain" translate="no">func (*Reader) Remain
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Remain() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
@@ -3858,7 +3858,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
             <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size">func (*Reader) Size
+                      <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size" translate="no">func (*Reader) Size
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Size() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
@@ -3869,7 +3869,7 @@ calls to Read or Close.</p>
 <p>Deprecated: use Reader.Attrs.Size.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs">ReaderObjectAttrs</h3>
+                  <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs" translate="no">ReaderObjectAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ReaderObjectAttrs struct {
 	// Size is the length of the object's content.
@@ -3911,7 +3911,7 @@ get the full set of attributes, use ObjectHandle.Attrs.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy">RetentionPolicy</h3>
+        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy" translate="no">RetentionPolicy</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type RetentionPolicy struct {
 	// RetentionPeriod specifies the duration that objects need to be
@@ -3944,7 +3944,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions">SignedURLOptions</h3>
+        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions" translate="no">SignedURLOptions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SignedURLOptions struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -4041,7 +4041,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme">SigningScheme</h3>
+        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme" translate="no">SigningScheme</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SigningScheme <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
@@ -4049,7 +4049,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
+            <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4" translate="no">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// SigningSchemeDefault is presently V2 and will change to V4 in the future.
@@ -4064,7 +4064,7 @@ subject to any SLA or deprecation policy.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle">URLStyle</h3>
+                  <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle" translate="no">URLStyle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type URLStyle interface {
 	// contains filtered or unexported methods
@@ -4076,7 +4076,7 @@ default. All non-default options work with V4 scheme only. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname">func BucketBoundHostname
+            <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname" translate="no">func BucketBoundHostname
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func BucketBoundHostname(hostname <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4091,7 +4091,7 @@ for details. Note that for CNAMEs, only HTTP is supported, so Insecure must
 be set to true.<p>
 </object-name></bucket-bound-hostname></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle">func PathStyle
+                      <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle" translate="no">func PathStyle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func PathStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4100,7 +4100,7 @@ be set to true.<p>
 &quot;storage.googleapis.com/<bucket-name>/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle">func VirtualHostedStyle
+                      <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle" translate="no">func VirtualHostedStyle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func VirtualHostedStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4109,7 +4109,7 @@ be set to true.<p>
 hostname, e.g. &quot;<bucket-name>.storage.googleapis.com/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess">UniformBucketLevelAccess</h3>
+                  <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess" translate="no">UniformBucketLevelAccess</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type UniformBucketLevelAccess struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -4125,7 +4125,7 @@ policies.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer">Writer</h3>
+        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer" translate="no">Writer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Writer struct {
 	// ObjectAttrs are optional attributes to set on the object. Any attributes
@@ -4178,7 +4178,7 @@ policies.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs">func (*Writer) Attrs
+            <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs" translate="no">func (*Writer) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Attrs() *<a href="#objectattrs">ObjectAttrs</a></code></pre>	
@@ -4187,7 +4187,7 @@ policies.</p>
 It&#39;s only valid to call it after Close returns nil.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close">func (*Writer) Close
+                      <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close" translate="no">func (*Writer) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -4197,7 +4197,7 @@ If Close doesn&#39;t return an error, metadata about the written object
 can be retrieved by calling Attrs.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError">func (*Writer) CloseWithError
+                      <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError" translate="no">func (*Writer) CloseWithError
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) CloseWithError(err <a href="https://pkg.go.dev/builtin#error">error</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -4207,7 +4207,7 @@ CloseWithError always returns nil.</p>
 <p>Deprecated: cancel the context passed to NewWriter instead.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write">func (*Writer) Write
+                      <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write" translate="no">func (*Writer) Write
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Write(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (n <a href="https://pkg.go.dev/builtin#int">int</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -4322,7 +4322,7 @@ func main() {
     <h2 id="functions">Functions
   
   </h2>
-        <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL">func SignedURL
+        <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL" translate="no">func SignedURL
 </h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">func SignedURL(bucket, name <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#signedurloptions">SignedURLOptions</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -247,7 +247,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="consts">
   Constants
   </h2>
-        <h3 id="cloud_google_com_go_storage_DeleteAction_SetStorageClassAction" data-uid="cloud.google.com/go/storage.DeleteAction,SetStorageClassAction" translate="no">DeleteAction, SetStorageClassAction</h3>
+        <h3 id="cloud_google_com_go_storage_DeleteAction_SetStorageClassAction" data-uid="cloud.google.com/go/storage.DeleteAction,SetStorageClassAction" class="notranslate">DeleteAction, SetStorageClassAction</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 
@@ -263,7 +263,7 @@ These errors can be introspected for more information by type asserting to the r
         <div class="markdown level1 summary"></div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload" translate="no">NoPayload, JSONPayload</h3>
+        <h3 id="cloud_google_com_go_storage_NoPayload_JSONPayload" data-uid="cloud.google.com/go/storage.NoPayload,JSONPayload" class="notranslate">NoPayload, JSONPayload</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Send no payload with notification messages.
@@ -277,7 +277,7 @@ These errors can be introspected for more information by type asserting to the r
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent" translate="no">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectFinalizeEvent_ObjectMetadataUpdateEvent_ObjectDeleteEvent_ObjectArchiveEvent" data-uid="cloud.google.com/go/storage.ObjectFinalizeEvent,ObjectMetadataUpdateEvent,ObjectDeleteEvent,ObjectArchiveEvent" class="notranslate">ObjectFinalizeEvent, ObjectMetadataUpdateEvent, ObjectDeleteEvent, ObjectArchiveEvent</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// Event that occurs when an object is successfully created.
@@ -298,7 +298,7 @@ These errors can be introspected for more information by type asserting to the r
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite" translate="no">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
+        <h3 id="cloud_google_com_go_storage_ScopeFullControl_ScopeReadOnly_ScopeReadWrite" data-uid="cloud.google.com/go/storage.ScopeFullControl,ScopeReadOnly,ScopeReadWrite" class="notranslate">ScopeFullControl, ScopeReadOnly, ScopeReadWrite</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">const (
 	// ScopeFullControl grants permissions to manage your
@@ -320,7 +320,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="variables">Variables
   
   </h2>
-        <h3 id="cloud_google_com_go_storage_ErrBucketNotExist_ErrObjectNotExist" data-uid="cloud.google.com/go/storage.ErrBucketNotExist,ErrObjectNotExist" translate="no">ErrBucketNotExist, ErrObjectNotExist</h3>
+        <h3 id="cloud_google_com_go_storage_ErrBucketNotExist_ErrObjectNotExist" data-uid="cloud.google.com/go/storage.ErrBucketNotExist,ErrObjectNotExist" class="notranslate">ErrBucketNotExist, ErrObjectNotExist</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">var (
 	// ErrBucketNotExist indicates that the bucket does not exist.
@@ -335,7 +335,7 @@ These errors can be introspected for more information by type asserting to the r
     <h2 id="types">
   Types
   </h2>
-        <h3 id="cloud_google_com_go_storage_ACLEntity" data-uid="cloud.google.com/go/storage.ACLEntity" translate="no">ACLEntity</h3>
+        <h3 id="cloud_google_com_go_storage_ACLEntity" data-uid="cloud.google.com/go/storage.ACLEntity" class="notranslate">ACLEntity</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLEntity <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -348,7 +348,7 @@ They are sometimes referred to as grantees.</p>
 </projectid></domain></email></groupid></email></userid></div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers" translate="no">AllUsers, AllAuthenticatedUsers</h4>
+            <h4 id="cloud_google_com_go_storage_AllUsers_AllAuthenticatedUsers" data-uid="cloud.google.com/go/storage.AllUsers,AllAuthenticatedUsers" class="notranslate">AllUsers, AllAuthenticatedUsers</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	AllUsers              <a href="#aclentity">ACLEntity</a> = "allUsers"
@@ -357,7 +357,7 @@ They are sometimes referred to as grantees.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle" translate="no">ACLHandle</h3>
+                  <h3 id="cloud_google_com_go_storage_ACLHandle" data-uid="cloud.google.com/go/storage.ACLHandle" class="notranslate">ACLHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLHandle struct {
 	// contains filtered or unexported fields
@@ -367,7 +367,7 @@ They are sometimes referred to as grantees.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete" translate="no">func (*ACLHandle) Delete
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Delete" data-uid="cloud.google.com/go/storage.ACLHandle.Delete" class="notranslate">func (*ACLHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -397,7 +397,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List" translate="no">func (*ACLHandle) List
+            <h4 id="cloud_google_com_go_storage_ACLHandle_List" data-uid="cloud.google.com/go/storage.ACLHandle.List" class="notranslate">func (*ACLHandle) List
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) List(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (rules []<a href="#aclrule">ACLRule</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -430,7 +430,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set" translate="no">func (*ACLHandle) Set
+            <h4 id="cloud_google_com_go_storage_ACLHandle_Set" data-uid="cloud.google.com/go/storage.ACLHandle.Set" class="notranslate">func (*ACLHandle) Set
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (a *<a href="#aclhandle">ACLHandle</a>) Set(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, entity <a href="#aclentity">ACLEntity</a>, role <a href="#aclrole">ACLRole</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -461,7 +461,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole" translate="no">ACLRole</h3>
+        <h3 id="cloud_google_com_go_storage_ACLRole" data-uid="cloud.google.com/go/storage.ACLRole" class="notranslate">ACLRole</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRole <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -469,7 +469,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter" translate="no">RoleOwner, RoleReader, RoleWriter</h4>
+            <h4 id="cloud_google_com_go_storage_RoleOwner_RoleReader_RoleWriter" data-uid="cloud.google.com/go/storage.RoleOwner,RoleReader,RoleWriter" class="notranslate">RoleOwner, RoleReader, RoleWriter</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	RoleOwner  <a href="#aclrole">ACLRole</a> = "OWNER"
@@ -479,7 +479,7 @@ func main() {
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule" translate="no">ACLRule</h3>
+                  <h3 id="cloud_google_com_go_storage_ACLRule" data-uid="cloud.google.com/go/storage.ACLRule" class="notranslate">ACLRule</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ACLRule struct {
 	<a href="#entity">Entity</a>      <a href="#aclentity">ACLEntity</a>
@@ -495,7 +495,7 @@ Google Cloud Storage object or bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs" translate="no">BucketAttrs</h3>
+        <h3 id="cloud_google_com_go_storage_BucketAttrs" data-uid="cloud.google.com/go/storage.BucketAttrs" class="notranslate">BucketAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrs struct {
 	// Name is the name of the bucket.
@@ -609,7 +609,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate" translate="no">BucketAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_BucketAttrsToUpdate" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate" class="notranslate">BucketAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketAttrsToUpdate struct {
 	// If set, updates whether the bucket uses versioning.
@@ -676,7 +676,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel" translate="no">func (*BucketAttrsToUpdate) DeleteLabel
+            <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_DeleteLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.DeleteLabel" class="notranslate">func (*BucketAttrsToUpdate) DeleteLabel
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) DeleteLabel(name <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
@@ -685,7 +685,7 @@ Read-only fields are ignored by BucketHandle.Create.</p>
 call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel" translate="no">func (*BucketAttrsToUpdate) SetLabel
+                      <h4 id="cloud_google_com_go_storage_BucketAttrsToUpdate_SetLabel" data-uid="cloud.google.com/go/storage.BucketAttrsToUpdate.SetLabel" class="notranslate">func (*BucketAttrsToUpdate) SetLabel
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (ua *<a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) SetLabel(name, value <a href="https://pkg.go.dev/builtin#string">string</a>)</code></pre>	
@@ -694,7 +694,7 @@ call to Bucket.Update.</p>
 in a call to Bucket.Update.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions" translate="no">BucketConditions</h3>
+                  <h3 id="cloud_google_com_go_storage_BucketConditions" data-uid="cloud.google.com/go/storage.BucketConditions" class="notranslate">BucketConditions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketConditions struct {
 	// MetagenerationMatch specifies that the bucket must have the given
@@ -713,7 +713,7 @@ in a call to Bucket.Update.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption" translate="no">BucketEncryption</h3>
+        <h3 id="cloud_google_com_go_storage_BucketEncryption" data-uid="cloud.google.com/go/storage.BucketEncryption" class="notranslate">BucketEncryption</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketEncryption struct {
 	// A Cloud KMS key name, in the form
@@ -727,7 +727,7 @@ in a call to Bucket.Update.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle" translate="no">BucketHandle</h3>
+        <h3 id="cloud_google_com_go_storage_BucketHandle" data-uid="cloud.google.com/go/storage.BucketHandle" class="notranslate">BucketHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketHandle struct {
 	// contains filtered or unexported fields
@@ -738,7 +738,7 @@ Use Client.Bucket to get a handle.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         <h5 id="cloud_google_com_go_storage_BucketHandle_examples">Examples</h5>
-        <h6 translate="no">exists</h6>
+        <h6 class="notranslate">exists</h6>
         <div class="codewrapper">
         <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -768,7 +768,7 @@ func main() {
 {% endverbatim %}</code></pre>
         </div>
   
-            <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL" translate="no">func (*BucketHandle) ACL
+            <h4 id="cloud_google_com_go_storage_BucketHandle_ACL" data-uid="cloud.google.com/go/storage.BucketHandle.ACL" class="notranslate">func (*BucketHandle) ACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -779,7 +779,7 @@ This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_ACL_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -808,7 +808,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification" translate="no">func (*BucketHandle) AddNotification
+            <h4 id="cloud_google_com_go_storage_BucketHandle_AddNotification" data-uid="cloud.google.com/go/storage.BucketHandle.AddNotification" class="notranslate">func (*BucketHandle) AddNotification
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) AddNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, n *<a href="#notification">Notification</a>) (ret *<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -847,7 +847,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs" translate="no">func (*BucketHandle) Attrs
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Attrs" data-uid="cloud.google.com/go/storage.BucketHandle.Attrs" class="notranslate">func (*BucketHandle) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -879,7 +879,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create" translate="no">func (*BucketHandle) Create
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Create" data-uid="cloud.google.com/go/storage.BucketHandle.Create" class="notranslate">func (*BucketHandle) Create
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Create(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, attrs *<a href="#bucketattrs">BucketAttrs</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -909,7 +909,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL" translate="no">func (*BucketHandle) DefaultObjectACL
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL" data-uid="cloud.google.com/go/storage.BucketHandle.DefaultObjectACL" class="notranslate">func (*BucketHandle) DefaultObjectACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DefaultObjectACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -920,7 +920,7 @@ This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_DefaultObjectACL_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -949,7 +949,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete" translate="no">func (*BucketHandle) Delete
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Delete" data-uid="cloud.google.com/go/storage.BucketHandle.Delete" class="notranslate">func (*BucketHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -978,7 +978,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification" translate="no">func (*BucketHandle) DeleteNotification
+            <h4 id="cloud_google_com_go_storage_BucketHandle_DeleteNotification" data-uid="cloud.google.com/go/storage.BucketHandle.DeleteNotification" class="notranslate">func (*BucketHandle) DeleteNotification
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) DeleteNotification(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, id <a href="https://pkg.go.dev/builtin#string">string</a>) (err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1013,7 +1013,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM" translate="no">func (*BucketHandle) IAM
+            <h4 id="cloud_google_com_go_storage_BucketHandle_IAM" data-uid="cloud.google.com/go/storage.BucketHandle.IAM" class="notranslate">func (*BucketHandle) IAM
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) IAM() *<a href="https://pkg.go.dev/cloud.google.com/go/iam">iam</a>.<a href="https://pkg.go.dev/cloud.google.com/go/iam#Handle">Handle</a></code></pre>	
@@ -1022,7 +1022,7 @@ func main() {
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_IAM_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1051,7 +1051,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If" translate="no">func (*BucketHandle) If
+            <h4 id="cloud_google_com_go_storage_BucketHandle_If" data-uid="cloud.google.com/go/storage.BucketHandle.If" class="notranslate">func (*BucketHandle) If
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) If(conds <a href="#bucketconditions">BucketConditions</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1064,7 +1064,7 @@ and MetagenerationNotMatch.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_If_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1093,7 +1093,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy" translate="no">func (*BucketHandle) LockRetentionPolicy
+            <h4 id="cloud_google_com_go_storage_BucketHandle_LockRetentionPolicy" data-uid="cloud.google.com/go/storage.BucketHandle.LockRetentionPolicy" class="notranslate">func (*BucketHandle) LockRetentionPolicy
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) LockRetentionPolicy(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -1137,7 +1137,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications" translate="no">func (*BucketHandle) Notifications
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Notifications" data-uid="cloud.google.com/go/storage.BucketHandle.Notifications" class="notranslate">func (*BucketHandle) Notifications
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Notifications(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (n map[<a href="https://pkg.go.dev/builtin#string">string</a>]*<a href="#notification">Notification</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1173,7 +1173,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object" translate="no">func (*BucketHandle) Object
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Object" data-uid="cloud.google.com/go/storage.BucketHandle.Object" class="notranslate">func (*BucketHandle) Object
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Object(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -1186,7 +1186,7 @@ for valid object names can be found at:
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_Object_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1215,7 +1215,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects" translate="no">func (*BucketHandle) Objects
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Objects" data-uid="cloud.google.com/go/storage.BucketHandle.Objects" class="notranslate">func (*BucketHandle) Objects
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Objects(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, q *<a href="#query">Query</a>) *<a href="#objectiterator">ObjectIterator</a></code></pre>	
@@ -1246,7 +1246,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update" translate="no">func (*BucketHandle) Update
+            <h4 id="cloud_google_com_go_storage_BucketHandle_Update" data-uid="cloud.google.com/go/storage.BucketHandle.Update" class="notranslate">func (*BucketHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#bucketattrstoupdate">BucketAttrsToUpdate</a>) (attrs *<a href="#bucketattrs">BucketAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1280,7 +1280,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">readModifyWrite</h6>
+  <h6 class="notranslate">readModifyWrite</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1316,7 +1316,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject" translate="no">func (*BucketHandle) UserProject
+            <h4 id="cloud_google_com_go_storage_BucketHandle_UserProject" data-uid="cloud.google.com/go/storage.BucketHandle.UserProject" class="notranslate">func (*BucketHandle) UserProject
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (b *<a href="#buckethandle">BucketHandle</a>) UserProject(projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1328,7 +1328,7 @@ project rather than to the bucket&#39;s owning project.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_BucketHandle_UserProject_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1357,7 +1357,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator" translate="no">BucketIterator</h3>
+        <h3 id="cloud_google_com_go_storage_BucketIterator" data-uid="cloud.google.com/go/storage.BucketIterator" class="notranslate">BucketIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketIterator struct {
 	// Prefix restricts the iterator to buckets whose names begin with it.
@@ -1370,7 +1370,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next" translate="no">func (*BucketIterator) Next
+            <h4 id="cloud_google_com_go_storage_BucketIterator_Next" data-uid="cloud.google.com/go/storage.BucketIterator.Next" class="notranslate">func (*BucketIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) Next() (*<a href="#bucketattrs">BucketAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1412,7 +1412,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo" translate="no">func (*BucketIterator) PageInfo
+            <h4 id="cloud_google_com_go_storage_BucketIterator_PageInfo" data-uid="cloud.google.com/go/storage.BucketIterator.PageInfo" class="notranslate">func (*BucketIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#bucketiterator">BucketIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -1421,7 +1421,7 @@ func main() {
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging" translate="no">BucketLogging</h3>
+                  <h3 id="cloud_google_com_go_storage_BucketLogging" data-uid="cloud.google.com/go/storage.BucketLogging" class="notranslate">BucketLogging</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketLogging struct {
 	// The destination bucket where the current bucket's logs
@@ -1438,7 +1438,7 @@ logs.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly" translate="no">BucketPolicyOnly</h3>
+        <h3 id="cloud_google_com_go_storage_BucketPolicyOnly" data-uid="cloud.google.com/go/storage.BucketPolicyOnly" class="notranslate">BucketPolicyOnly</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketPolicyOnly struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -1454,7 +1454,7 @@ Use of UniformBucketLevelAccess is preferred above BucketPolicyOnly.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite" translate="no">BucketWebsite</h3>
+        <h3 id="cloud_google_com_go_storage_BucketWebsite" data-uid="cloud.google.com/go/storage.BucketWebsite" class="notranslate">BucketWebsite</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type BucketWebsite struct {
 	// If the requested object path is missing, the service will ensure the path has
@@ -1475,7 +1475,7 @@ service behaves when accessing bucket contents as a web site. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS" translate="no">CORS</h3>
+        <h3 id="cloud_google_com_go_storage_CORS" data-uid="cloud.google.com/go/storage.CORS" class="notranslate">CORS</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type CORS struct {
 	// MaxAge is the value to return in the Access-Control-Max-Age
@@ -1502,7 +1502,7 @@ service behaves when accessing bucket contents as a web site. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client" translate="no">Client</h3>
+        <h3 id="cloud_google_com_go_storage_Client" data-uid="cloud.google.com/go/storage.Client" class="notranslate">Client</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Client struct {
 	// contains filtered or unexported fields
@@ -1514,7 +1514,7 @@ The methods of Client are safe for concurrent use by multiple goroutines.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient" translate="no">func NewClient
+            <h4 id="cloud_google_com_go_storage_Client_NewClient" data-uid="cloud.google.com/go/storage.Client.NewClient" class="notranslate">func NewClient
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func NewClient(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="https://pkg.go.dev/google.golang.org/api/option">option</a>.<a href="https://pkg.go.dev/google.golang.org/api/option#ClientOption">ClientOption</a>) (*<a href="#client">Client</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1553,7 +1553,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">unauthenticated</h6>
+  <h6 class="notranslate">unauthenticated</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1578,7 +1578,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket" translate="no">func (*Client) Bucket
+            <h4 id="cloud_google_com_go_storage_Client_Bucket" data-uid="cloud.google.com/go/storage.Client.Bucket" class="notranslate">func (*Client) Bucket
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Bucket(name <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#buckethandle">BucketHandle</a></code></pre>	
@@ -1591,7 +1591,7 @@ found at:
   <a href="https://cloud.google.com/storage/docs/bucket-naming">https://cloud.google.com/storage/docs/bucket-naming</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets" translate="no">func (*Client) Buckets
+                      <h4 id="cloud_google_com_go_storage_Client_Buckets" data-uid="cloud.google.com/go/storage.Client.Buckets" class="notranslate">func (*Client) Buckets
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Buckets(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#bucketiterator">BucketIterator</a></code></pre>	
@@ -1623,7 +1623,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close" translate="no">func (*Client) Close
+            <h4 id="cloud_google_com_go_storage_Client_Close" data-uid="cloud.google.com/go/storage.Client.Close" class="notranslate">func (*Client) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -1632,7 +1632,7 @@ func main() {
 <p>Close need not be called at program exit.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey" translate="no">func (*Client) CreateHMACKey
+                      <h4 id="cloud_google_com_go_storage_Client_CreateHMACKey" data-uid="cloud.google.com/go/storage.Client.CreateHMACKey" class="notranslate">func (*Client) CreateHMACKey
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) CreateHMACKey(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID, serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1665,7 +1665,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle" translate="no">func (*Client) HMACKeyHandle
+            <h4 id="cloud_google_com_go_storage_Client_HMACKeyHandle" data-uid="cloud.google.com/go/storage.Client.HMACKeyHandle" class="notranslate">func (*Client) HMACKeyHandle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) HMACKeyHandle(projectID, accessID <a href="https://pkg.go.dev/builtin#string">string</a>) *<a href="#hmackeyhandle">HMACKeyHandle</a></code></pre>	
@@ -1674,7 +1674,7 @@ func main() {
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys" translate="no">func (*Client) ListHMACKeys
+                      <h4 id="cloud_google_com_go_storage_Client_ListHMACKeys" data-uid="cloud.google.com/go/storage.Client.ListHMACKeys" class="notranslate">func (*Client) ListHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ListHMACKeys(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) *<a href="#hmackeysiterator">HMACKeysIterator</a></code></pre>	
@@ -1715,7 +1715,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">forServiceAccountEmail</h6>
+  <h6 class="notranslate">forServiceAccountEmail</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1746,7 +1746,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">showDeletedKeys</h6>
+  <h6 class="notranslate">showDeletedKeys</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -1777,7 +1777,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount" translate="no">func (*Client) ServiceAccount
+            <h4 id="cloud_google_com_go_storage_Client_ServiceAccount" data-uid="cloud.google.com/go/storage.Client.ServiceAccount" class="notranslate">func (*Client) ServiceAccount
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#client">Client</a>) ServiceAccount(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, projectID <a href="https://pkg.go.dev/builtin#string">string</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1785,7 +1785,7 @@ func main() {
             <div class="markdown level1 summary"><p>ServiceAccount fetches the email address of the given project&#39;s Google Cloud Storage service account.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer" translate="no">Composer</h3>
+                  <h3 id="cloud_google_com_go_storage_Composer" data-uid="cloud.google.com/go/storage.Composer" class="notranslate">Composer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Composer struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1807,7 +1807,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run" translate="no">func (*Composer) Run
+            <h4 id="cloud_google_com_go_storage_Composer_Run" data-uid="cloud.google.com/go/storage.Composer.Run" class="notranslate">func (*Composer) Run
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#composer">Composer</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1859,7 +1859,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions" translate="no">Conditions</h3>
+        <h3 id="cloud_google_com_go_storage_Conditions" data-uid="cloud.google.com/go/storage.Conditions" class="notranslate">Conditions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Conditions struct {
 
@@ -1899,7 +1899,7 @@ for details on how these operate.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier" translate="no">Copier</h3>
+        <h3 id="cloud_google_com_go_storage_Copier" data-uid="cloud.google.com/go/storage.Copier" class="notranslate">Copier</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Copier struct {
 	// ObjectAttrs are optional attributes to set on the destination object.
@@ -1942,7 +1942,7 @@ for details on how these operate.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run" translate="no">func (*Copier) Run
+            <h4 id="cloud_google_com_go_storage_Copier_Run" data-uid="cloud.google.com/go/storage.Copier.Run" class="notranslate">func (*Copier) Run
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (c *<a href="#copier">Copier</a>) Run(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -1987,7 +1987,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">progress</h6>
+  <h6 class="notranslate">progress</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2017,7 +2017,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey" translate="no">HMACKey</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKey" data-uid="cloud.google.com/go/storage.HMACKey" class="notranslate">HMACKey</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKey struct {
 	// The HMAC's secret key.
@@ -2058,7 +2058,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate" translate="no">HMACKeyAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyAttrsToUpdate" data-uid="cloud.google.com/go/storage.HMACKeyAttrsToUpdate" class="notranslate">HMACKeyAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyAttrsToUpdate struct {
 	// State is required and must be either StateActive or StateInactive.
@@ -2073,7 +2073,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle" translate="no">HMACKeyHandle</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyHandle" data-uid="cloud.google.com/go/storage.HMACKeyHandle" class="notranslate">HMACKeyHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyHandle struct {
 	// contains filtered or unexported fields
@@ -2084,7 +2084,7 @@ authentication, please visit <a href="https://cloud.google.com/storage/docs/migr
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete" translate="no">func (*HMACKeyHandle) Delete
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Delete" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Delete" class="notranslate">func (*HMACKeyHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -2119,7 +2119,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get" translate="no">func (*HMACKeyHandle) Get
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Get" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Get" class="notranslate">func (*HMACKeyHandle) Get
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (hkh *<a href="#hmackeyhandle">HMACKeyHandle</a>) Get(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2156,7 +2156,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update" translate="no">func (*HMACKeyHandle) Update
+            <h4 id="cloud_google_com_go_storage_HMACKeyHandle_Update" data-uid="cloud.google.com/go/storage.HMACKeyHandle.Update" class="notranslate">func (*HMACKeyHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (h *<a href="#hmackeyhandle">HMACKeyHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, au <a href="#hmackeyattrstoupdate">HMACKeyAttrsToUpdate</a>, opts ...<a href="#hmackeyoption">HMACKeyOption</a>) (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2192,7 +2192,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption" translate="no">HMACKeyOption</h3>
+        <h3 id="cloud_google_com_go_storage_HMACKeyOption" data-uid="cloud.google.com/go/storage.HMACKeyOption" class="notranslate">HMACKeyOption</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeyOption interface {
 	// contains filtered or unexported methods
@@ -2203,7 +2203,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail" translate="no">func ForHMACKeyServiceAccountEmail
+            <h4 id="cloud_google_com_go_storage_HMACKeyOption_ForHMACKeyServiceAccountEmail" data-uid="cloud.google.com/go/storage.HMACKeyOption.ForHMACKeyServiceAccountEmail" class="notranslate">func ForHMACKeyServiceAccountEmail
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ForHMACKeyServiceAccountEmail(serviceAccountEmail <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2215,7 +2215,7 @@ of these options are applied, the last email to be set will be used.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys" translate="no">func ShowDeletedHMACKeys
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_ShowDeletedHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.ShowDeletedHMACKeys" class="notranslate">func ShowDeletedHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ShowDeletedHMACKeys() <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2224,7 +2224,7 @@ of these options are applied, the last email to be set will be used.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys" translate="no">func UserProjectForHMACKeys
+                      <h4 id="cloud_google_com_go_storage_HMACKeyOption_UserProjectForHMACKeys" data-uid="cloud.google.com/go/storage.HMACKeyOption.UserProjectForHMACKeys" class="notranslate">func UserProjectForHMACKeys
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func UserProjectForHMACKeys(userProjectID <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#hmackeyoption">HMACKeyOption</a></code></pre>	
@@ -2235,7 +2235,7 @@ if userProjectID is non-empty.</p>
 <p>This option is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator" translate="no">HMACKeysIterator</h3>
+                  <h3 id="cloud_google_com_go_storage_HMACKeysIterator" data-uid="cloud.google.com/go/storage.HMACKeysIterator" class="notranslate">HMACKeysIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACKeysIterator struct {
 	// contains filtered or unexported fields
@@ -2247,7 +2247,7 @@ if userProjectID is non-empty.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next" translate="no">func (*HMACKeysIterator) Next
+            <h4 id="cloud_google_com_go_storage_HMACKeysIterator_Next" data-uid="cloud.google.com/go/storage.HMACKeysIterator.Next" class="notranslate">func (*HMACKeysIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) Next() (*<a href="#hmackey">HMACKey</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2259,7 +2259,7 @@ calls will return iterator.Done.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo" translate="no">func (*HMACKeysIterator) PageInfo
+                      <h4 id="cloud_google_com_go_storage_HMACKeysIterator_PageInfo" data-uid="cloud.google.com/go/storage.HMACKeysIterator.PageInfo" class="notranslate">func (*HMACKeysIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#hmackeysiterator">HMACKeysIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -2269,7 +2269,7 @@ calls will return iterator.Done.</p>
 <p>This method is EXPERIMENTAL and subject to change or removal without notice.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState" translate="no">HMACState</h3>
+                  <h3 id="cloud_google_com_go_storage_HMACState" data-uid="cloud.google.com/go/storage.HMACState" class="notranslate">HMACState</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type HMACState <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>
         </div>
@@ -2278,7 +2278,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted" translate="no">Active, Inactive, Deleted</h4>
+            <h4 id="cloud_google_com_go_storage_Active_Inactive_Deleted" data-uid="cloud.google.com/go/storage.Active,Inactive,Deleted" class="notranslate">Active, Inactive, Deleted</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// Active is the status for an active key that can be used to sign
@@ -2298,7 +2298,7 @@ calls will return iterator.Done.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle" translate="no">Lifecycle</h3>
+                  <h3 id="cloud_google_com_go_storage_Lifecycle" data-uid="cloud.google.com/go/storage.Lifecycle" class="notranslate">Lifecycle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Lifecycle struct {
 	<a href="#rules">Rules</a> []<a href="#lifecyclerule">LifecycleRule</a>
@@ -2308,7 +2308,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction" translate="no">LifecycleAction</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleAction" data-uid="cloud.google.com/go/storage.LifecycleAction" class="notranslate">LifecycleAction</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleAction struct {
 	// Type is the type of action to take on matching objects.
@@ -2327,7 +2327,7 @@ calls will return iterator.Done.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition" translate="no">LifecycleCondition</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleCondition" data-uid="cloud.google.com/go/storage.LifecycleCondition" class="notranslate">LifecycleCondition</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleCondition struct {
 	// AgeInDays is the age of the object in days.
@@ -2384,7 +2384,7 @@ action automatically.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule" translate="no">LifecycleRule</h3>
+        <h3 id="cloud_google_com_go_storage_LifecycleRule" data-uid="cloud.google.com/go/storage.LifecycleRule" class="notranslate">LifecycleRule</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type LifecycleRule struct {
 	// Action is the action to take when all of the associated conditions are
@@ -2402,7 +2402,7 @@ configured action will automatically be taken on that object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness" translate="no">Liveness</h3>
+        <h3 id="cloud_google_com_go_storage_Liveness" data-uid="cloud.google.com/go/storage.Liveness" class="notranslate">Liveness</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Liveness <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
@@ -2410,7 +2410,7 @@ configured action will automatically be taken on that object.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived" translate="no">LiveAndArchived, Live, Archived</h4>
+            <h4 id="cloud_google_com_go_storage_LiveAndArchived_Live_Archived" data-uid="cloud.google.com/go/storage.LiveAndArchived,Live,Archived" class="notranslate">LiveAndArchived, Live, Archived</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// LiveAndArchived includes both live and archived objects.
@@ -2423,7 +2423,7 @@ configured action will automatically be taken on that object.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification" translate="no">Notification</h3>
+                  <h3 id="cloud_google_com_go_storage_Notification" data-uid="cloud.google.com/go/storage.Notification" class="notranslate">Notification</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Notification struct {
 	//The ID of the notification.
@@ -2458,7 +2458,7 @@ events occur in a bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs" translate="no">ObjectAttrs</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectAttrs" data-uid="cloud.google.com/go/storage.ObjectAttrs" class="notranslate">ObjectAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrs struct {
 	// Bucket is the name of the bucket containing this GCS object.
@@ -2608,7 +2608,7 @@ events occur in a bucket.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate" translate="no">ObjectAttrsToUpdate</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectAttrsToUpdate" data-uid="cloud.google.com/go/storage.ObjectAttrsToUpdate" class="notranslate">ObjectAttrsToUpdate</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectAttrsToUpdate struct {
 	<a href="#eventbasedhold">EventBasedHold</a>     <a href="https://pkg.go.dev/cloud.google.com/go/internal/optional">optional</a>.<a href="https://pkg.go.dev/cloud.google.com/go/internal/optional#Bool">Bool</a>
@@ -2640,7 +2640,7 @@ Metadata, use
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle" translate="no">ObjectHandle</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectHandle" data-uid="cloud.google.com/go/storage.ObjectHandle" class="notranslate">ObjectHandle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectHandle struct {
 	// contains filtered or unexported fields
@@ -2651,7 +2651,7 @@ Use BucketHandle.Object to get a handle.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         <h5 id="cloud_google_com_go_storage_ObjectHandle_examples">Examples</h5>
-        <h6 translate="no">exists</h6>
+        <h6 class="notranslate">exists</h6>
         <div class="codewrapper">
         <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2681,7 +2681,7 @@ func main() {
 {% endverbatim %}</code></pre>
         </div>
   
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL" translate="no">func (*ObjectHandle) ACL
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ACL" data-uid="cloud.google.com/go/storage.ObjectHandle.ACL" class="notranslate">func (*ObjectHandle) ACL
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ACL() *<a href="#aclhandle">ACLHandle</a></code></pre>	
@@ -2692,7 +2692,7 @@ This call does not perform any network operations.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ACL_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2721,7 +2721,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs" translate="no">func (*ObjectHandle) Attrs
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Attrs" data-uid="cloud.google.com/go/storage.ObjectHandle.Attrs" class="notranslate">func (*ObjectHandle) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Attrs(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (attrs *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -2754,7 +2754,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">withConditions</h6>
+  <h6 class="notranslate">withConditions</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2788,7 +2788,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName" translate="no">func (*ObjectHandle) BucketName
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_BucketName" data-uid="cloud.google.com/go/storage.ObjectHandle.BucketName" class="notranslate">func (*ObjectHandle) BucketName
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) BucketName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -2797,7 +2797,7 @@ func main() {
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_BucketName_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2826,7 +2826,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom" translate="no">func (*ObjectHandle) ComposerFrom
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.ComposerFrom" class="notranslate">func (*ObjectHandle) ComposerFrom
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) ComposerFrom(srcs ...*<a href="#objecthandle">ObjectHandle</a>) *<a href="#composer">Composer</a></code></pre>	
@@ -2840,7 +2840,7 @@ to specify an encryption key for any of the source objects.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ComposerFrom_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2869,7 +2869,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom" translate="no">func (*ObjectHandle) CopierFrom
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom" data-uid="cloud.google.com/go/storage.ObjectHandle.CopierFrom" class="notranslate">func (*ObjectHandle) CopierFrom
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (dst *<a href="#objecthandle">ObjectHandle</a>) CopierFrom(src *<a href="#objecthandle">ObjectHandle</a>) *<a href="#copier">Copier</a></code></pre>	
@@ -2882,7 +2882,7 @@ in which case the user project of src is billed.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_CopierFrom_examples">Examples</h5>
-  <h6 translate="no">rotateEncryptionKeys</h6>
+  <h6 class="notranslate">rotateEncryptionKeys</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -2909,7 +2909,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete" translate="no">func (*ObjectHandle) Delete
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Delete" data-uid="cloud.google.com/go/storage.ObjectHandle.Delete" class="notranslate">func (*ObjectHandle) Delete
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Delete(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -2958,7 +2958,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation" translate="no">func (*ObjectHandle) Generation
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Generation" data-uid="cloud.google.com/go/storage.ObjectHandle.Generation" class="notranslate">func (*ObjectHandle) Generation
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Generation(gen <a href="https://pkg.go.dev/builtin#int64">int64</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3003,7 +3003,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If" translate="no">func (*ObjectHandle) If
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_If" data-uid="cloud.google.com/go/storage.ObjectHandle.If" class="notranslate">func (*ObjectHandle) If
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) If(conds <a href="#conditions">Conditions</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3063,7 +3063,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key" translate="no">func (*ObjectHandle) Key
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Key" data-uid="cloud.google.com/go/storage.ObjectHandle.Key" class="notranslate">func (*ObjectHandle) Key
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Key(encryptionKey []<a href="https://pkg.go.dev/builtin#byte">byte</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3103,7 +3103,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader" translate="no">func (*ObjectHandle) NewRangeReader
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewRangeReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewRangeReader" class="notranslate">func (*ObjectHandle) NewRangeReader
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewRangeReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, offset, length <a href="https://pkg.go.dev/builtin#int64">int64</a>) (r *<a href="#reader">Reader</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3151,7 +3151,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">lastNBytes</h6>
+  <h6 class="notranslate">lastNBytes</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -3183,7 +3183,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">untilEnd</h6>
+  <h6 class="notranslate">untilEnd</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -3215,7 +3215,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader" translate="no">func (*ObjectHandle) NewReader
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewReader" data-uid="cloud.google.com/go/storage.ObjectHandle.NewReader" class="notranslate">func (*ObjectHandle) NewReader
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewReader(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) (*<a href="#reader">Reader</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3256,7 +3256,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter" translate="no">func (*ObjectHandle) NewWriter
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_NewWriter" data-uid="cloud.google.com/go/storage.ObjectHandle.NewWriter" class="notranslate">func (*ObjectHandle) NewWriter
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) NewWriter(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>) *<a href="#writer">Writer</a></code></pre>	
@@ -3295,7 +3295,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName" translate="no">func (*ObjectHandle) ObjectName
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ObjectName" data-uid="cloud.google.com/go/storage.ObjectHandle.ObjectName" class="notranslate">func (*ObjectHandle) ObjectName
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ObjectName() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3304,7 +3304,7 @@ func main() {
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ObjectName_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -3333,7 +3333,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed" translate="no">func (*ObjectHandle) ReadCompressed
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed" data-uid="cloud.google.com/go/storage.ObjectHandle.ReadCompressed" class="notranslate">func (*ObjectHandle) ReadCompressed
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) ReadCompressed(compressed <a href="https://pkg.go.dev/builtin#bool">bool</a>) *<a href="#objecthandle">ObjectHandle</a></code></pre>	
@@ -3342,7 +3342,7 @@ func main() {
 </div>
             <div class="markdown level1 conceptual"></div>
             <h5 id="cloud_google_com_go_storage_ObjectHandle_ReadCompressed_examples">Examples</h5>
-  <h6 translate="no">exists</h6>
+  <h6 class="notranslate">exists</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -3371,7 +3371,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update" translate="no">func (*ObjectHandle) Update
+            <h4 id="cloud_google_com_go_storage_ObjectHandle_Update" data-uid="cloud.google.com/go/storage.ObjectHandle.Update" class="notranslate">func (*ObjectHandle) Update
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (o *<a href="#objecthandle">ObjectHandle</a>) Update(ctx <a href="https://pkg.go.dev/context">context</a>.<a href="https://pkg.go.dev/context#Context">Context</a>, uattrs <a href="#objectattrstoupdate">ObjectAttrsToUpdate</a>) (oa *<a href="#objectattrs">ObjectAttrs</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3409,7 +3409,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator" translate="no">ObjectIterator</h3>
+        <h3 id="cloud_google_com_go_storage_ObjectIterator" data-uid="cloud.google.com/go/storage.ObjectIterator" class="notranslate">ObjectIterator</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ObjectIterator struct {
 	// contains filtered or unexported fields
@@ -3420,7 +3420,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next" translate="no">func (*ObjectIterator) Next
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_Next" data-uid="cloud.google.com/go/storage.ObjectIterator.Next" class="notranslate">func (*ObjectIterator) Next
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) Next() (*<a href="#objectattrs">ObjectAttrs</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3471,7 +3471,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-            <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo" translate="no">func (*ObjectIterator) PageInfo
+            <h4 id="cloud_google_com_go_storage_ObjectIterator_PageInfo" data-uid="cloud.google.com/go/storage.ObjectIterator.PageInfo" class="notranslate">func (*ObjectIterator) PageInfo
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (it *<a href="#objectiterator">ObjectIterator</a>) PageInfo() *<a href="https://pkg.go.dev/google.golang.org/api/iterator">iterator</a>.<a href="https://pkg.go.dev/google.golang.org/api/iterator#PageInfo">PageInfo</a></code></pre>	
@@ -3480,7 +3480,7 @@ func main() {
 <p>Note: This method is not safe for concurrent operations without explicit synchronization.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields" translate="no">PolicyV4Fields</h3>
+                  <h3 id="cloud_google_com_go_storage_PolicyV4Fields" data-uid="cloud.google.com/go/storage.PolicyV4Fields" class="notranslate">PolicyV4Fields</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PolicyV4Fields struct {
 	// ACL specifies the access control permissions for the object.
@@ -3518,7 +3518,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4" translate="no">PostPolicyV4</h3>
+        <h3 id="cloud_google_com_go_storage_PostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4" class="notranslate">PostPolicyV4</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4 struct {
 	// URL is the generated URL that the file upload will be made to.
@@ -3532,7 +3532,7 @@ func main() {
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4" translate="no">func GenerateSignedPostPolicyV4
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4_GenerateSignedPostPolicyV4" data-uid="cloud.google.com/go/storage.PostPolicyV4.GenerateSignedPostPolicyV4" class="notranslate">func GenerateSignedPostPolicyV4
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func GenerateSignedPostPolicyV4(bucket, object <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#postpolicyv4options">PostPolicyV4Options</a>) (*<a href="#postpolicyv4">PostPolicyV4</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3616,7 +3616,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition" translate="no">PostPolicyV4Condition</h3>
+        <h3 id="cloud_google_com_go_storage_PostPolicyV4Condition" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition" class="notranslate">PostPolicyV4Condition</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Condition interface {
 	<a href="https://pkg.go.dev/encoding/json">json</a>.<a href="https://pkg.go.dev/encoding/json#Marshaler">Marshaler</a>
@@ -3628,7 +3628,7 @@ object upload&#39;s multipart form fields will be expected to conform to.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange" translate="no">func ConditionContentLengthRange
+            <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionContentLengthRange" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionContentLengthRange" class="notranslate">func ConditionContentLengthRange
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ConditionContentLengthRange(start, end <a href="https://pkg.go.dev/builtin#uint64">uint64</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
@@ -3637,7 +3637,7 @@ object upload&#39;s multipart form fields will be expected to conform to.</p>
 multipart upload&#39;s range header will be expected to be within.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith" translate="no">func ConditionStartsWith
+                      <h4 id="cloud_google_com_go_storage_PostPolicyV4Condition_ConditionStartsWith" data-uid="cloud.google.com/go/storage.PostPolicyV4Condition.ConditionStartsWith" class="notranslate">func ConditionStartsWith
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func ConditionStartsWith(key, value <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#postpolicyv4condition">PostPolicyV4Condition</a></code></pre>	
@@ -3646,7 +3646,7 @@ multipart upload&#39;s range header will be expected to be within.</p>
 An empty value will cause this condition to be ignored.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options" translate="no">PostPolicyV4Options</h3>
+                  <h3 id="cloud_google_com_go_storage_PostPolicyV4Options" data-uid="cloud.google.com/go/storage.PostPolicyV4Options" class="notranslate">PostPolicyV4Options</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type PostPolicyV4Options struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -3721,7 +3721,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam" translate="no">ProjectTeam</h3>
+        <h3 id="cloud_google_com_go_storage_ProjectTeam" data-uid="cloud.google.com/go/storage.ProjectTeam" class="notranslate">ProjectTeam</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ProjectTeam struct {
 	<a href="#projectnumber">ProjectNumber</a> <a href="https://pkg.go.dev/builtin#string">string</a>
@@ -3732,7 +3732,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query" translate="no">Query</h3>
+        <h3 id="cloud_google_com_go_storage_Query" data-uid="cloud.google.com/go/storage.Query" class="notranslate">Query</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Query struct {
 	// Delimiter returns results in a directory-like fashion.
@@ -3770,7 +3770,7 @@ for reference about the fields.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection" translate="no">func (*Query) SetAttrSelection
+            <h4 id="cloud_google_com_go_storage_Query_SetAttrSelection" data-uid="cloud.google.com/go/storage.Query.SetAttrSelection" class="notranslate">func (*Query) SetAttrSelection
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (q *<a href="#query">Query</a>) SetAttrSelection(attrs []<a href="https://pkg.go.dev/builtin#string">string</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -3784,7 +3784,7 @@ optimization; for more information, see
 <a href="https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance">https://cloud.google.com/storage/docs/json_api/v1/how-tos/performance</a></p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader" translate="no">Reader</h3>
+                  <h3 id="cloud_google_com_go_storage_Reader" data-uid="cloud.google.com/go/storage.Reader" class="notranslate">Reader</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Reader struct {
 	<a href="#attrs">Attrs</a> <a href="#readerobjectattrs">ReaderObjectAttrs</a>
@@ -3799,7 +3799,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl" translate="no">func (*Reader) CacheControl
+            <h4 id="cloud_google_com_go_storage_Reader_CacheControl" data-uid="cloud.google.com/go/storage.Reader.CacheControl" class="notranslate">func (*Reader) CacheControl
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) CacheControl() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3808,7 +3808,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.CacheControl.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close" translate="no">func (*Reader) Close
+                      <h4 id="cloud_google_com_go_storage_Reader_Close" data-uid="cloud.google.com/go/storage.Reader.Close" class="notranslate">func (*Reader) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -3816,7 +3816,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
             <div class="markdown level1 summary"><p>Close closes the Reader. It must be called when done reading.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding" translate="no">func (*Reader) ContentEncoding
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentEncoding" data-uid="cloud.google.com/go/storage.Reader.ContentEncoding" class="notranslate">func (*Reader) ContentEncoding
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentEncoding() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3825,7 +3825,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.ContentEncoding.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType" translate="no">func (*Reader) ContentType
+                      <h4 id="cloud_google_com_go_storage_Reader_ContentType" data-uid="cloud.google.com/go/storage.Reader.ContentType" class="notranslate">func (*Reader) ContentType
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) ContentType() <a href="https://pkg.go.dev/builtin#string">string</a></code></pre>	
@@ -3834,7 +3834,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.ContentType.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified" translate="no">func (*Reader) LastModified
+                      <h4 id="cloud_google_com_go_storage_Reader_LastModified" data-uid="cloud.google.com/go/storage.Reader.LastModified" class="notranslate">func (*Reader) LastModified
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) LastModified() (<a href="https://pkg.go.dev/time">time</a>.<a href="https://pkg.go.dev/time#Time">Time</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -3843,14 +3843,14 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
 <p>Deprecated: use Reader.Attrs.LastModified.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read" translate="no">func (*Reader) Read
+                      <h4 id="cloud_google_com_go_storage_Reader_Read" data-uid="cloud.google.com/go/storage.Reader.Read" class="notranslate">func (*Reader) Read
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Read(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (<a href="https://pkg.go.dev/builtin#int">int</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain" translate="no">func (*Reader) Remain
+                      <h4 id="cloud_google_com_go_storage_Reader_Remain" data-uid="cloud.google.com/go/storage.Reader.Remain" class="notranslate">func (*Reader) Remain
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Remain() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
@@ -3858,7 +3858,7 @@ is skipped if transcoding occurs. See <a href="https://cloud.google.com/storage/
             <div class="markdown level1 summary"><p>Remain returns the number of bytes left to read, or -1 if unknown.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size" translate="no">func (*Reader) Size
+                      <h4 id="cloud_google_com_go_storage_Reader_Size" data-uid="cloud.google.com/go/storage.Reader.Size" class="notranslate">func (*Reader) Size
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (r *<a href="#reader">Reader</a>) Size() <a href="https://pkg.go.dev/builtin#int64">int64</a></code></pre>	
@@ -3869,7 +3869,7 @@ calls to Read or Close.</p>
 <p>Deprecated: use Reader.Attrs.Size.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs" translate="no">ReaderObjectAttrs</h3>
+                  <h3 id="cloud_google_com_go_storage_ReaderObjectAttrs" data-uid="cloud.google.com/go/storage.ReaderObjectAttrs" class="notranslate">ReaderObjectAttrs</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type ReaderObjectAttrs struct {
 	// Size is the length of the object's content.
@@ -3911,7 +3911,7 @@ get the full set of attributes, use ObjectHandle.Attrs.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy" translate="no">RetentionPolicy</h3>
+        <h3 id="cloud_google_com_go_storage_RetentionPolicy" data-uid="cloud.google.com/go/storage.RetentionPolicy" class="notranslate">RetentionPolicy</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type RetentionPolicy struct {
 	// RetentionPeriod specifies the duration that objects need to be
@@ -3944,7 +3944,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions" translate="no">SignedURLOptions</h3>
+        <h3 id="cloud_google_com_go_storage_SignedURLOptions" data-uid="cloud.google.com/go/storage.SignedURLOptions" class="notranslate">SignedURLOptions</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SignedURLOptions struct {
 	// GoogleAccessID represents the authorizer of the signed URL generation.
@@ -4041,7 +4041,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme" translate="no">SigningScheme</h3>
+        <h3 id="cloud_google_com_go_storage_SigningScheme" data-uid="cloud.google.com/go/storage.SigningScheme" class="notranslate">SigningScheme</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type SigningScheme <a href="https://pkg.go.dev/builtin#int">int</a></code></pre>
         </div>
@@ -4049,7 +4049,7 @@ subject to any SLA or deprecation policy.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4" translate="no">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
+            <h4 id="cloud_google_com_go_storage_SigningSchemeDefault_SigningSchemeV2_SigningSchemeV4" data-uid="cloud.google.com/go/storage.SigningSchemeDefault,SigningSchemeV2,SigningSchemeV4" class="notranslate">SigningSchemeDefault, SigningSchemeV2, SigningSchemeV4</h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">const (
 	// SigningSchemeDefault is presently V2 and will change to V4 in the future.
@@ -4064,7 +4064,7 @@ subject to any SLA or deprecation policy.</p>
             </div>
             <div class="markdown level1 summary"></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle" translate="no">URLStyle</h3>
+                  <h3 id="cloud_google_com_go_storage_URLStyle" data-uid="cloud.google.com/go/storage.URLStyle" class="notranslate">URLStyle</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type URLStyle interface {
 	// contains filtered or unexported methods
@@ -4076,7 +4076,7 @@ default. All non-default options work with V4 scheme only. See
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname" translate="no">func BucketBoundHostname
+            <h4 id="cloud_google_com_go_storage_URLStyle_BucketBoundHostname" data-uid="cloud.google.com/go/storage.URLStyle.BucketBoundHostname" class="notranslate">func BucketBoundHostname
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func BucketBoundHostname(hostname <a href="https://pkg.go.dev/builtin#string">string</a>) <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4091,7 +4091,7 @@ for details. Note that for CNAMEs, only HTTP is supported, so Insecure must
 be set to true.<p>
 </object-name></bucket-bound-hostname></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle" translate="no">func PathStyle
+                      <h4 id="cloud_google_com_go_storage_URLStyle_PathStyle" data-uid="cloud.google.com/go/storage.URLStyle.PathStyle" class="notranslate">func PathStyle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func PathStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4100,7 +4100,7 @@ be set to true.<p>
 &quot;storage.googleapis.com/<bucket-name>/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle" translate="no">func VirtualHostedStyle
+                      <h4 id="cloud_google_com_go_storage_URLStyle_VirtualHostedStyle" data-uid="cloud.google.com/go/storage.URLStyle.VirtualHostedStyle" class="notranslate">func VirtualHostedStyle
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func VirtualHostedStyle() <a href="#urlstyle">URLStyle</a></code></pre>	
@@ -4109,7 +4109,7 @@ be set to true.<p>
 hostname, e.g. &quot;<bucket-name>.storage.googleapis.com/<object-name>&quot;.<p>
 </object-name></bucket-name></div>
             <div class="markdown level1 conceptual"></div>
-                  <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess" translate="no">UniformBucketLevelAccess</h3>
+                  <h3 id="cloud_google_com_go_storage_UniformBucketLevelAccess" data-uid="cloud.google.com/go/storage.UniformBucketLevelAccess" class="notranslate">UniformBucketLevelAccess</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type UniformBucketLevelAccess struct {
 	// Enabled specifies whether access checks use only bucket-level IAM
@@ -4125,7 +4125,7 @@ policies.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer" translate="no">Writer</h3>
+        <h3 id="cloud_google_com_go_storage_Writer" data-uid="cloud.google.com/go/storage.Writer" class="notranslate">Writer</h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">type Writer struct {
 	// ObjectAttrs are optional attributes to set on the object. Any attributes
@@ -4178,7 +4178,7 @@ policies.</p>
 </div>
         <div class="markdown level1 conceptual"></div>
         
-            <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs" translate="no">func (*Writer) Attrs
+            <h4 id="cloud_google_com_go_storage_Writer_Attrs" data-uid="cloud.google.com/go/storage.Writer.Attrs" class="notranslate">func (*Writer) Attrs
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Attrs() *<a href="#objectattrs">ObjectAttrs</a></code></pre>	
@@ -4187,7 +4187,7 @@ policies.</p>
 It&#39;s only valid to call it after Close returns nil.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close" translate="no">func (*Writer) Close
+                      <h4 id="cloud_google_com_go_storage_Writer_Close" data-uid="cloud.google.com/go/storage.Writer.Close" class="notranslate">func (*Writer) Close
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Close() <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -4197,7 +4197,7 @@ If Close doesn&#39;t return an error, metadata about the written object
 can be retrieved by calling Attrs.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError" translate="no">func (*Writer) CloseWithError
+                      <h4 id="cloud_google_com_go_storage_Writer_CloseWithError" data-uid="cloud.google.com/go/storage.Writer.CloseWithError" class="notranslate">func (*Writer) CloseWithError
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) CloseWithError(err <a href="https://pkg.go.dev/builtin#error">error</a>) <a href="https://pkg.go.dev/builtin#error">error</a></code></pre>	
@@ -4207,7 +4207,7 @@ CloseWithError always returns nil.</p>
 <p>Deprecated: cancel the context passed to NewWriter instead.</p>
 </div>
             <div class="markdown level1 conceptual"></div>
-                      <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write" translate="no">func (*Writer) Write
+                      <h4 id="cloud_google_com_go_storage_Writer_Write" data-uid="cloud.google.com/go/storage.Writer.Write" class="notranslate">func (*Writer) Write
 </h4>
             <div class="codewrapper">	
               <pre><code class="prettyprint">func (w *<a href="#writer">Writer</a>) Write(p []<a href="https://pkg.go.dev/builtin#byte">byte</a>) (n <a href="https://pkg.go.dev/builtin#int">int</a>, err <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>	
@@ -4252,7 +4252,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">checksum</h6>
+  <h6 class="notranslate">checksum</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -4285,7 +4285,7 @@ func main() {
 }
 {% endverbatim %}</code></pre>
   </div>
-  <h6 translate="no">timeout</h6>
+  <h6 class="notranslate">timeout</h6>
   <div class="codewrapper">
   <pre><code class="prettyprint">{% verbatim %}package main
 
@@ -4322,7 +4322,7 @@ func main() {
     <h2 id="functions">Functions
   
   </h2>
-        <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL" translate="no">func SignedURL
+        <h3 id="cloud_google_com_go_storage_SignedURL" data-uid="cloud.google.com/go/storage.SignedURL" class="notranslate">func SignedURL
 </h3>
         <div class="codewrapper">
           <pre><code class="prettyprint">func SignedURL(bucket, name <a href="https://pkg.go.dev/builtin#string">string</a>, opts *<a href="#signedurloptions">SignedURLOptions</a>) (<a href="https://pkg.go.dev/builtin#string">string</a>, <a href="https://pkg.go.dev/builtin#error">error</a>)</code></pre>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#appEngineRouting:member">appEngineRouting</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#appEngineRouting:member" translate="no">appEngineRouting</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#body:member">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#body:member" translate="no">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#headers:member">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#headers:member" translate="no">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#httpMethod:member">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#relativeUri:member">relativeUri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#relativeUri:member" translate="no">relativeUri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public relativeUri: string;</code></pre>
   </div>
@@ -159,7 +159,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -203,7 +203,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -353,7 +353,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -473,7 +473,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineHttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -526,7 +526,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#appEngineRouting:member" translate="no">appEngineRouting</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#appEngineRouting:member" class="notranslate">appEngineRouting</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#body:member" translate="no">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#body:member" class="notranslate">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#headers:member" translate="no">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#headers:member" class="notranslate">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#httpMethod:member" class="notranslate">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#relativeUri:member" translate="no">relativeUri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#relativeUri:member" class="notranslate">relativeUri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public relativeUri: string;</code></pre>
   </div>
@@ -159,7 +159,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineHttpTarget): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -203,7 +203,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -353,7 +353,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineHttpTarget;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -473,7 +473,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineHttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -526,7 +526,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineHttpTarget.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineRouting);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#host:member" translate="no">host</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#host:member" class="notranslate">host</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public host: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#instance:member" translate="no">instance</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#instance:member" class="notranslate">instance</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public instance: string;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#service:member" translate="no">service</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#service:member" class="notranslate">service</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public service: string;</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#version:member" translate="no">version</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#version:member" class="notranslate">version</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public version: string;</code></pre>
   </div>
@@ -137,7 +137,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineRouting): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -181,7 +181,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -278,7 +278,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -331,7 +331,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -428,7 +428,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -451,7 +451,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineRouting, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -504,7 +504,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IAppEngineRouting);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#host:member">host</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#host:member" translate="no">host</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public host: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#instance:member">instance</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#instance:member" translate="no">instance</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public instance: string;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#service:member">service</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#service:member" translate="no">service</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public service: string;</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#version:member">version</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#version:member" translate="no">version</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public version: string;</code></pre>
   </div>
@@ -137,7 +137,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IAppEngineRouting): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -181,7 +181,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -278,7 +278,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -331,7 +331,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IAppEngineRouting, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.AppEngineRouting;</code></pre>
   </div>
@@ -428,7 +428,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -451,7 +451,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.AppEngineRouting, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -504,7 +504,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.AppEngineRouting.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
@@ -22,7 +22,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler:constructor(1)" translate="no">(constructor)(rpcImpl, requestDelimited, responseDelimited)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler:constructor(1)" class="notranslate">(constructor)(rpcImpl, requestDelimited, responseDelimited)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);</code></pre>
   </div>
@@ -70,7 +70,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler.create:member(1)" translate="no">create(rpcImpl, requestDelimited, responseDelimited)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler.create:member(1)" class="notranslate">create(rpcImpl, requestDelimited, responseDelimited)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): CloudScheduler;</code></pre>
   </div>
@@ -132,7 +132,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(1)" translate="no">createJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(1)" class="notranslate">createJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.CreateJobCallback): void;</code></pre>
   </div>
@@ -184,7 +184,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(2)" translate="no">createJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(2)" class="notranslate">createJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -228,7 +228,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(1)" translate="no">deleteJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(1)" class="notranslate">deleteJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.DeleteJobCallback): void;</code></pre>
   </div>
@@ -280,7 +280,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(2)" translate="no">deleteJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(2)" class="notranslate">deleteJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest): Promise&lt;google.protobuf.Empty&gt;;</code></pre>
   </div>
@@ -324,7 +324,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(1)" translate="no">getJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(1)" class="notranslate">getJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.GetJobCallback): void;</code></pre>
   </div>
@@ -376,7 +376,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(2)" translate="no">getJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(2)" class="notranslate">getJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -420,7 +420,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(1)" translate="no">listJobs(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(1)" class="notranslate">listJobs(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ListJobsCallback): void;</code></pre>
   </div>
@@ -472,7 +472,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(2)" translate="no">listJobs(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(2)" class="notranslate">listJobs(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest): Promise&lt;google.cloud.scheduler.v1.ListJobsResponse&gt;;</code></pre>
   </div>
@@ -516,7 +516,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(1)" translate="no">pauseJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(1)" class="notranslate">pauseJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.PauseJobCallback): void;</code></pre>
   </div>
@@ -568,7 +568,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(2)" translate="no">pauseJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(2)" class="notranslate">pauseJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -612,7 +612,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(1)" translate="no">resumeJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(1)" class="notranslate">resumeJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ResumeJobCallback): void;</code></pre>
   </div>
@@ -664,7 +664,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(2)" translate="no">resumeJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(2)" class="notranslate">resumeJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -708,7 +708,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(1)" translate="no">runJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(1)" class="notranslate">runJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.RunJobCallback): void;</code></pre>
   </div>
@@ -760,7 +760,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(2)" translate="no">runJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(2)" class="notranslate">runJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -804,7 +804,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(1)" translate="no">updateJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(1)" class="notranslate">updateJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.UpdateJobCallback): void;</code></pre>
   </div>
@@ -856,7 +856,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(2)" translate="no">updateJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(2)" class="notranslate">updateJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
@@ -22,7 +22,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler:constructor(1)">(constructor)(rpcImpl, requestDelimited, responseDelimited)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler:constructor(1)" translate="no">(constructor)(rpcImpl, requestDelimited, responseDelimited)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean);</code></pre>
   </div>
@@ -70,7 +70,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler.create:member(1)">create(rpcImpl, requestDelimited, responseDelimited)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler.create:member(1)" translate="no">create(rpcImpl, requestDelimited, responseDelimited)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(rpcImpl: $protobuf.RPCImpl, requestDelimited?: boolean, responseDelimited?: boolean): CloudScheduler;</code></pre>
   </div>
@@ -132,7 +132,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(1)">createJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(1)" translate="no">createJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.CreateJobCallback): void;</code></pre>
   </div>
@@ -184,7 +184,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(2)">createJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_createJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#createJob:member(2)" translate="no">createJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public createJob(request: google.cloud.scheduler.v1.ICreateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -228,7 +228,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(1)">deleteJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(1)" translate="no">deleteJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.DeleteJobCallback): void;</code></pre>
   </div>
@@ -280,7 +280,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(2)">deleteJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_deleteJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#deleteJob:member(2)" translate="no">deleteJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public deleteJob(request: google.cloud.scheduler.v1.IDeleteJobRequest): Promise&lt;google.protobuf.Empty&gt;;</code></pre>
   </div>
@@ -324,7 +324,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(1)">getJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(1)" translate="no">getJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.GetJobCallback): void;</code></pre>
   </div>
@@ -376,7 +376,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(2)">getJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_getJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#getJob:member(2)" translate="no">getJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public getJob(request: google.cloud.scheduler.v1.IGetJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -420,7 +420,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(1)">listJobs(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(1)" translate="no">listJobs(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ListJobsCallback): void;</code></pre>
   </div>
@@ -472,7 +472,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(2)">listJobs(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_listJobs_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#listJobs:member(2)" translate="no">listJobs(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public listJobs(request: google.cloud.scheduler.v1.IListJobsRequest): Promise&lt;google.cloud.scheduler.v1.ListJobsResponse&gt;;</code></pre>
   </div>
@@ -516,7 +516,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(1)">pauseJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(1)" translate="no">pauseJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.PauseJobCallback): void;</code></pre>
   </div>
@@ -568,7 +568,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(2)">pauseJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_pauseJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#pauseJob:member(2)" translate="no">pauseJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pauseJob(request: google.cloud.scheduler.v1.IPauseJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -612,7 +612,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(1)">resumeJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(1)" translate="no">resumeJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.ResumeJobCallback): void;</code></pre>
   </div>
@@ -664,7 +664,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(2)">resumeJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_resumeJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#resumeJob:member(2)" translate="no">resumeJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public resumeJob(request: google.cloud.scheduler.v1.IResumeJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -708,7 +708,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(1)">runJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(1)" translate="no">runJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.RunJobCallback): void;</code></pre>
   </div>
@@ -760,7 +760,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(2)">runJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_runJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#runJob:member(2)" translate="no">runJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public runJob(request: google.cloud.scheduler.v1.IRunJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>
@@ -804,7 +804,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(1)">updateJob(request, callback)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(1)" translate="no">updateJob(request, callback)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest, callback: google.cloud.scheduler.v1.CloudScheduler.UpdateJobCallback): void;</code></pre>
   </div>
@@ -856,7 +856,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(2)">updateJob(request)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CloudScheduler_updateJob_member_2_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CloudScheduler#updateJob:member(2)" translate="no">updateJob(request)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateJob(request: google.cloud.scheduler.v1.IUpdateJobRequest): Promise&lt;google.cloud.scheduler.v1.Job&gt;;</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.ICreateJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#job:member">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#job:member" translate="no">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#parent:member">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#parent:member" translate="no">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.ICreateJobRequest): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.CreateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.ICreateJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#job:member" translate="no">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#job:member" class="notranslate">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#parent:member" translate="no">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#parent:member" class="notranslate">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.ICreateJobRequest): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.ICreateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.CreateJobRequest;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.CreateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.CreateJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IDeleteJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IDeleteJobRequest): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.DeleteJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IDeleteJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IDeleteJobRequest): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IDeleteJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.DeleteJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.DeleteJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.DeleteJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IGetJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IGetJobRequest): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.GetJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IGetJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IGetJobRequest): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IGetJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.GetJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.GetJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.GetJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IHttpTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_authorizationHeader_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#authorizationHeader:member" translate="no">authorizationHeader</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_authorizationHeader_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#authorizationHeader:member" class="notranslate">authorizationHeader</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public authorizationHeader?: (&quot;oauthToken&quot;|&quot;oidcToken&quot;);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#body:member" translate="no">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#body:member" class="notranslate">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#headers:member" translate="no">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#headers:member" class="notranslate">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#httpMethod:member" translate="no">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#httpMethod:member" class="notranslate">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oauthToken:member" translate="no">oauthToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oauthToken:member" class="notranslate">oauthToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
@@ -157,7 +157,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oidcToken:member" translate="no">oidcToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oidcToken:member" class="notranslate">oidcToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
@@ -179,7 +179,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#uri:member" translate="no">uri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#uri:member" class="notranslate">uri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public uri: string;</code></pre>
   </div>
@@ -203,7 +203,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IHttpTarget): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -247,7 +247,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -344,7 +344,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -397,7 +397,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -494,7 +494,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -517,7 +517,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.HttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -570,7 +570,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IHttpTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_authorizationHeader_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#authorizationHeader:member">authorizationHeader</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_authorizationHeader_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#authorizationHeader:member" translate="no">authorizationHeader</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public authorizationHeader?: (&quot;oauthToken&quot;|&quot;oidcToken&quot;);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#body:member">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#body:member" translate="no">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public body: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#headers:member">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#headers:member" translate="no">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public headers: { [k: string]: string };</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#httpMethod:member">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#httpMethod:member" translate="no">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpMethod: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oauthToken:member">oauthToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oauthToken:member" translate="no">oauthToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
@@ -157,7 +157,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oidcToken:member">oidcToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#oidcToken:member" translate="no">oidcToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
@@ -179,7 +179,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#uri:member">uri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#uri:member" translate="no">uri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public uri: string;</code></pre>
   </div>
@@ -203,7 +203,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IHttpTarget): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -247,7 +247,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -344,7 +344,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -397,7 +397,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IHttpTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.HttpTarget;</code></pre>
   </div>
@@ -494,7 +494,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -517,7 +517,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.HttpTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -570,7 +570,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.HttpTarget.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#appEngineRouting:member">appEngineRouting</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#appEngineRouting:member" translate="no">appEngineRouting</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#body:member">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#body:member" translate="no">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#headers:member">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#headers:member" translate="no">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#httpMethod:member">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#relativeUri:member">relativeUri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#relativeUri:member" translate="no">relativeUri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">relativeUri?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#appEngineRouting:member" translate="no">appEngineRouting</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_appEngineRouting_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#appEngineRouting:member" class="notranslate">appEngineRouting</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineRouting?: (google.cloud.scheduler.v1.IAppEngineRouting|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#body:member" translate="no">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#body:member" class="notranslate">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#headers:member" translate="no">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#headers:member" class="notranslate">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#httpMethod:member" class="notranslate">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#relativeUri:member" translate="no">relativeUri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineHttpTarget_relativeUri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineHttpTarget#relativeUri:member" class="notranslate">relativeUri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">relativeUri?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#host:member" translate="no">host</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#host:member" class="notranslate">host</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">host?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#instance:member" translate="no">instance</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#instance:member" class="notranslate">instance</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">instance?: (string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#service:member" translate="no">service</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#service:member" class="notranslate">service</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">service?: (string|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#version:member" translate="no">version</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#version:member" class="notranslate">version</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">version?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#host:member">host</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_host_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#host:member" translate="no">host</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">host?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#instance:member">instance</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_instance_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#instance:member" translate="no">instance</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">instance?: (string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#service:member">service</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_service_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#service:member" translate="no">service</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">service?: (string|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#version:member">version</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IAppEngineRouting_version_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IAppEngineRouting#version:member" translate="no">version</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">version?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#job:member" translate="no">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#job:member" class="notranslate">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#parent:member" translate="no">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#parent:member" class="notranslate">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#job:member">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#job:member" translate="no">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#parent:member">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ICreateJobRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ICreateJobRequest#parent:member" translate="no">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IDeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IDeleteJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IDeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IDeleteJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IDeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IDeleteJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IDeleteJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IDeleteJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IGetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IGetJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IGetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IGetJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IGetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IGetJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IGetJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IGetJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#body:member" translate="no">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#body:member" class="notranslate">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#headers:member" translate="no">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#headers:member" class="notranslate">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#httpMethod:member" class="notranslate">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oauthToken:member" translate="no">oauthToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oauthToken:member" class="notranslate">oauthToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oidcToken:member" translate="no">oidcToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oidcToken:member" class="notranslate">oidcToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
@@ -127,7 +127,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#uri:member" translate="no">uri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#uri:member" class="notranslate">uri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">uri?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#body:member">body</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_body_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#body:member" translate="no">body</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">body?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#headers:member">headers</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_headers_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#headers:member" translate="no">headers</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">headers?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#httpMethod:member">httpMethod</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_httpMethod_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#httpMethod:member" translate="no">httpMethod</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpMethod?: (google.cloud.scheduler.v1.HttpMethod|keyof typeof google.cloud.scheduler.v1.HttpMethod|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oauthToken:member">oauthToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oauthToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oauthToken:member" translate="no">oauthToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">oauthToken?: (google.cloud.scheduler.v1.IOAuthToken|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oidcToken:member">oidcToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_oidcToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#oidcToken:member" translate="no">oidcToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">oidcToken?: (google.cloud.scheduler.v1.IOidcToken|null);</code></pre>
   </div>
@@ -127,7 +127,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#uri:member">uri</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IHttpTarget_uri_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IHttpTarget#uri:member" translate="no">uri</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">uri?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#appEngineHttpTarget:member" translate="no">appEngineHttpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#appEngineHttpTarget:member" class="notranslate">appEngineHttpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#attemptDeadline:member" translate="no">attemptDeadline</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#attemptDeadline:member" class="notranslate">attemptDeadline</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#description:member" translate="no">description</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#description:member" class="notranslate">description</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">description?: (string|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#httpTarget:member" translate="no">httpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#httpTarget:member" class="notranslate">httpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#lastAttemptTime:member" translate="no">lastAttemptTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#lastAttemptTime:member" class="notranslate">lastAttemptTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -127,7 +127,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
@@ -149,7 +149,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#pubsubTarget:member" translate="no">pubsubTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#pubsubTarget:member" class="notranslate">pubsubTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
@@ -171,7 +171,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#retryConfig:member" translate="no">retryConfig</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#retryConfig:member" class="notranslate">retryConfig</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
@@ -193,7 +193,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#schedule:member" translate="no">schedule</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#schedule:member" class="notranslate">schedule</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">schedule?: (string|null);</code></pre>
   </div>
@@ -215,7 +215,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#scheduleTime:member" translate="no">scheduleTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#scheduleTime:member" class="notranslate">scheduleTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -237,7 +237,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#state:member" translate="no">state</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#state:member" class="notranslate">state</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">state?: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State|null);</code></pre>
   </div>
@@ -259,7 +259,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#status:member" translate="no">status</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#status:member" class="notranslate">status</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">status?: (google.rpc.IStatus|null);</code></pre>
   </div>
@@ -281,7 +281,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#timeZone:member" translate="no">timeZone</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#timeZone:member" class="notranslate">timeZone</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">timeZone?: (string|null);</code></pre>
   </div>
@@ -303,7 +303,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#userUpdateTime:member" translate="no">userUpdateTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#userUpdateTime:member" class="notranslate">userUpdateTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#appEngineHttpTarget:member">appEngineHttpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#appEngineHttpTarget:member" translate="no">appEngineHttpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#attemptDeadline:member">attemptDeadline</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#attemptDeadline:member" translate="no">attemptDeadline</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#description:member">description</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#description:member" translate="no">description</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">description?: (string|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#httpTarget:member">httpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#httpTarget:member" translate="no">httpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#lastAttemptTime:member">lastAttemptTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#lastAttemptTime:member" translate="no">lastAttemptTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -127,7 +127,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>
@@ -149,7 +149,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#pubsubTarget:member">pubsubTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#pubsubTarget:member" translate="no">pubsubTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
@@ -171,7 +171,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#retryConfig:member">retryConfig</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#retryConfig:member" translate="no">retryConfig</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
@@ -193,7 +193,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#schedule:member">schedule</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#schedule:member" translate="no">schedule</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">schedule?: (string|null);</code></pre>
   </div>
@@ -215,7 +215,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#scheduleTime:member">scheduleTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#scheduleTime:member" translate="no">scheduleTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -237,7 +237,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#state:member">state</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#state:member" translate="no">state</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">state?: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State|null);</code></pre>
   </div>
@@ -259,7 +259,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#status:member">status</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#status:member" translate="no">status</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">status?: (google.rpc.IStatus|null);</code></pre>
   </div>
@@ -281,7 +281,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#timeZone:member">timeZone</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#timeZone:member" translate="no">timeZone</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">timeZone?: (string|null);</code></pre>
   </div>
@@ -303,7 +303,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#userUpdateTime:member">userUpdateTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IJob_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IJob#userUpdateTime:member" translate="no">userUpdateTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageSize:member">pageSize</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageSize:member" translate="no">pageSize</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageSize?: (number|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageToken:member">pageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageToken:member" translate="no">pageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageToken?: (string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#parent:member">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#parent:member" translate="no">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageSize:member" translate="no">pageSize</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageSize:member" class="notranslate">pageSize</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageSize?: (number|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageToken:member" translate="no">pageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#pageToken:member" class="notranslate">pageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">pageToken?: (string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#parent:member" translate="no">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsRequest#parent:member" class="notranslate">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">parent?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#jobs:member" translate="no">jobs</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#jobs:member" class="notranslate">jobs</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">jobs?: (google.cloud.scheduler.v1.IJob[]|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#nextPageToken:member" translate="no">nextPageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#nextPageToken:member" class="notranslate">nextPageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">nextPageToken?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#jobs:member">jobs</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#jobs:member" translate="no">jobs</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">jobs?: (google.cloud.scheduler.v1.IJob[]|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#nextPageToken:member">nextPageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IListJobsResponse#nextPageToken:member" translate="no">nextPageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">nextPageToken?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#scope:member">scope</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#scope:member" translate="no">scope</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">scope?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#serviceAccountEmail:member">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#scope:member" translate="no">scope</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#scope:member" class="notranslate">scope</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">scope?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOAuthToken#serviceAccountEmail:member" class="notranslate">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#audience:member" translate="no">audience</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#audience:member" class="notranslate">audience</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">audience?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#serviceAccountEmail:member" class="notranslate">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#audience:member">audience</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#audience:member" translate="no">audience</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">audience?: (string|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#serviceAccountEmail:member">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IOidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IOidcToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">serviceAccountEmail?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPauseJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPauseJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPauseJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPauseJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#attributes:member" translate="no">attributes</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#attributes:member" class="notranslate">attributes</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">attributes?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#data:member" translate="no">data</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#data:member" class="notranslate">data</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">data?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#topicName:member" translate="no">topicName</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#topicName:member" class="notranslate">topicName</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">topicName?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#attributes:member">attributes</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#attributes:member" translate="no">attributes</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">attributes?: ({ [k: string]: string }|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#data:member">data</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#data:member" translate="no">data</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">data?: (Uint8Array|string|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#topicName:member">topicName</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IPubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IPubsubTarget#topicName:member" translate="no">topicName</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">topicName?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IResumeJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IResumeJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IResumeJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IResumeJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxBackoffDuration:member" translate="no">maxBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxBackoffDuration:member" class="notranslate">maxBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxDoublings:member" translate="no">maxDoublings</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxDoublings:member" class="notranslate">maxDoublings</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxDoublings?: (number|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxRetryDuration:member" translate="no">maxRetryDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxRetryDuration:member" class="notranslate">maxRetryDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#minBackoffDuration:member" translate="no">minBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#minBackoffDuration:member" class="notranslate">minBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#retryCount:member" translate="no">retryCount</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#retryCount:member" class="notranslate">retryCount</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryCount?: (number|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxBackoffDuration:member">maxBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxBackoffDuration:member" translate="no">maxBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxDoublings:member">maxDoublings</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxDoublings:member" translate="no">maxDoublings</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxDoublings?: (number|null);</code></pre>
   </div>
@@ -61,7 +61,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxRetryDuration:member">maxRetryDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#maxRetryDuration:member" translate="no">maxRetryDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -83,7 +83,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#minBackoffDuration:member">minBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#minBackoffDuration:member" translate="no">minBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -105,7 +105,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#retryCount:member">retryCount</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRetryConfig#retryCount:member" translate="no">retryCount</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">retryCount?: (number|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRunJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRunJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRunJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IRunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IRunJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">name?: (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#job:member">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#job:member" translate="no">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#updateMask:member">updateMask</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#updateMask:member" translate="no">updateMask</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#job:member" translate="no">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#job:member" class="notranslate">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -39,7 +39,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#updateMask:member" translate="no">updateMask</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_IUpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.IUpdateJobRequest#updateMask:member" class="notranslate">updateMask</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IJob);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#appEngineHttpTarget:member">appEngineHttpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#appEngineHttpTarget:member" translate="no">appEngineHttpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#attemptDeadline:member">attemptDeadline</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#attemptDeadline:member" translate="no">attemptDeadline</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#description:member">description</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#description:member" translate="no">description</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public description: string;</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#httpTarget:member">httpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#httpTarget:member" translate="no">httpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#lastAttemptTime:member">lastAttemptTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#lastAttemptTime:member" translate="no">lastAttemptTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -157,7 +157,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -179,7 +179,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#pubsubTarget:member">pubsubTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#pubsubTarget:member" translate="no">pubsubTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
@@ -201,7 +201,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#retryConfig:member">retryConfig</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#retryConfig:member" translate="no">retryConfig</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
@@ -223,7 +223,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#schedule:member">schedule</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#schedule:member" translate="no">schedule</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public schedule: string;</code></pre>
   </div>
@@ -245,7 +245,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#scheduleTime:member">scheduleTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#scheduleTime:member" translate="no">scheduleTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -267,7 +267,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#state:member">state</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#state:member" translate="no">state</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public state: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State);</code></pre>
   </div>
@@ -289,7 +289,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#status:member">status</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#status:member" translate="no">status</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public status?: (google.rpc.IStatus|null);</code></pre>
   </div>
@@ -311,7 +311,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_target_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#target:member">target</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_target_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#target:member" translate="no">target</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public target?: (&quot;pubsubTarget&quot;|&quot;appEngineHttpTarget&quot;|&quot;httpTarget&quot;);</code></pre>
   </div>
@@ -333,7 +333,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#timeZone:member">timeZone</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#timeZone:member" translate="no">timeZone</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public timeZone: string;</code></pre>
   </div>
@@ -355,7 +355,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#userUpdateTime:member">userUpdateTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#userUpdateTime:member" translate="no">userUpdateTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -379,7 +379,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IJob): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -423,7 +423,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -476,7 +476,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -520,7 +520,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -573,7 +573,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -626,7 +626,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -670,7 +670,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -693,7 +693,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.Job, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -746,7 +746,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IJob);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#appEngineHttpTarget:member" translate="no">appEngineHttpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_appEngineHttpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#appEngineHttpTarget:member" class="notranslate">appEngineHttpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public appEngineHttpTarget?: (google.cloud.scheduler.v1.IAppEngineHttpTarget|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#attemptDeadline:member" translate="no">attemptDeadline</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_attemptDeadline_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#attemptDeadline:member" class="notranslate">attemptDeadline</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attemptDeadline?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#description:member" translate="no">description</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_description_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#description:member" class="notranslate">description</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public description: string;</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#httpTarget:member" translate="no">httpTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_httpTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#httpTarget:member" class="notranslate">httpTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public httpTarget?: (google.cloud.scheduler.v1.IHttpTarget|null);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#lastAttemptTime:member" translate="no">lastAttemptTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_lastAttemptTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#lastAttemptTime:member" class="notranslate">lastAttemptTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public lastAttemptTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -157,7 +157,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -179,7 +179,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#pubsubTarget:member" translate="no">pubsubTarget</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_pubsubTarget_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#pubsubTarget:member" class="notranslate">pubsubTarget</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pubsubTarget?: (google.cloud.scheduler.v1.IPubsubTarget|null);</code></pre>
   </div>
@@ -201,7 +201,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#retryConfig:member" translate="no">retryConfig</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_retryConfig_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#retryConfig:member" class="notranslate">retryConfig</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryConfig?: (google.cloud.scheduler.v1.IRetryConfig|null);</code></pre>
   </div>
@@ -223,7 +223,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#schedule:member" translate="no">schedule</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_schedule_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#schedule:member" class="notranslate">schedule</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public schedule: string;</code></pre>
   </div>
@@ -245,7 +245,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#scheduleTime:member" translate="no">scheduleTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_scheduleTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#scheduleTime:member" class="notranslate">scheduleTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scheduleTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -267,7 +267,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#state:member" translate="no">state</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_state_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#state:member" class="notranslate">state</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public state: (google.cloud.scheduler.v1.Job.State|keyof typeof google.cloud.scheduler.v1.Job.State);</code></pre>
   </div>
@@ -289,7 +289,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#status:member" translate="no">status</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_status_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#status:member" class="notranslate">status</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public status?: (google.rpc.IStatus|null);</code></pre>
   </div>
@@ -311,7 +311,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_target_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#target:member" translate="no">target</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_target_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#target:member" class="notranslate">target</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public target?: (&quot;pubsubTarget&quot;|&quot;appEngineHttpTarget&quot;|&quot;httpTarget&quot;);</code></pre>
   </div>
@@ -333,7 +333,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#timeZone:member" translate="no">timeZone</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_timeZone_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#timeZone:member" class="notranslate">timeZone</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public timeZone: string;</code></pre>
   </div>
@@ -355,7 +355,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#userUpdateTime:member" translate="no">userUpdateTime</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_userUpdateTime_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#userUpdateTime:member" class="notranslate">userUpdateTime</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public userUpdateTime?: (google.protobuf.ITimestamp|null);</code></pre>
   </div>
@@ -379,7 +379,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IJob): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -423,7 +423,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -476,7 +476,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -520,7 +520,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -573,7 +573,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IJob, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -626,7 +626,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.Job;</code></pre>
   </div>
@@ -670,7 +670,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -693,7 +693,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.Job, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -746,7 +746,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.Job.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageSize:member">pageSize</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageSize:member" translate="no">pageSize</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageSize: number;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageToken:member">pageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageToken:member" translate="no">pageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageToken: string;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#parent:member">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#parent:member" translate="no">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
@@ -115,7 +115,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsRequest): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -159,7 +159,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -309,7 +309,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -429,7 +429,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -482,7 +482,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageSize:member" translate="no">pageSize</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageSize_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageSize:member" class="notranslate">pageSize</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageSize: number;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageToken:member" translate="no">pageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_pageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#pageToken:member" class="notranslate">pageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public pageToken: string;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#parent:member" translate="no">parent</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_parent_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#parent:member" class="notranslate">parent</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public parent: string;</code></pre>
   </div>
@@ -115,7 +115,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsRequest): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -159,7 +159,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -309,7 +309,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsRequest;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -429,7 +429,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -482,7 +482,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsResponse);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#jobs:member" translate="no">jobs</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#jobs:member" class="notranslate">jobs</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public jobs: google.cloud.scheduler.v1.IJob[];</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#nextPageToken:member" translate="no">nextPageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#nextPageToken:member" class="notranslate">nextPageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public nextPageToken: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsResponse): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IListJobsResponse);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#jobs:member">jobs</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_jobs_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#jobs:member" translate="no">jobs</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public jobs: google.cloud.scheduler.v1.IJob[];</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#nextPageToken:member">nextPageToken</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_nextPageToken_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#nextPageToken:member" translate="no">nextPageToken</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public nextPageToken: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IListJobsResponse): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IListJobsResponse, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ListJobsResponse;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ListJobsResponse, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ListJobsResponse.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOAuthToken);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#scope:member" translate="no">scope</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#scope:member" class="notranslate">scope</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scope: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#serviceAccountEmail:member" class="notranslate">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOAuthToken): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OAuthToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOAuthToken);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#scope:member">scope</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_scope_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#scope:member" translate="no">scope</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public scope: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#serviceAccountEmail:member">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOAuthToken): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOAuthToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OAuthToken;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OAuthToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OAuthToken.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOidcToken);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#audience:member">audience</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#audience:member" translate="no">audience</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public audience: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#serviceAccountEmail:member">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOidcToken): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OidcToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IOidcToken);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#audience:member" translate="no">audience</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_audience_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#audience:member" class="notranslate">audience</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public audience: string;</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#serviceAccountEmail:member" translate="no">serviceAccountEmail</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_serviceAccountEmail_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#serviceAccountEmail:member" class="notranslate">serviceAccountEmail</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public serviceAccountEmail: string;</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IOidcToken): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IOidcToken, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.OidcToken;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.OidcToken, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.OidcToken.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPauseJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPauseJobRequest): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PauseJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPauseJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPauseJobRequest): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPauseJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PauseJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PauseJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PauseJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPubsubTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#attributes:member" translate="no">attributes</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#attributes:member" class="notranslate">attributes</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attributes: { [k: string]: string };</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#data:member" translate="no">data</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#data:member" class="notranslate">data</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public data: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#topicName:member" translate="no">topicName</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#topicName:member" class="notranslate">topicName</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public topicName: string;</code></pre>
   </div>
@@ -115,7 +115,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPubsubTarget): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -159,7 +159,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -309,7 +309,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -429,7 +429,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PubsubTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -482,7 +482,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IPubsubTarget);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#attributes:member">attributes</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_attributes_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#attributes:member" translate="no">attributes</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public attributes: { [k: string]: string };</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#data:member">data</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_data_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#data:member" translate="no">data</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public data: (Uint8Array|string);</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#topicName:member">topicName</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_topicName_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#topicName:member" translate="no">topicName</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public topicName: string;</code></pre>
   </div>
@@ -115,7 +115,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IPubsubTarget): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -159,7 +159,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -309,7 +309,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IPubsubTarget, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.PubsubTarget;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -429,7 +429,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.PubsubTarget, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -482,7 +482,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.PubsubTarget.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IResumeJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IResumeJobRequest): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ResumeJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IResumeJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IResumeJobRequest): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IResumeJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.ResumeJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.ResumeJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.ResumeJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRetryConfig);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxBackoffDuration:member" translate="no">maxBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxBackoffDuration:member" class="notranslate">maxBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxDoublings:member" translate="no">maxDoublings</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxDoublings:member" class="notranslate">maxDoublings</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxDoublings: number;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxRetryDuration:member" translate="no">maxRetryDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxRetryDuration:member" class="notranslate">maxRetryDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#minBackoffDuration:member" translate="no">minBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#minBackoffDuration:member" class="notranslate">minBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#retryCount:member" translate="no">retryCount</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#retryCount:member" class="notranslate">retryCount</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryCount: number;</code></pre>
   </div>
@@ -159,7 +159,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRetryConfig): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -203,7 +203,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -353,7 +353,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -473,7 +473,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RetryConfig, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -526,7 +526,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRetryConfig);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxBackoffDuration:member">maxBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxBackoffDuration:member" translate="no">maxBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxDoublings:member">maxDoublings</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxDoublings_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxDoublings:member" translate="no">maxDoublings</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxDoublings: number;</code></pre>
   </div>
@@ -91,7 +91,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxRetryDuration:member">maxRetryDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_maxRetryDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#maxRetryDuration:member" translate="no">maxRetryDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public maxRetryDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -113,7 +113,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#minBackoffDuration:member">minBackoffDuration</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_minBackoffDuration_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#minBackoffDuration:member" translate="no">minBackoffDuration</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public minBackoffDuration?: (google.protobuf.IDuration|null);</code></pre>
   </div>
@@ -135,7 +135,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#retryCount:member">retryCount</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_retryCount_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#retryCount:member" translate="no">retryCount</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public retryCount: number;</code></pre>
   </div>
@@ -159,7 +159,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRetryConfig): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -203,7 +203,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -256,7 +256,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -300,7 +300,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -353,7 +353,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRetryConfig, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -406,7 +406,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RetryConfig;</code></pre>
   </div>
@@ -450,7 +450,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -473,7 +473,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RetryConfig, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -526,7 +526,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RetryConfig.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRunJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#name:member" translate="no">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#name:member" class="notranslate">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRunJobRequest): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RunJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IRunJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#name:member">name</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_name_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#name:member" translate="no">name</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public name: string;</code></pre>
   </div>
@@ -71,7 +71,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IRunJobRequest): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -115,7 +115,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -168,7 +168,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -212,7 +212,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -265,7 +265,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IRunJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -318,7 +318,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.RunJobRequest;</code></pre>
   </div>
@@ -362,7 +362,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -385,7 +385,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.RunJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -438,7 +438,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.RunJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest:constructor(1)">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IUpdateJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#job:member">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#job:member" translate="no">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#updateMask:member">updateMask</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#updateMask:member" translate="no">updateMask</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.create:member(1)">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.create:member(1)" translate="no">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IUpdateJobRequest): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decode:member(1)">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decodeDelimited:member(1)">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encode:member(1)">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encodeDelimited:member(1)">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.fromObject:member(1)">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#toJSON:member(1)">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.toObject:member(1)">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.UpdateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.verify:member(1)">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.verify:member(1)" translate="no">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
@@ -17,7 +17,7 @@
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h3 id="constructors">Constructors
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest:constructor(1)" translate="no">(constructor)(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_constructor_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest:constructor(1)" class="notranslate">(constructor)(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">constructor(properties?: google.cloud.scheduler.v1.IUpdateJobRequest);</code></pre>
   </div>
@@ -47,7 +47,7 @@
   </table>
   <h3 id="properties">Properties
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#job:member" translate="no">job</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_job_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#job:member" class="notranslate">job</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public job?: (google.cloud.scheduler.v1.IJob|null);</code></pre>
   </div>
@@ -69,7 +69,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#updateMask:member" translate="no">updateMask</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_updateMask_member" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#updateMask:member" class="notranslate">updateMask</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public updateMask?: (google.protobuf.IFieldMask|null);</code></pre>
   </div>
@@ -93,7 +93,7 @@
   </table>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.create:member(1)" translate="no">create(properties)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_create_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.create:member(1)" class="notranslate">create(properties)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static create(properties?: google.cloud.scheduler.v1.IUpdateJobRequest): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -137,7 +137,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decode:member(1)" translate="no">decode(reader, length)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decode:member(1)" class="notranslate">decode(reader, length)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decode(reader: ($protobuf.Reader|Uint8Array), length?: number): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -190,7 +190,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decodeDelimited:member(1)" translate="no">decodeDelimited(reader)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_decodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.decodeDelimited:member(1)" class="notranslate">decodeDelimited(reader)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static decodeDelimited(reader: ($protobuf.Reader|Uint8Array)): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -234,7 +234,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encode:member(1)" translate="no">encode(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encode_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encode:member(1)" class="notranslate">encode(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encode(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -287,7 +287,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encodeDelimited:member(1)" translate="no">encodeDelimited(message, writer)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_encodeDelimited_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.encodeDelimited:member(1)" class="notranslate">encodeDelimited(message, writer)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static encodeDelimited(message: google.cloud.scheduler.v1.IUpdateJobRequest, writer?: $protobuf.Writer): $protobuf.Writer;</code></pre>
   </div>
@@ -340,7 +340,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.fromObject:member(1)" translate="no">fromObject(object)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_fromObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.fromObject:member(1)" class="notranslate">fromObject(object)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static fromObject(object: { [k: string]: any }): google.cloud.scheduler.v1.UpdateJobRequest;</code></pre>
   </div>
@@ -384,7 +384,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#toJSON:member(1)" translate="no">toJSON()</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toJSON_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest#toJSON:member(1)" class="notranslate">toJSON()</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public toJSON(): { [k: string]: any };</code></pre>
   </div>
@@ -407,7 +407,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.toObject:member(1)" translate="no">toObject(message, options)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_toObject_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.toObject:member(1)" class="notranslate">toObject(message, options)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static toObject(message: google.cloud.scheduler.v1.UpdateJobRequest, options?: $protobuf.IConversionOptions): { [k: string]: any };</code></pre>
   </div>
@@ -460,7 +460,7 @@
       </tr>
     </tbody>
   </table>
-  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.verify:member(1)" translate="no">verify(message)</h4>
+  <h4 id="_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_" data-uid="@google-cloud/scheduler!google.cloud.scheduler.v1.UpdateJobRequest.verify:member(1)" class="notranslate">verify(message)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static verify(message: { [k: string]: any }): (string|null);</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.list_voices">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" class="notranslate">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" class="notranslate">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" class="notranslate">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" class="notranslate">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_file" class="notranslate">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_json" class="notranslate">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.list_voices" class="notranslate">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.synthesize_speech" class="notranslate">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.list_voices">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" class="notranslate">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" class="notranslate">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" class="notranslate">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" class="notranslate">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.list_voices">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechAsyncClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_file">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_json">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.list_voices">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.synthesize_speech">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
@@ -22,7 +22,7 @@
   </div>
   <h3 id="methods">Methods
   </h3>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_file" translate="no">from_service_account_file(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_file" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_file" class="notranslate">from_service_account_file(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_file(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -86,7 +86,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_json" translate="no">from_service_account_json(filename: str, *args, **kwargs)</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_from_service_account_json" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.from_service_account_json" class="notranslate">from_service_account_json(filename: str, *args, **kwargs)</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">from_service_account_json(filename: str, *args, **kwargs)</code></pre>
   </div>
@@ -150,7 +150,7 @@ file.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.list_voices" translate="no">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_list_voices" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.list_voices" class="notranslate">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">list_voices(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesRequest = None, *, language_code: str = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.ListVoicesResponse</code></pre>
   </div>
@@ -246,7 +246,7 @@ method.</p>
       </tr>
     </tbody>
   </table>
-  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.synthesize_speech" translate="no">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
+  <h4 id="google_cloud_texttospeech_v1beta1_services_text_to_speech_TextToSpeechClient_synthesize_speech" data-uid="google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.synthesize_speech" class="notranslate">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</h4>
   <div class="codewrapper">
     <pre><code class="prettyprint">synthesize_speech(request: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechRequest = None, *, input: google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesisInput = None, voice: google.cloud.texttospeech_v1beta1.types.cloud_tts.VoiceSelectionParams = None, audio_config: google.cloud.texttospeech_v1beta1.types.cloud_tts.AudioConfig = None, retry: google.api_core.retry.Retry = &lt;object object&gt;, timeout: float = None, metadata: typing.Sequence[typing.Tuple[str, str]] = ()) -&gt; google.cloud.texttospeech_v1beta1.types.cloud_tts.SynthesizeSpeechResponse</code></pre>
   </div>

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -18,7 +18,7 @@
 {{#overload}}
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
-<h3 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h3>
+<h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h3>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -18,7 +18,7 @@
 {{#overload}}
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
-<h3 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h3>
+<h3 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h3>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -18,7 +18,7 @@
 {{#overload}}
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
-<h4 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h4>
+<h4 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h4>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -18,7 +18,7 @@
 {{#overload}}
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
-<h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+<h4 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h4>
 {{#syntax}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.examples.tmpl.partial
@@ -10,7 +10,7 @@
 {{#codeexamples}}
 {{#name}}
 {{^name.0}}
-<h6 translate="no">{{name}}</h6>
+<h6 class="notranslate">{{name}}</h6>
 {{/name.0}}
 {{/name}}
 <div class="codewrapper">

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -33,7 +33,7 @@
       {{#overload}}
       <a id="{{id}}" data-uid="{{uid}}"></a>
       {{/overload}}
-      <h3 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h3>
+      <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h3>
       {{#syntax}}
       <div class="codewrapper">
         <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>
@@ -218,7 +218,7 @@
       {{#children}}
         {{! Note: don't print the Functions/Methods headers for children of children.}}
         {{#children}}
-          <h4 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h4>
+          <h4 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h4>
           {{#syntax}}
           <div class="codewrapper">	
             <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>	

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -33,7 +33,7 @@
       {{#overload}}
       <a id="{{id}}" data-uid="{{uid}}"></a>
       {{/overload}}
-      <h3 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h3>
+      <h3 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h3>
       {{#syntax}}
       <div class="codewrapper">
         <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>
@@ -218,7 +218,7 @@
       {{#children}}
         {{! Note: don't print the Functions/Methods headers for children of children.}}
         {{#children}}
-          <h4 id="{{id}}" data-uid="{{uid}}">{{name.0.value}}</h4>
+          <h4 id="{{id}}" data-uid="{{uid}}" translate="no">{{name.0.value}}</h4>
           {{#syntax}}
           <div class="codewrapper">	
             <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>	


### PR DESCRIPTION
Using the recently bumped declaration section as a pivot, went through the headers to mark some of the code related ones as `translate="no"`.

Verified by updating the golden tests to see if the relevant header from the template would be code.

Fixes #23 