### PR TITLE
fix: add space in alt link note

### DIFF
--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -11,7 +11,7 @@
 </h1>
   
   <aside class="note">
-    <strong>Note:</strong>To get more information about this package, such as access to older versions, view <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">this package on pkg.go.dev</a>.
+    <strong>Note:</strong> To get more information about this package, such as access to older versions, view <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">this package on pkg.go.dev</a>.
   </aside>
   {% verbatim %}
   <div class="markdown level0 summary"><p><p>

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -2,7 +2,7 @@
 
 {{#alt_link}}
 <aside class="note">
-  <strong>Note:</strong>To get more information about this package, such as access to older versions, view <a href="{{alt_link}}" class="external">this package on pkg.go.dev</a>.
+  <strong>Note:</strong> To get more information about this package, such as access to older versions, view <a href="{{alt_link}}" class="external">this package on pkg.go.dev</a>.
 </aside>
 {{/alt_link}}
 {% verbatim %}


### PR DESCRIPTION
cc @jennyrosewood