### PR TITLE
test: improve golden test failure messages

### DIFF
--- a/tests/test_goldens.py
+++ b/tests/test_goldens.py
@@ -53,9 +53,9 @@ def test_goldens(update_goldens, test_dir):
     got_files = [os.path.relpath(f, out_dir) for f in out_dir.rglob("*")]
     golden_files = [os.path.relpath(f, golden_dir) for f in golden_dir.rglob("*")]
 
-    nl = '\n'
-    extra = 'Extra:\n' + '\n+ '.join([f for f in got_files if f not in golden_files])
-    missing = 'Missing:\n' + '\n- '.join(
+    nl = "\n"
+    extra = "Extra:\n" + "\n+ ".join([f for f in got_files if f not in golden_files])
+    missing = "Missing:\n" + "\n- ".join(
         [f for f in golden_files if f not in got_files]
     )
 
@@ -75,6 +75,6 @@ def test_goldens(update_goldens, test_dir):
                 with open(golden_dir / f) as gold:
                     out_lines = out.readlines()
                     gold_lines = gold.readlines()
-                    diff = '\n'.join(difflib.context_diff(out_lines, gold_lines))
+                    diff = "\n".join(difflib.context_diff(out_lines, gold_lines))
 
         pytest.fail(f"got files that don't match goldens: {diff}")

--- a/tests/test_goldens.py
+++ b/tests/test_goldens.py
@@ -75,6 +75,13 @@ def test_goldens(update_goldens, test_dir):
                 with open(golden_dir / f) as gold:
                     out_lines = out.readlines()
                     gold_lines = gold.readlines()
-                    diff = "\n".join(difflib.context_diff(out_lines, gold_lines))
+                    diff = "\n" + "\n".join(
+                        difflib.context_diff(
+                            gold_lines,
+                            out_lines,
+                            fromfile=str(golden_dir / f),
+                            tofile=str(out_dir / f),
+                        )
+                    )
 
         pytest.fail(f"got files that don't match goldens: {diff}")


### PR DESCRIPTION
This prints an error like this:
```
E           Failed: got files that don't match goldens: 
E           *** testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
E           
E           --- testdata/dotnet/site/api/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
E           
E           ***************
E           
E           *** 4,10 ****
E           
E                 <meta name="project_path" value="/dotnet/_project.yaml">
E           
E                 <meta name="book_path" value="/dotnet/_book.yaml">
E           
E               </head>
E           
E           !   <body> uh oh
E           
E                 <div>
E           
E                   <article data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest">
E           
E             <h1 class="page-title">Class AnalyzeIamPolicyRequest
E           
E           --- 4,10 ----
E           
E                 <meta name="project_path" value="/dotnet/_project.yaml">
E           
E                 <meta name="book_path" value="/dotnet/_book.yaml">
E           
E               </head>
E           
E           !   <body>
E           
E                 <div>
E           
E                   <article data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest">
E           
E             <h1 class="page-title">Class AnalyzeIamPolicyRequest

tests/test_goldens.py:87: Failed
```