### PR TITLE
fix: mark summary field verbatim

### DIFF
--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -11,6 +11,7 @@
 </h1>
   
   <aside class="note"><strong>Note:</strong> You can also view this documentation at <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">https://pkg.go.dev/cloud.google.com/go/storage</a>.</aside>
+  {% verbatim %}
   <div class="markdown level0 summary"><p><p>
 Package storage provides an easy way to work with Google Cloud Storage.
 Google Cloud Storage stores data in named objects, which are grouped into buckets.
@@ -242,6 +243,7 @@ These errors can be introspected for more information by type asserting to the r
 }
 </pre>
 </div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="consts">

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package text_to_speech
 </h1>
   
+  {% verbatim %}
   <div class="markdown level0 summary"></div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package types
 </h1>
   
+  {% verbatim %}
   <div class="markdown level0 summary"></div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package text_to_speech
 </h1>
   
+  {% verbatim %}
   <div class="markdown level0 summary"></div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package types
 </h1>
   
+  {% verbatim %}
   <div class="markdown level0 summary"></div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes

--- a/testdata/goldens/python-small/index.html
+++ b/testdata/goldens/python-small/index.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package google-cloud-texttospeech
 </h1>
   
+  {% verbatim %}
   <div class="markdown level0 summary"></div>
+  {% endverbatim %}
   <div class="markdown level0 conceptual"></div>
   <div class="markdown level0 remarks"></div>
     <h2 id="packages">

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -3,7 +3,9 @@
 {{#alt_link}}
 <aside class="note"><strong>Note:</strong> You can also view this documentation at <a href="{{alt_link}}" class="external">{{alt_link}}</a>.</aside>
 {{/alt_link}}
+{% verbatim %}
 <div class="markdown level0 summary">{{{summary}}}</div>
+{% endverbatim %}
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
 {{#package.0}}
 <h6><strong>{{__global.package}}</strong>: {{{value.specName.0.value}}}</h6>


### PR DESCRIPTION
Otherwise, an errant `{{` can mess the template up.

Fixes #140.