### PR TITLE
cleanup: Update hanging test case

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,14 +17,8 @@ import pytest
 
 def pytest_addoption(parser):
     parser.addoption("--update-goldens", action="store", default=False)
-    parser.addoption("--long", action="store", default=False)
 
 
 @pytest.fixture
 def update_goldens(request):
     return request.config.getoption("--update-goldens")
-
-
-@pytest.fixture
-def test_long(request):
-    return request.config.getoption("--long")

--- a/tests/test_hanging.py
+++ b/tests/test_hanging.py
@@ -21,10 +21,7 @@ import pytest
 import subprocess
 
 
-def test_generate(test_long):
-    if not test_long:
-        pytest.skip("skipping hanging test unless --long option is supplied.")
-
+def test_generate():
     build_dir = Path("testdata/nodejs-hang")
     out_dir = build_dir / "site/api"
 
@@ -37,7 +34,7 @@ def test_generate(test_long):
                 "-t",
                 "../../third_party/docfx/templates/devsite",
             ],
-            timeout=7200,
+            timeout=600,
             cwd=build_dir,
             hide_output=False,
         )


### PR DESCRIPTION
Confirmed that running `pytest tests` for all 6 tests takes
roughly around 3 minutes. Set the timeout for hanging
test case down to 10 minutes and included it for all tests.

Fixes #143