### PR TITLE
ci: make UPDATE_GOLDENS only run golden tests

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -28,7 +28,7 @@ black --check tests
 flake8 tests
 
 if [ -n "$UPDATE_GOLDENS" ]; then
-    pytest --update-goldens tests
+    pytest --update-goldens True tests/test_goldens.py
 else
     pytest tests
 fi


### PR DESCRIPTION
This makes updating the goldens locally faster because we don't run the other tests.