### PR TITLE
fix: improve alt link aside text

### DIFF
--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -10,7 +10,9 @@
 <h1 class="page-title">Package cloud.google.com/go/storage
 </h1>
   
-  <aside class="note"><strong>Note:</strong> You can also view this documentation at <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">https://pkg.go.dev/cloud.google.com/go/storage</a>.</aside>
+  <aside class="note">
+    <strong>Note:</strong>To get more information about this package, such as access to older versions, view <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">this package on pkg.go.dev</a>.
+  </aside>
   {% verbatim %}
   <div class="markdown level0 summary"><p><p>
 Package storage provides an easy way to work with Google Cloud Storage.

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -1,7 +1,9 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 {{#alt_link}}
-<aside class="note"><strong>Note:</strong> You can also view this documentation at <a href="{{alt_link}}" class="external">{{alt_link}}</a>.</aside>
+<aside class="note">
+  <strong>Note:</strong>To get more information about this package, such as access to older versions, view <a href="{{alt_link}}" class="external">this package on pkg.go.dev</a>.
+</aside>
 {{/alt_link}}
 {% verbatim %}
 <div class="markdown level0 summary">{{{summary}}}</div>


### PR DESCRIPTION
I didn't use the title of the page because the page title would be less descriptive than what the link is to (pkg.go.dev). For example, see https://pkg.go.dev/cloud.google.com/go/storage.

Fixes #147.

@jennyrosewood, please take a look -- can't add as a reviewer.