### PR TITLE
chore: don't show 'namespace'/'assembly' section when not available

### DIFF
--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeMetadata_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeMetadata.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeMetadata.Builder&gt; implements LongRunningRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeMetadata_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeMetadata extends GeneratedMessageV3 implements LongRunningRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeMetadataOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeMetadataOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeRequest.Builder&gt; implements LongRunningRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeRequest extends GeneratedMessageV3 implements LongRunningRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
@@ -223,8 +223,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeResponse.Builder&gt; implements LongRunningRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
@@ -268,8 +268,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeResponse extends GeneratedMessageV3 implements LongRunningRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_LongRunningRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
@@ -69,8 +69,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionAudio_AudioSourceCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionAudio.AudioSourceCase extends Enum&lt;RecognitionAudio.AudioSourceCase&gt; implements Internal.EnumLite, AbstractMessageLite.InternalOneOfEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
@@ -222,8 +222,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionAudio_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionAudio.Builder extends GeneratedMessageV3.Builder&lt;RecognitionAudio.Builder&gt; implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
@@ -267,8 +267,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionAudio_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionAudio extends GeneratedMessageV3 implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionAudioOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionAudioOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
@@ -88,8 +88,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionConfig_AudioEncoding_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionConfig.AudioEncoding extends Enum&lt;RecognitionConfig.AudioEncoding&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;RecognitionConfig.Builder&gt; implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionConfig extends GeneratedMessageV3 implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionMetadata.Builder extends GeneratedMessageV3.Builder&lt;RecognitionMetadata.Builder&gt; implements RecognitionMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
@@ -71,8 +71,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_InteractionType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.InteractionType extends Enum&lt;RecognitionMetadata.InteractionType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_MicrophoneDistance_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.MicrophoneDistance extends Enum&lt;RecognitionMetadata.MicrophoneDistance&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_OriginalMediaType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.OriginalMediaType extends Enum&lt;RecognitionMetadata.OriginalMediaType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_RecordingDeviceType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.RecordingDeviceType extends Enum&lt;RecognitionMetadata.RecordingDeviceType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadata_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionMetadata extends GeneratedMessageV3 implements RecognitionMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognitionMetadataOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionMetadataOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;RecognizeRequest.Builder&gt; implements RecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognizeRequest extends GeneratedMessageV3 implements RecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;RecognizeResponse.Builder&gt; implements RecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognizeResponse extends GeneratedMessageV3 implements RecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_RecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeakerDiarizationConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeakerDiarizationConfig.Builder extends GeneratedMessageV3.Builder&lt;SpeakerDiarizationConfig.Builder&gt; implements SpeakerDiarizationConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeakerDiarizationConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeakerDiarizationConfig extends GeneratedMessageV3 implements SpeakerDiarizationConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeakerDiarizationConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeakerDiarizationConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
@@ -85,8 +85,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechClient_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechClient implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechContext_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechContext.Builder extends GeneratedMessageV3.Builder&lt;SpeechContext.Builder&gt; implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechContext_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechContext extends GeneratedMessageV3 implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechContextOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechContextOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechBlockingStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechBlockingStub extends AbstractBlockingStub&lt;SpeechGrpc.SpeechBlockingStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechFutureStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechFutureStub extends AbstractFutureStub&lt;SpeechGrpc.SpeechFutureStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
@@ -59,8 +59,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract static class SpeechGrpc.SpeechImplBase implements BindableService</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechStub extends AbstractAsyncStub&lt;SpeechGrpc.SpeechStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechGrpc_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechGrpc</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
@@ -54,8 +54,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechProto_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechProto</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionAlternative_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionAlternative.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionAlternative.Builder&gt; implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionAlternative_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionAlternative extends GeneratedMessageV3 implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionAlternativeOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionAlternativeOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionResult.Builder&gt; implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionResult extends GeneratedMessageV3 implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
@@ -128,8 +128,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class SpeechSettings.Builder extends ClientSettings.Builder&lt;SpeechSettings,SpeechSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_SpeechSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechSettings extends ClientSettings&lt;SpeechSettings&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionConfig.Builder&gt; implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionConfig extends GeneratedMessageV3 implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionResult.Builder&gt; implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionResult extends GeneratedMessageV3 implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
@@ -223,8 +223,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeRequest.Builder&gt; implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -69,8 +69,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeRequest_StreamingRequestCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeRequest.StreamingRequestCase extends Enum&lt;StreamingRecognizeRequest.StreamingRequestCase&gt; implements Internal.EnumLite, AbstractMessageLite.InternalOneOfEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
@@ -268,8 +268,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeRequest extends GeneratedMessageV3 implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
@@ -254,8 +254,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeResponse.Builder&gt; implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeResponse_SpeechEventType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeResponse.SpeechEventType extends Enum&lt;StreamingRecognizeResponse.SpeechEventType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
@@ -299,8 +299,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeResponse extends GeneratedMessageV3 implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_StreamingRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_WordInfo_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class WordInfo.Builder extends GeneratedMessageV3.Builder&lt;WordInfo.Builder&gt; implements WordInfoOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_WordInfo_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class WordInfo extends GeneratedMessageV3 implements WordInfoOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_WordInfoOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface WordInfoOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_stub_GrpcSpeechCallableFactory_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcSpeechCallableFactory implements GrpcStubCallableFactory</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
@@ -75,8 +75,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcSpeechStub extends SpeechStub</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_stub_SpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract class SpeechStub implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
@@ -131,8 +131,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class SpeechStubSettings.Builder extends StubSettings.Builder&lt;SpeechStubSettings,SpeechStubSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1_stub_SpeechStubSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechStubSettings extends StubSettings&lt;SpeechStubSettings&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeMetadata_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AsyncRecognizeMetadata.Builder extends GeneratedMessageV3.Builder&lt;AsyncRecognizeMetadata.Builder&gt; implements AsyncRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeMetadata_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class AsyncRecognizeMetadata extends GeneratedMessageV3 implements AsyncRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeMetadataOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface AsyncRecognizeMetadataOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AsyncRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;AsyncRecognizeRequest.Builder&gt; implements AsyncRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class AsyncRecognizeRequest extends GeneratedMessageV3 implements AsyncRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface AsyncRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
@@ -222,8 +222,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AsyncRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;AsyncRecognizeResponse.Builder&gt; implements AsyncRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
@@ -267,8 +267,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class AsyncRecognizeResponse extends GeneratedMessageV3 implements AsyncRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_AsyncRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface AsyncRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
@@ -68,8 +68,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionAudio_AudioSourceCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionAudio.AudioSourceCase extends Enum&lt;RecognitionAudio.AudioSourceCase&gt; implements Internal.EnumLite</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
@@ -222,8 +222,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionAudio_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionAudio.Builder extends GeneratedMessageV3.Builder&lt;RecognitionAudio.Builder&gt; implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
@@ -267,8 +267,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionAudio_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionAudio extends GeneratedMessageV3 implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionAudioOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionAudioOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
@@ -77,8 +77,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionConfig_AudioEncoding_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionConfig.AudioEncoding extends Enum&lt;RecognitionConfig.AudioEncoding&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;RecognitionConfig.Builder&gt; implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionConfig extends GeneratedMessageV3 implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_RecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechContext_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechContext.Builder extends GeneratedMessageV3.Builder&lt;SpeechContext.Builder&gt; implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechContext_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechContext extends GeneratedMessageV3 implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechContextOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechContextOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -104,8 +104,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechBlockingStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechBlockingStub extends AbstractStub&lt;SpeechGrpc.SpeechBlockingStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -104,8 +104,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechFutureStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechFutureStub extends AbstractStub&lt;SpeechGrpc.SpeechFutureStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
@@ -59,8 +59,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechImplBase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract static class SpeechGrpc.SpeechImplBase implements BindableService</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
@@ -104,8 +104,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechStub extends AbstractStub&lt;SpeechGrpc.SpeechStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechGrpc_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechGrpc</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
@@ -54,8 +54,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechProto_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechProto</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionAlternative_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionAlternative.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionAlternative.Builder&gt; implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionAlternative_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionAlternative extends GeneratedMessageV3 implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionAlternativeOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionAlternativeOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionResult.Builder&gt; implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionResult extends GeneratedMessageV3 implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SpeechRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionConfig.Builder&gt; implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionConfig extends GeneratedMessageV3 implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionResult.Builder&gt; implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionResult extends GeneratedMessageV3 implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
@@ -223,8 +223,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeRequest.Builder&gt; implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -68,8 +68,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeRequest_StreamingRequestCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeRequest.StreamingRequestCase extends Enum&lt;StreamingRecognizeRequest.StreamingRequestCase&gt; implements Internal.EnumLite</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
@@ -268,8 +268,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeRequest extends GeneratedMessageV3 implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
@@ -262,8 +262,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeResponse.Builder&gt; implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeResponse_EndpointerType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeResponse.EndpointerType extends Enum&lt;StreamingRecognizeResponse.EndpointerType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
@@ -307,8 +307,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeResponse extends GeneratedMessageV3 implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_StreamingRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SyncRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;SyncRecognizeRequest.Builder&gt; implements SyncRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SyncRecognizeRequest extends GeneratedMessageV3 implements SyncRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SyncRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SyncRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;SyncRecognizeResponse.Builder&gt; implements SyncRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SyncRecognizeResponse extends GeneratedMessageV3 implements SyncRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1beta1_SyncRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SyncRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
@@ -73,8 +73,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListCustomClassesFixedSizeCollection_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListCustomClassesFixedSizeCollection extends AbstractFixedSizeCollection&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass,AdaptationClient.ListCustomClassesPage,AdaptationClient.ListCustomClassesFixedSizeCollection&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
@@ -91,8 +91,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListCustomClassesPage_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListCustomClassesPage extends AbstractPage&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass,AdaptationClient.ListCustomClassesPage&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
@@ -73,8 +73,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListCustomClassesPagedResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListCustomClassesPagedResponse extends AbstractPagedListResponse&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass,AdaptationClient.ListCustomClassesPage,AdaptationClient.ListCustomClassesFixedSizeCollection&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
@@ -73,8 +73,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListPhraseSetFixedSizeCollection_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListPhraseSetFixedSizeCollection extends AbstractFixedSizeCollection&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet,AdaptationClient.ListPhraseSetPage,AdaptationClient.ListPhraseSetFixedSizeCollection&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
@@ -91,8 +91,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListPhraseSetPage_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListPhraseSetPage extends AbstractPage&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet,AdaptationClient.ListPhraseSetPage&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
@@ -73,8 +73,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_ListPhraseSetPagedResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationClient.ListPhraseSetPagedResponse extends AbstractPagedListResponse&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet,AdaptationClient.ListPhraseSetPage,AdaptationClient.ListPhraseSetFixedSizeCollection&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
@@ -87,8 +87,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class AdaptationClient implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationBlockingStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AdaptationGrpc.AdaptationBlockingStub extends AbstractBlockingStub&lt;AdaptationGrpc.AdaptationBlockingStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationFutureStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AdaptationGrpc.AdaptationFutureStub extends AbstractFutureStub&lt;AdaptationGrpc.AdaptationFutureStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
@@ -59,8 +59,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract static class AdaptationGrpc.AdaptationImplBase implements BindableService</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class AdaptationGrpc.AdaptationStub extends AbstractAsyncStub&lt;AdaptationGrpc.AdaptationStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class AdaptationGrpc</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
@@ -128,8 +128,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationSettings.Builder extends ClientSettings.Builder&lt;AdaptationSettings,AdaptationSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class AdaptationSettings extends ClientSettings&lt;AdaptationSettings&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreateCustomClassRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class CreateCustomClassRequest.Builder extends GeneratedMessageV3.Builder&lt;CreateCustomClassRequest.Builder&gt; implements CreateCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreateCustomClassRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class CreateCustomClassRequest extends GeneratedMessageV3 implements CreateCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreateCustomClassRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface CreateCustomClassRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreatePhraseSetRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class CreatePhraseSetRequest.Builder extends GeneratedMessageV3.Builder&lt;CreatePhraseSetRequest.Builder&gt; implements CreatePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreatePhraseSetRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class CreatePhraseSetRequest extends GeneratedMessageV3 implements CreatePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CreatePhraseSetRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface CreatePhraseSetRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClass_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class CustomClass.Builder extends GeneratedMessageV3.Builder&lt;CustomClass.Builder&gt; implements CustomClassOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClass_ClassItem_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class CustomClass.ClassItem.Builder extends GeneratedMessageV3.Builder&lt;CustomClass.ClassItem.Builder&gt; implements CustomClass.ClassItemOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClass_ClassItem_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class CustomClass.ClassItem extends GeneratedMessageV3 implements CustomClass.ClassItemOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClass_ClassItemOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static interface CustomClass.ClassItemOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClass_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class CustomClass extends GeneratedMessageV3 implements CustomClassOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClassName_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class CustomClassName.Builder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
@@ -58,8 +58,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClassName_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class CustomClassName implements ResourceName</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_CustomClassOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface CustomClassOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class DeleteCustomClassRequest.Builder extends GeneratedMessageV3.Builder&lt;DeleteCustomClassRequest.Builder&gt; implements DeleteCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class DeleteCustomClassRequest extends GeneratedMessageV3 implements DeleteCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface DeleteCustomClassRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeletePhraseSetRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class DeletePhraseSetRequest.Builder extends GeneratedMessageV3.Builder&lt;DeletePhraseSetRequest.Builder&gt; implements DeletePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeletePhraseSetRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class DeletePhraseSetRequest extends GeneratedMessageV3 implements DeletePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_DeletePhraseSetRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface DeletePhraseSetRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetCustomClassRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class GetCustomClassRequest.Builder extends GeneratedMessageV3.Builder&lt;GetCustomClassRequest.Builder&gt; implements GetCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetCustomClassRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class GetCustomClassRequest extends GeneratedMessageV3 implements GetCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetCustomClassRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface GetCustomClassRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetPhraseSetRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class GetPhraseSetRequest.Builder extends GeneratedMessageV3.Builder&lt;GetPhraseSetRequest.Builder&gt; implements GetPhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetPhraseSetRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class GetPhraseSetRequest extends GeneratedMessageV3 implements GetPhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_GetPhraseSetRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface GetPhraseSetRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class ListCustomClassesRequest.Builder extends GeneratedMessageV3.Builder&lt;ListCustomClassesRequest.Builder&gt; implements ListCustomClassesRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class ListCustomClassesRequest extends GeneratedMessageV3 implements ListCustomClassesRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface ListCustomClassesRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class ListCustomClassesResponse.Builder extends GeneratedMessageV3.Builder&lt;ListCustomClassesResponse.Builder&gt; implements ListCustomClassesResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class ListCustomClassesResponse extends GeneratedMessageV3 implements ListCustomClassesResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListCustomClassesResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface ListCustomClassesResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class ListPhraseSetRequest.Builder extends GeneratedMessageV3.Builder&lt;ListPhraseSetRequest.Builder&gt; implements ListPhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class ListPhraseSetRequest extends GeneratedMessageV3 implements ListPhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface ListPhraseSetRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class ListPhraseSetResponse.Builder extends GeneratedMessageV3.Builder&lt;ListPhraseSetResponse.Builder&gt; implements ListPhraseSetResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class ListPhraseSetResponse extends GeneratedMessageV3 implements ListPhraseSetResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_ListPhraseSetResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface ListPhraseSetResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LocationName_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class LocationName.Builder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
@@ -58,8 +58,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LocationName_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class LocationName implements ResourceName</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeMetadata_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeMetadata.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeMetadata.Builder&gt; implements LongRunningRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeMetadata_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeMetadata extends GeneratedMessageV3 implements LongRunningRecognizeMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeMetadataOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeMetadataOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeRequest.Builder&gt; implements LongRunningRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeRequest extends GeneratedMessageV3 implements LongRunningRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
@@ -223,8 +223,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class LongRunningRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;LongRunningRecognizeResponse.Builder&gt; implements LongRunningRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
@@ -268,8 +268,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class LongRunningRecognizeResponse extends GeneratedMessageV3 implements LongRunningRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_LongRunningRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface LongRunningRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSet_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class PhraseSet.Builder extends GeneratedMessageV3.Builder&lt;PhraseSet.Builder&gt; implements PhraseSetOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
@@ -236,8 +236,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSet_Phrase_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class PhraseSet.Phrase.Builder extends GeneratedMessageV3.Builder&lt;PhraseSet.Phrase.Builder&gt; implements PhraseSet.PhraseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
@@ -281,8 +281,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSet_Phrase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class PhraseSet.Phrase extends GeneratedMessageV3 implements PhraseSet.PhraseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSet_PhraseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static interface PhraseSet.PhraseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSet_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class PhraseSet extends GeneratedMessageV3 implements PhraseSetOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSetName_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class PhraseSetName.Builder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
@@ -58,8 +58,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSetName_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class PhraseSetName implements ResourceName</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_PhraseSetOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface PhraseSetOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
@@ -69,8 +69,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionAudio_AudioSourceCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionAudio.AudioSourceCase extends Enum&lt;RecognitionAudio.AudioSourceCase&gt; implements Internal.EnumLite, AbstractMessageLite.InternalOneOfEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
@@ -222,8 +222,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionAudio_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionAudio.Builder extends GeneratedMessageV3.Builder&lt;RecognitionAudio.Builder&gt; implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
@@ -267,8 +267,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionAudio_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionAudio extends GeneratedMessageV3 implements RecognitionAudioOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionAudioOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionAudioOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
@@ -89,8 +89,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionConfig_AudioEncoding_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionConfig.AudioEncoding extends Enum&lt;RecognitionConfig.AudioEncoding&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;RecognitionConfig.Builder&gt; implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionConfig extends GeneratedMessageV3 implements RecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognitionMetadata.Builder extends GeneratedMessageV3.Builder&lt;RecognitionMetadata.Builder&gt; implements RecognitionMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
@@ -71,8 +71,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_InteractionType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.InteractionType extends Enum&lt;RecognitionMetadata.InteractionType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_MicrophoneDistance_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.MicrophoneDistance extends Enum&lt;RecognitionMetadata.MicrophoneDistance&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_OriginalMediaType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.OriginalMediaType extends Enum&lt;RecognitionMetadata.OriginalMediaType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_RecordingDeviceType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum RecognitionMetadata.RecordingDeviceType extends Enum&lt;RecognitionMetadata.RecordingDeviceType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadata_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognitionMetadata extends GeneratedMessageV3 implements RecognitionMetadataOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognitionMetadataOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognitionMetadataOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;RecognizeRequest.Builder&gt; implements RecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognizeRequest extends GeneratedMessageV3 implements RecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
@@ -221,8 +221,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class RecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;RecognizeResponse.Builder&gt; implements RecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
@@ -266,8 +266,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class RecognizeResponse extends GeneratedMessageV3 implements RecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_RecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface RecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeakerDiarizationConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeakerDiarizationConfig.Builder extends GeneratedMessageV3.Builder&lt;SpeakerDiarizationConfig.Builder&gt; implements SpeakerDiarizationConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeakerDiarizationConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeakerDiarizationConfig extends GeneratedMessageV3 implements SpeakerDiarizationConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeakerDiarizationConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeakerDiarizationConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechAdaptation_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechAdaptation.Builder extends GeneratedMessageV3.Builder&lt;SpeechAdaptation.Builder&gt; implements SpeechAdaptationOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechAdaptation_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechAdaptation extends GeneratedMessageV3 implements SpeechAdaptationOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechAdaptationOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechAdaptationOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
@@ -54,8 +54,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechAdaptationProto_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechAdaptationProto</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
@@ -85,8 +85,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechClient_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechClient implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechContext_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechContext.Builder extends GeneratedMessageV3.Builder&lt;SpeechContext.Builder&gt; implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechContext_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechContext extends GeneratedMessageV3 implements SpeechContextOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechContextOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechContextOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechBlockingStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechBlockingStub extends AbstractBlockingStub&lt;SpeechGrpc.SpeechBlockingStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechFutureStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechFutureStub extends AbstractFutureStub&lt;SpeechGrpc.SpeechFutureStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
@@ -59,8 +59,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract static class SpeechGrpc.SpeechImplBase implements BindableService</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
@@ -105,8 +105,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechGrpc.SpeechStub extends AbstractAsyncStub&lt;SpeechGrpc.SpeechStub&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
@@ -55,8 +55,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechGrpc</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
@@ -54,8 +54,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechProto_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechProto</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionAlternative_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionAlternative.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionAlternative.Builder&gt; implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionAlternative_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionAlternative extends GeneratedMessageV3 implements SpeechRecognitionAlternativeOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionAlternativeOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionAlternativeOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class SpeechRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;SpeechRecognitionResult.Builder&gt; implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechRecognitionResult extends GeneratedMessageV3 implements SpeechRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface SpeechRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
@@ -54,8 +54,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechResourceProto_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class SpeechResourceProto</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
@@ -128,8 +128,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class SpeechSettings.Builder extends ClientSettings.Builder&lt;SpeechSettings,SpeechSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_SpeechSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechSettings extends ClientSettings&lt;SpeechSettings&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionConfig_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionConfig.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionConfig.Builder&gt; implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionConfig_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionConfig extends GeneratedMessageV3 implements StreamingRecognitionConfigOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionConfigOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionConfigOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
@@ -220,8 +220,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionResult_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognitionResult.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognitionResult.Builder&gt; implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
@@ -265,8 +265,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionResult_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognitionResult extends GeneratedMessageV3 implements StreamingRecognitionResultOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognitionResultOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognitionResultOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
@@ -223,8 +223,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeRequest.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeRequest.Builder&gt; implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -69,8 +69,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeRequest_StreamingRequestCase_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeRequest.StreamingRequestCase extends Enum&lt;StreamingRecognizeRequest.StreamingRequestCase&gt; implements Internal.EnumLite, AbstractMessageLite.InternalOneOfEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
@@ -268,8 +268,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeRequest extends GeneratedMessageV3 implements StreamingRecognizeRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
@@ -254,8 +254,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponse_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingRecognizeResponse.Builder extends GeneratedMessageV3.Builder&lt;StreamingRecognizeResponse.Builder&gt; implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
@@ -70,8 +70,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponse_SpeechEventType_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public enum StreamingRecognizeResponse.SpeechEventType extends Enum&lt;StreamingRecognizeResponse.SpeechEventType&gt; implements ProtocolMessageEnum</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
@@ -299,8 +299,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponse_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class StreamingRecognizeResponse extends GeneratedMessageV3 implements StreamingRecognizeResponseOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponseOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface StreamingRecognizeResponseOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class UpdateCustomClassRequest.Builder extends GeneratedMessageV3.Builder&lt;UpdateCustomClassRequest.Builder&gt; implements UpdateCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class UpdateCustomClassRequest extends GeneratedMessageV3 implements UpdateCustomClassRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface UpdateCustomClassRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdatePhraseSetRequest_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class UpdatePhraseSetRequest.Builder extends GeneratedMessageV3.Builder&lt;UpdatePhraseSetRequest.Builder&gt; implements UpdatePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdatePhraseSetRequest_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class UpdatePhraseSetRequest extends GeneratedMessageV3 implements UpdatePhraseSetRequestOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_UpdatePhraseSetRequestOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface UpdatePhraseSetRequestOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
@@ -219,8 +219,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_WordInfo_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class WordInfo.Builder extends GeneratedMessageV3.Builder&lt;WordInfo.Builder&gt; implements WordInfoOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
@@ -264,8 +264,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_WordInfo_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final class WordInfo extends GeneratedMessageV3 implements WordInfoOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
@@ -17,8 +17,6 @@
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_WordInfoOrBuilder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public interface WordInfoOrBuilder extends MessageOrBuilder</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract class AdaptationStub implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
@@ -131,8 +131,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class AdaptationStubSettings.Builder extends StubSettings.Builder&lt;AdaptationStubSettings,AdaptationStubSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class AdaptationStubSettings extends StubSettings&lt;AdaptationStubSettings&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationCallableFactory_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcAdaptationCallableFactory implements GrpcStubCallableFactory</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
@@ -96,8 +96,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcAdaptationStub extends AdaptationStub</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechCallableFactory_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcSpeechCallableFactory implements GrpcStubCallableFactory</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
@@ -75,8 +75,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class GrpcSpeechStub extends SpeechStub</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
@@ -60,8 +60,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStub_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract class SpeechStub implements BackgroundResource</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
@@ -131,8 +131,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static class SpeechStubSettings.Builder extends StubSettings.Builder&lt;SpeechStubSettings,SpeechStubSettings.Builder&gt;</code></pre>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
@@ -111,8 +111,6 @@
       <span class="xref">java.lang.Object.wait(long,int)</span>
     </div>
   </div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint">public class SpeechStubSettings extends StubSettings&lt;SpeechStubSettings&gt;</code></pre>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
@@ -14,8 +14,6 @@
   <div class="markdown level0 summary"><p>HttpMethod enum.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpMethod_enum_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint"></code></pre>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
@@ -14,8 +14,6 @@
   <div class="markdown level0 summary"><p>State enum.</p>
 </div>
   <div class="markdown level0 conceptual"></div>
-  <h6><strong>Namespace</strong>: </h6>
-  <h6><strong>Assembly</strong>: .dll</h6>
   <h5 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_State_enum_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint"></code></pre>

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -48,8 +48,10 @@
 {{#derivedClasses.0}}
 </div>
 {{/derivedClasses.0}}
-{{#assemblies.0}}
+{{#namespace.specName.0.value}}
 <h6><strong>{{__global.namespace}}</strong>: {{{namespace.specName.0.value}}}</h6>
+{{/namespace.specName.0.value}}
+{{#assemblies.0}}
 <h6><strong>{{__global.assembly}}</strong>: {{assemblies.0}}.dll</h6>
 {{/assemblies.0}}
 <h5 id="{{id}}_syntax">{{__global.syntax}}</h5>

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -48,8 +48,10 @@
 {{#derivedClasses.0}}
 </div>
 {{/derivedClasses.0}}
+{{#assemblies.0}}
 <h6><strong>{{__global.namespace}}</strong>: {{{namespace.specName.0.value}}}</h6>
 <h6><strong>{{__global.assembly}}</strong>: {{assemblies.0}}.dll</h6>
+{{/assemblies.0}}
 <h5 id="{{id}}_syntax">{{__global.syntax}}</h5>
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>


### PR DESCRIPTION
Fixes #179730104

updating third_party/docfx/templates/devsite/partials/class.header.tmpl.partial to only show 'Namespace' and 'Assembly' section when available. Still needed and shows for .NET but updates java and nodejs html generation

