### PR TITLE
feat: make implements a comma separated list

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -22,10 +22,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -33,10 +33,10 @@ unmatched_node_count(implicit)</li>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -22,10 +22,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -28,10 +28,10 @@ for more information.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -20,10 +20,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -23,10 +23,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -25,10 +25,10 @@ Pub/Sub topics.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -21,8 +21,8 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Api.Gax.IResourceName</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>&gt;</div>
+    <span><span class="xref">Google.Api.Gax.IResourceName</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -24,10 +24,10 @@ any of them.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -23,10 +23,10 @@ directly or indirectly.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -23,10 +23,10 @@ projects.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -36,10 +36,10 @@ combinations.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -23,10 +23,10 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -22,10 +22,10 @@ access control lists.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -22,10 +22,10 @@ resource, an identity or an access.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -20,10 +20,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -21,11 +21,11 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -21,13 +21,13 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</div>
-    <div><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</div>
-    <div><span class="xref">System.Collections.IEnumerable</span></div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -21,11 +21,11 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;</div>
-    <div><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -21,13 +21,13 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;</div>
-    <div><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</div>
-    <div><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</div>
-    <div><span class="xref">System.Collections.IEnumerable</span></div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a>&gt;,</span>
+    <span><span class="xref">Google.Api.Gax.Grpc.IPageResponse</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.Generic.IEnumerable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;,</span>
+    <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -22,10 +22,10 @@ when it was observed and its status during that window.</p>
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -21,10 +21,10 @@
   </div>
   <div classs="implements">
     <h5>Implements</h5>
-    <div><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IMessage</span></div>
-    <div><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;</div>
-    <div><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;</div>
+    <span><span class="xref">Google.Protobuf.IMessage</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IMessage</span>,</span>
+    <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;,</span>
+    <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers">
     <h5>Inherited Members</h5>

--- a/third_party/docfx/templates/devsite/ManagedReference.extension.js
+++ b/third_party/docfx/templates/devsite/ManagedReference.extension.js
@@ -11,5 +11,11 @@ exports.preTransform = function (model) {
  * This method will be called at the end of exports.transform in ManagedReference.html.primary.js
  */
 exports.postTransform = function (model) {
+  // Set last field of last implements element so we can build a comma separated
+  // list in the template. Otherwise, the final element would have a trailing
+  // comma.
+  if (model.implements) {
+    model.implements[model.implements.length - 1].last = true;
+  }
   return model;
 }

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -16,7 +16,7 @@
   <h5>{{__global.implements}}</h5>
 {{/implements.0}}
 {{#implements}}
-  <div>{{{specName.0.value}}}</div>
+  <span>{{{specName.0.value}}}{{^last}},{{/last}}</span>
 {{/implements}}
 {{#implements.0}}
 </div>


### PR DESCRIPTION
This required some JavaScript trickery because Mustache (the template engine) doesn't have an easy way to do this.

Fixes #146.