### PR TITLE
chore: only include 'summary' + 'conceptual' divs when available

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>A request message for
 [google.cloud.asset.v1.AssetService.AnalyzeIamPolicy][google.cloud.asset.v1.AssetService.AnalyzeIamPolicy].</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyRequest_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest)" class="notranslate">AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyRequest(AnalyzeIamPolicyRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>The request query.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,7 +128,6 @@ If it&apos;s not finished until then, you will get a  DEADLINE_EXCEEDED error.</
 (--   other purposes could make our backend system harder to reason  --)
 (--   about.                                                         --)</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.NodeType.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Type of the node.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_Types_NodeType_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the Stats message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -25,7 +25,6 @@ execution_timeout_node_count + other_unexplored_node_count(implicit)</li>
 unmatched_node_count(implicit)</li>
 </ul>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -66,15 +65,11 @@ unmatched_node_count(implicit)</li>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_Types_Stats_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)" class="notranslate">Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Stats(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -102,7 +97,6 @@ unmatched_node_count(implicit)</li>
   <div class="markdown level1 summary"><p>The count of nodes that get explored, but are capped by max fanout
 setting.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -125,7 +119,6 @@ setting.</p>
   </div>
   <div class="markdown level1 summary"><p>The count of discovered nodes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,7 +141,6 @@ setting.</p>
   </div>
   <div class="markdown level1 summary"><p>The count of unexplored nodes caused by execution timeout.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,7 +163,6 @@ setting.</p>
   </div>
   <div class="markdown level1 summary"><p>The count of explored nodes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -195,7 +186,6 @@ setting.</p>
   <div class="markdown level1 summary"><p>The count of nodes that match the query. These nodes form a sub-graph
 of discovered nodes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -224,7 +214,6 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
 <li>For Access: Role or Permission</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -247,7 +236,6 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
   </div>
   <div class="markdown level1 summary"><p>Node type.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -270,7 +258,6 @@ cloudresourcemanager.googleapis.com/Organization, etc.</li>
   </div>
   <div class="markdown level1 summary"><p>The count of unexplored nodes caused by permission denied error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the IamPolicyAnalysis message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>An analysis message to group the query and results.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_Types_IamPolicyAnalysis_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)" class="notranslate">IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysis(AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>The analysis query.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,7 +107,6 @@
   <div class="markdown level1 summary"><p>A list of [google.cloud.asset.v1.IamPolicyAnalysisResult][google.cloud.asset.v1.IamPolicyAnalysisResult]
 that matches the analysis query, or empty if no result is found.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +131,6 @@ that matches the analysis query, or empty if no result is found.</p>
 [analysis_results][analysis_results] have been fully explored to answer
 the query.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,7 +153,6 @@ the query.</p>
   </div>
   <div class="markdown level1 summary"><p>A list of non-critical errors happened during the query handling.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -184,7 +175,6 @@ the query.</p>
   </div>
   <div class="markdown level1 summary"><p>The stats of how the analysis has been explored.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the AnalyzeIamPolicyResponse message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>A response message for
 [google.cloud.asset.v1.AssetService.AnalyzeIamPolicy][google.cloud.asset.v1.AssetService.AnalyzeIamPolicy].</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse__ctor_Google_Cloud_Asset_V1_AnalyzeIamPolicyResponse_" data-uid="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.#ctor(Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse)" class="notranslate">AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse(AnalyzeIamPolicyResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +87,6 @@
 [service_account_impersonation_analysis][] have been fully explored to
 answer the query in the request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,7 +109,6 @@ answer the query in the request.</p>
   </div>
   <div class="markdown level1 summary"><p>The main analysis that matches the original request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,7 +133,6 @@ answer the query in the request.</p>
 [google.cloud.asset.v1.AnalyzeIamPolicyRequest.analyze_service_account_impersonation][google.cloud.asset.v1.AnalyzeIamPolicyRequest.analyze_service_account_impersonation]
 is enabled.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.AccessContextPolicyOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.AccessContextPolicyOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;access_context_policy&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_Asset_AccessContextPolicyOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -20,7 +20,6 @@ See <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types
 types</a>
 for more information.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -61,15 +60,11 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Asset__ctor_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Asset__ctor_Google_Cloud_Asset_V1_Asset_" data-uid="Google.Cloud.Asset.V1.Asset.#ctor(Google.Cloud.Asset.V1.Asset)" class="notranslate">Asset(Asset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset(Asset other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,8 +89,6 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset.AccessContextPolicyOneofCase AccessContextPolicyCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +112,6 @@ for more information.</p>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-levels">access level user
 guide</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +135,6 @@ guide</a>.</p>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-policies">access policy user
 guide</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +163,6 @@ is a project, folder, or organization, the ancestry path starts from the
 asset itself.</p>
 <p>Example: <code>[&amp;quot;projects/123456789&amp;quot;, &amp;quot;folders/5432&amp;quot;, &amp;quot;organizations/1234&amp;quot;]</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -198,7 +188,6 @@ asset itself.</p>
 types</a>
 for more information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,7 +218,6 @@ the hierarchy. See
 <a href="https://cloud.google.com/iam/docs/policies#inheritance">this topic</a> for
 more information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,7 +244,6 @@ more information.</p>
 names</a>
 for more information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -282,7 +269,6 @@ policy</a>.
 There can be more than one organization policy with different constraints
 set on a given resource.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -305,7 +291,6 @@ set on a given resource.</p>
   </div>
   <div class="markdown level1 summary"><p>A representation of the resource.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -328,7 +313,6 @@ set on a given resource.</p>
   </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Asset.html#Google_Cloud_Asset_V1_Asset_Name">Name</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -352,7 +336,6 @@ set on a given resource.</p>
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/vpc-service-controls/docs/overview">service perimeter user
 guide</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,7 +359,6 @@ guide</a>.</p>
   <div class="markdown level1 summary"><p>The last update timestamp of an asset. update_time is updated when
 create/update/delete operation is performed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Base class for server-side implementations of AssetService</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -51,7 +50,6 @@ public abstract class AssetServiceBase</code></pre>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +103,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,7 +151,6 @@ error.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +198,6 @@ asset updates.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -259,7 +254,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +309,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,7 +403,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,7 +453,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -513,7 +503,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -561,7 +550,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Client for AssetService</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -57,7 +56,6 @@
   </div>
   <div class="markdown level1 summary"><p>Protected parameterless constructor to allow creation of test doubles.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)" class="notranslate">AssetServiceClient(CallInvoker)</h3>
   <div class="codewrapper">
@@ -65,7 +63,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new client for AssetService that uses a custom <code>CallInvoker</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +88,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new client for AssetService</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +113,6 @@
   </div>
   <div class="markdown level1 summary"><p>Protected constructor to allow creation of configured clients.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,7 +141,6 @@
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -195,7 +189,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,7 +249,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -305,7 +297,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,7 +362,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -425,7 +415,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -491,7 +480,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -545,7 +533,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,7 +593,6 @@ error.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,7 +641,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,7 +701,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,7 +749,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,7 +809,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a new instance of <span class="xref">Google.LongRunning.Operations.OperationsClient</span> using the same call invoker as
 this client.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,7 +832,6 @@ this client.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -898,7 +879,6 @@ this client.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,7 +938,6 @@ this client.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1006,7 +985,6 @@ this client.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1075,7 +1053,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1132,7 +1109,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1201,7 +1177,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1258,7 +1233,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1326,7 +1300,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1382,7 +1355,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1450,7 +1422,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,7 +1477,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1566,7 +1536,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1614,7 +1583,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1674,7 +1642,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1722,7 +1689,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1782,7 +1748,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1830,7 +1795,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1890,7 +1854,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1938,7 +1901,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1998,7 +1960,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Creates a new instance of client from given <code>ClientBaseConfiguration</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2043,7 +2004,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2094,7 +2054,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2157,7 +2116,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2208,7 +2166,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2271,7 +2228,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2322,7 +2278,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2385,7 +2340,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2436,7 +2390,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2496,7 +2449,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2544,7 +2496,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2604,7 +2555,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2652,7 +2602,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Asset service definition.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -49,7 +48,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates service definition that can be registered with a server</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +89,6 @@
   <div class="markdown level1 summary"><p>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
 Note: this method is part of an experimental API that can change or be removed without any prior notice.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>AssetService client wrapper, for convenient use.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -57,7 +56,6 @@
   <div class="markdown level1 summary"><p>The default endpoint for the AssetService service, which is a host of &quot;cloudasset.googleapis.com&quot; and a port
 of 443.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,7 +78,6 @@ of 443.</p>
   </div>
   <div class="markdown level1 summary"><p>The default AssetService scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,7 +104,6 @@ of 443.</p>
   </div>
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,7 +126,6 @@ of 443.</p>
   </div>
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,7 +148,6 @@ of 443.</p>
   </div>
   <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,7 +173,6 @@ of 443.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -228,7 +221,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,7 +269,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,7 +322,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +375,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,7 +428,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,7 +476,6 @@ error.</p>
   <div class="markdown level1 summary"><p>Synchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -513,7 +500,6 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   <div class="markdown level1 summary"><p>Asynchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,7 +542,6 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,7 +590,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,7 +642,6 @@ should be created in. It can only be an organization number (such as
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -707,7 +690,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,7 +738,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -809,7 +790,6 @@ should be created in. It can only be an organization number (such as
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,7 +841,6 @@ should be created in. It can only be an organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -893,7 +872,6 @@ should be created in. It can only be an organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -928,7 +906,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,7 +940,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1011,7 +987,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1059,7 +1034,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1110,7 +1084,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,7 +1134,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1212,7 +1184,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1272,7 +1243,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1329,7 +1299,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,7 +1355,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1442,7 +1410,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1498,7 +1465,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1554,7 +1520,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1602,7 +1567,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1653,7 +1617,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1701,7 +1664,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1752,7 +1714,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1803,7 +1764,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1854,7 +1814,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1902,7 +1861,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1950,7 +1908,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2001,7 +1958,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2052,7 +2008,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2100,7 +2055,6 @@ organizations/organization_number/feeds/feed_id</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2150,7 +2104,6 @@ listed. It can only be using project/folder/organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2198,7 +2151,6 @@ listed. It can only be using project/folder/organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2246,7 +2198,6 @@ listed. It can only be using project/folder/organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2296,7 +2247,6 @@ listed. It can only be using project/folder/organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2346,7 +2296,6 @@ listed. It can only be using project/folder/organization number (such as
   </div>
   <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of <code>ExportAssets</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2395,7 +2344,6 @@ listed. It can only be using project/folder/organization number (such as
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportAssets</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2444,7 +2392,6 @@ listed. It can only be using project/folder/organization number (such as
   <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2493,7 +2440,6 @@ listed. It can only be using project/folder/organization number (such as
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2544,7 +2490,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2595,7 +2540,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2702,7 +2646,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2753,7 +2696,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2860,7 +2802,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2911,7 +2852,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3034,7 +2974,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3085,7 +3024,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3207,7 +3145,6 @@ page.</p>
 <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_">CreateAsync(CancellationToken)</a>. Channels which weren&apos;t automatically created are not
 affected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3236,7 +3173,6 @@ by another call to this method.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3288,7 +3224,6 @@ organizations/organization_number/feeds/feed_id.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3336,7 +3271,6 @@ organizations/organization_number/feeds/feed_id.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3388,7 +3322,6 @@ organizations/organization_number/feeds/feed_id.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3440,7 +3373,6 @@ organizations/organization_number/feeds/feed_id.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3488,7 +3420,6 @@ organizations/organization_number/feeds/feed_id.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder class for <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> to provide simple configuration of credentials, endpoint etc.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -116,7 +115,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default <span class="xref">Google.Api.Gax.Grpc.GrpcAdapter</span>to use if not otherwise specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +139,6 @@
   </div>
   <div class="markdown level1 summary"><p>The settings to use for RPCs, or <code>null</code> for the default settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +163,6 @@
   </div>
   <div class="markdown level1 summary"><p>Builds the resulting client.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,7 +187,6 @@
   </div>
   <div class="markdown level1 summary"><p>Builds the resulting client asynchronously.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,7 +228,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the channel pool to use when no other options are specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,7 +252,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,7 +276,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default scopes for this builder type, used if no scopes are otherwise specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>AssetService client wrapper implementation, for convenient use.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -182,7 +181,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a client wrapper for the AssetService service, with the specified gRPC client and settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -216,7 +214,6 @@
   </div>
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,7 +238,6 @@
   </div>
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportIamPolicyAnalysis</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -266,7 +262,6 @@
   </div>
   <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -294,7 +289,6 @@
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -345,7 +339,6 @@ which resources.</p>
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -401,7 +394,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +449,6 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,7 +499,6 @@ error.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,7 +549,6 @@ asset updates.</p>
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,7 +598,6 @@ asset updates.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -643,7 +631,6 @@ asset updates.</p>
   </div>
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,7 +689,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -761,7 +747,6 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -819,7 +804,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -877,7 +861,6 @@ you to track the export status. We recommend intervals of at least 2
 seconds with exponential retry to poll the export operation result. The
 metadata contains the request to help callers to map responses to requests.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -927,7 +910,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,7 +959,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1027,7 +1008,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,7 +1057,6 @@ metadata contains the request to help callers to map responses to requests.</p>
   </div>
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,7 +1109,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1183,7 +1161,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1236,7 +1213,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1289,7 +1265,6 @@ folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,7 +1314,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,7 +1363,6 @@ otherwise the request will be rejected.</p>
   </div>
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Settings for <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> instances.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -65,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a> object with default settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicySettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicySettings*"></a>
@@ -76,7 +74,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.AnalyzeIamPolicy</code> and <code>AssetServiceClient.AnalyzeIamPolicyAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,7 +100,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.BatchGetAssetsHistory</code> and <code>AssetServiceClient.BatchGetAssetsHistoryAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,7 +126,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.CreateFeed</code> and <code>AssetServiceClient.CreateFeedAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +152,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.DeleteFeed</code> and <code>AssetServiceClient.DeleteFeedAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -184,7 +178,6 @@
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.ExportAssets</code> and
 <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,7 +205,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ExportAssets</code> and <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -239,7 +231,6 @@
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.ExportIamPolicyAnalysis</code> and
 <code>AssetServiceClient.ExportIamPolicyAnalysisAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -268,7 +259,6 @@
 <code>AssetServiceClient.ExportIamPolicyAnalysis</code> and <code>AssetServiceClient.ExportIamPolicyAnalysisAsync</code>
 .</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,7 +285,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to <code>AssetServiceClient.GetFeed</code>
  and <code>AssetServiceClient.GetFeedAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,7 +311,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ListFeeds</code> and <code>AssetServiceClient.ListFeedsAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +337,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllIamPolicies</code> and <code>AssetServiceClient.SearchAllIamPoliciesAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,7 +363,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllResources</code> and <code>AssetServiceClient.SearchAllResourcesAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,7 +389,6 @@
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.UpdateFeed</code> and <code>AssetServiceClient.UpdateFeedAsync</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -431,7 +416,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a deep clone of this object, with all the same property values.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +439,6 @@
   </div>
   <div class="markdown level1 summary"><p>Get a new instance of the default <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Batch get assets history request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest)" class="notranslate">BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryRequest(BatchGetAssetsHistoryRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +89,6 @@ Example:</p>
 <p>The request becomes a no-op if the asset name list is empty, and the max
 size of the asset name list is 100 in one request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +111,6 @@ size of the asset name list is 100 in one request.</p>
   </div>
   <div class="markdown level1 summary"><p>Optional. The content type.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,7 +135,6 @@ size of the asset name list is 100 in one request.</p>
 organization number (such as &quot;organizations/123&quot;), a project ID (such as
 &quot;projects/my-project-id&quot;)&quot;, or a project number (such as &quot;projects/12345&quot;).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +157,6 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
   </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html#Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent">Parent</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -193,7 +184,6 @@ If start_time is not set, the snapshot of the assets at end_time will be
 returned. The returned results contain all temporal assets whose time
 window overlap with read_time_window.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Batch get assets history response.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse__ctor_Google_Cloud_Asset_V1_BatchGetAssetsHistoryResponse_" data-uid="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.#ctor(Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse)" class="notranslate">BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BatchGetAssetsHistoryResponse(BatchGetAssetsHistoryResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>A list of assets with valid time windows.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A BigQuery destination for exporting assets to.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_BigQueryDestination__ctor_Google_Cloud_Asset_V1_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.BigQueryDestination)" class="notranslate">BigQueryDestination(BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(BigQueryDestination other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +87,6 @@
 should be exported. If this dataset does not exist, the export call returns
 an INVALID_ARGUMENT error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +112,6 @@ table will be overwritten by the contents of assets snapshot. If the flag
 is <code>FALSE</code> or unset and the destination table already exists, the export
 call returns an INVALID_ARGUMEMT error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +136,6 @@ call returns an INVALID_ARGUMEMT error.</p>
 written. If this table does not exist, a new table with the given name
 will be created.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ContentType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ContentType.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Asset content type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_ContentType_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Create asset feed request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_CreateFeedRequest__ctor_Google_Cloud_Asset_V1_CreateFeedRequest_" data-uid="Google.Cloud.Asset.V1.CreateFeedRequest.#ctor(Google.Cloud.Asset.V1.CreateFeedRequest)" class="notranslate">CreateFeedRequest(CreateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateFeedRequest(CreateFeedRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,7 +88,6 @@ projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +111,6 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="markdown level1 summary"><p>Required. This is the client-assigned asset feed identifier and it needs to
 be unique under a specific parent project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,7 +137,6 @@ should be created in. It can only be an organization number (such as
 (such as &quot;projects/my-project-id&quot;)&quot;, or a project number (such as
 &quot;projects/12345&quot;).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -53,15 +51,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_DeleteFeedRequest__ctor_Google_Cloud_Asset_V1_DeleteFeedRequest_" data-uid="Google.Cloud.Asset.V1.DeleteFeedRequest.#ctor(Google.Cloud.Asset.V1.DeleteFeedRequest)" class="notranslate">DeleteFeedRequest(DeleteFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteFeedRequest(DeleteFeedRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,7 +82,6 @@
   </div>
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html#Google_Cloud_Asset_V1_DeleteFeedRequest_Name">Name</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +107,6 @@ projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Export asset request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsRequest__ctor_Google_Cloud_Asset_V1_ExportAssetsRequest_" data-uid="Google.Cloud.Asset.V1.ExportAssetsRequest.#ctor(Google.Cloud.Asset.V1.ExportAssetsRequest)" class="notranslate">ExportAssetsRequest(ExportAssetsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsRequest(ExportAssetsRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,7 +99,6 @@ snapshot all asset types. See <a href="https://cloud.google.com/asset-inventory/
 Inventory</a>
 for all supported asset types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,7 +122,6 @@ for all supported asset types.</p>
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name will be
 returned.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -151,7 +144,6 @@ returned.</p>
   </div>
   <div class="markdown level1 summary"><p>Required. Output configuration indicating where the results will be output to.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,7 +169,6 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
 &quot;projects/my-project-id&quot;), or a project number (such as &quot;projects/12345&quot;),
 or a folder number (such as &quot;folders/123&quot;).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,7 +191,6 @@ or a folder number (such as &quot;folders/123&quot;).</p>
   </div>
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html#Google_Cloud_Asset_V1_ExportAssetsRequest_Parent">Parent</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -227,7 +217,6 @@ If not specified, the current time will be used. Due to delays in resource
 data collection and indexing, there is a volatile window during which
 running the same query may get different results.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -15,7 +15,6 @@
 [google.longrunning.Operations.GetOperation][google.longrunning.Operations.GetOperation] method in the returned
 [google.longrunning.Operation.response][google.longrunning.Operation.response] field.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -56,15 +55,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportAssetsResponse__ctor_Google_Cloud_Asset_V1_ExportAssetsResponse_" data-uid="Google.Cloud.Asset.V1.ExportAssetsResponse.#ctor(Google.Cloud.Asset.V1.ExportAssetsResponse)" class="notranslate">ExportAssetsResponse(ExportAssetsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportAssetsResponse(ExportAssetsResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +86,6 @@
   </div>
   <div class="markdown level1 summary"><p>Output configuration indicating where the results were output to.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +112,6 @@ exported to. The uris can be different from what [output_config] has
 specified, as the service will split the output object into multiple ones
 once it exceeds a single Google Cloud Storage object limit.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +134,6 @@ once it exceeds a single Google Cloud Storage object limit.</p>
   </div>
   <div class="markdown level1 summary"><p>Time the snapshot was taken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A request message for [AssetService.ExportIamPolicyAnalysis][].</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisRequest_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest)" class="notranslate">ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisRequest(ExportIamPolicyAnalysisRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>The request query.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>Output configuration indicating where the results will be output to.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>The export IAM policy analysis response.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse__ctor_Google_Cloud_Asset_V1_ExportIamPolicyAnalysisResponse_" data-uid="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.#ctor(Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse)" class="notranslate">ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ExportIamPolicyAnalysisResponse(ExportIamPolicyAnalysisResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -17,7 +17,6 @@ The asset feed must be created within a project, organization, or
 folder. Supported destinations are:
 Pub/Sub topics.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -58,15 +57,11 @@ Pub/Sub topics.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Feed__ctor_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Feed__ctor_Google_Cloud_Asset_V1_Feed_" data-uid="Google.Cloud.Asset.V1.Feed.#ctor(Google.Cloud.Asset.V1.Feed)" class="notranslate">Feed(Feed)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed(Feed other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -100,7 +95,6 @@ See <a href="https://cloud.google.com/apis/design/resource_names#full_resource_n
 Names</a>
 for more info.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +123,6 @@ Example: <code>&amp;quot;compute.googleapis.com/Disk&amp;quot;</code></p>
 topic</a>
 for a list of all supported asset types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,7 +154,6 @@ optional.</p>
 guide</a>
 for detailed instructions.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,7 +177,6 @@ for detailed instructions.</p>
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name and
 type will be returned.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -208,7 +199,6 @@ type will be returned.</p>
   </div>
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Feed.html#Google_Cloud_Asset_V1_Feed_Name">Name</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,7 +222,6 @@ type will be returned.</p>
   <div class="markdown level1 summary"><p>Required. Feed output configuration defining where the asset updates are
 published to.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -260,7 +249,6 @@ organizations/{organization_number}/feeds/{client-assigned_feed_identifier}</p>
 <p>The client-assigned feed identifier must be unique within the parent
 project/folder/organization.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.ResourceNameType.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.ResourceNameType.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>The possible contents of <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_FeedName_ResourceNameType_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Resource name for the <code>Feed</code> resource.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -49,7 +48,6 @@
   <div class="markdown level1 summary"><p>Constructs a new instance of a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> class from the component parts of pattern
 <code>projects/{project}/feeds/{feed}</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -83,7 +81,6 @@
   </div>
   <div class="markdown level1 summary"><p>The <code>Feed</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,7 +103,6 @@
   </div>
   <div class="markdown level1 summary"><p>The <code>Folder</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +125,6 @@
   </div>
   <div class="markdown level1 summary"><p>Whether this instance contains a resource name with a known pattern.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,7 +148,6 @@
   <div class="markdown level1 summary"><p>The <code>Organization</code> ID. May be <code>null</code>, depending on which resource name is contained by this
 instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@ instance.</p>
   </div>
   <div class="markdown level1 summary"><p>The <code>Project</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,7 +192,6 @@ instance.</p>
   </div>
   <div class="markdown level1 summary"><p>The <a class="xref" href="Google.Cloud.Asset.V1.FeedName.ResourceNameType.html">FeedName.ResourceNameType</a> of the contained resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,7 +215,6 @@ instance.</p>
   <div class="markdown level1 summary"><p>The contained <span class="xref">Google.Api.Gax.UnparsedResourceName</span>. Only non-<code>null</code> if this instance contains an
 unparsed resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,7 +240,6 @@ unparsed resource name.</p>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,7 +289,6 @@ unparsed resource name.</p>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>folders/{folder}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +337,6 @@ unparsed resource name.</p>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -398,7 +386,6 @@ unparsed resource name.</p>
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,7 +434,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>folders/{folder}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,7 +481,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -543,7 +528,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -591,7 +575,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> containing an unparsed resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,7 +616,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns a hash code for this resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,7 +640,6 @@ unparsed resource name.</p>
   </div>
   <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,7 +686,6 @@ unparsed resource name.</p>
   <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally allowing an
 unparseable resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -760,7 +740,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   </div>
   <div class="markdown level1 summary"><p>The string representation of the resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,7 +765,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   </div>
   <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,7 +817,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally
 allowing an unparseable resource name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -900,8 +877,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator ==(FeedName a, FeedName b)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,8 +919,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool operator !=(FeedName a, FeedName b)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.DestinationOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;destination&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_FeedOutputConfig_DestinationOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Output configuration for asset feed destination.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_FeedOutputConfig__ctor_Google_Cloud_Asset_V1_FeedOutputConfig_" data-uid="Google.Cloud.Asset.V1.FeedOutputConfig.#ctor(Google.Cloud.Asset.V1.FeedOutputConfig)" class="notranslate">FeedOutputConfig(FeedOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig(FeedOutputConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +104,6 @@
   </div>
   <div class="markdown level1 summary"><p>Destination on Pub/Sub.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.ObjectUriOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.ObjectUriOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;object_uri&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_GcsDestination_ObjectUriOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A Cloud Storage location.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsDestination__ctor_Google_Cloud_Asset_V1_GcsDestination_" data-uid="Google.Cloud.Asset.V1.GcsDestination.#ctor(Google.Cloud.Asset.V1.GcsDestination)" class="notranslate">GcsDestination(GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(GcsDestination other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination.ObjectUriOneofCase ObjectUriCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,7 +108,6 @@ Editing Object
 Metadata</a>
 for more information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,7 +138,6 @@ compute.googleapis.com/Disk assets. An INVALID_ARGUMENT error will be
 returned if file with the same name &quot;gs://bucket_name/object_name_prefix&quot;
 already exists.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A Cloud Storage output result.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GcsOutputResult__ctor_Google_Cloud_Asset_V1_GcsOutputResult_" data-uid="Google.Cloud.Asset.V1.GcsOutputResult.#ctor(Google.Cloud.Asset.V1.GcsOutputResult)" class="notranslate">GcsOutputResult(GcsOutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult(GcsOutputResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>List of uris of the Cloud Storage objects. Example:
 &quot;gs://bucket_name/object_name&quot;.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Get asset feed request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_GetFeedRequest__ctor_Google_Cloud_Asset_V1_GetFeedRequest_" data-uid="Google.Cloud.Asset.V1.GetFeedRequest.#ctor(Google.Cloud.Asset.V1.GetFeedRequest)" class="notranslate">GetFeedRequest(GetFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetFeedRequest(GetFeedRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html#Google_Cloud_Asset_V1_GetFeedRequest_Name">Name</a> resource name property.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,7 +109,6 @@ projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;destination&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_DestinationOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey.html
@@ -16,7 +16,6 @@ Partitioning can improve query performance and reduce query cost by
 filtering partitions. Refer to
 <a href="https://cloud.google.com/bigquery/docs/partitioned-tables">https://cloud.google.com/bigquery/docs/partitioned-tables</a> for details.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Types_PartitionKey_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.WriteMode.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Write mode types if table exists.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_Types_WriteMode_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the BigQueryDestination message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A BigQuery destination.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_BigQueryDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)" class="notranslate">BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination(IamPolicyAnalysisOutputConfig.Types.BigQueryDestination other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +86,6 @@
 to which the analysis results should be exported. If this dataset does
 not exist, the export call will return an INVALID_ARGUMENT error.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +108,6 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
   </div>
   <div class="markdown level1 summary"><p>The partition key for BigQuery partitioned table.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,7 +138,6 @@ When [partition_key] is specified, both tables will be partitioned based
 on the [partition_key].</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +161,6 @@ on the [partition_key].</li>
   <div class="markdown level1 summary"><p>The write mode when table exists. WriteMode is ignored when no existing
 tables, or no existing partitions are found.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A Cloud Storage location.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_Types_GcsDestination_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination)" class="notranslate">GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination(IamPolicyAnalysisOutputConfig.Types.GcsDestination other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,7 +88,6 @@ Editing Object
 Metadata</a>
 for more information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the IamPolicyAnalysisOutputConfig message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Output configuration for export IAM policy analysis destination.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisOutputConfig_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig)" class="notranslate">IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig(IamPolicyAnalysisOutputConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>Destination on BigQuery.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,8 +104,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,7 +126,6 @@
   </div>
   <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -16,7 +16,6 @@ identities possessing them and the resources they control. If multiple
 values are specified, results will include roles or permissions matching
 any of them.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -57,15 +56,11 @@ any of them.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_AccessSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector)" class="notranslate">AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessSelector(IamPolicyAnalysisQuery.Types.AccessSelector other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +87,6 @@ any of them.</p>
   </div>
   <div class="markdown level1 summary"><p>The permissions to appear in result.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -115,7 +109,6 @@ any of them.</p>
   </div>
   <div class="markdown level1 summary"><p>The roles to appear in result.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -15,7 +15,6 @@
 roles assigned either directly to them or to the groups they belong to,
 directly or indirectly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -56,15 +55,11 @@ directly or indirectly.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_IdentitySelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector)" class="notranslate">IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentitySelector(IamPolicyAnalysisQuery.Types.IdentitySelector other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -100,7 +95,6 @@ binding</a>.</p>
 <p>Notice that wildcard characters (such as * and ?) are not supported.
 You must give a specific identity.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Contains query options.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_Options_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options)" class="notranslate">Options(IamPolicyAnalysisQuery.Types.Options)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Options(IamPolicyAnalysisQuery.Types.Options other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,7 +104,6 @@ F. And those advanced analysis results will be included in
 [google.cloud.asset.v1.AnalyzeIamPolicyResponse.service_account_impersonation_analysis][google.cloud.asset.v1.AnalyzeIamPolicyResponse.service_account_impersonation_analysis].</p>
 <p>Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +132,6 @@ is specified, the identity in the result will be determined by the
 selector, and this flag is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,7 +170,6 @@ a GCP folder with this option enabled, the results will include all users
 who have permission P on that folder or any lower resource(ex. project).</p>
 <p>Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,7 +198,6 @@ is specified, the access section of the result will be determined by the
 selector, and this flag is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +222,6 @@ selector, and this flag is not allowed to set.</p>
 is enabled. This internal field is to help load testing and determine a
 proper value, and won&apos;t be public in the future.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,7 +247,6 @@ GCP Project etc., when [expand_resources][] is enabled. This internal
 field is to help load testing and determine a proper value, and won&apos;t be
 public in the future.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -282,7 +271,6 @@ public in the future.</p>
 from the binding&apos;s group members, to any expanded identities.
 Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,7 +295,6 @@ Default is false.</p>
 from the policy attached resource, to any expanded resources.
 Default is false.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -15,7 +15,6 @@
 directly on the resource, or on ancestors such as organizations, folders or
 projects.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -56,15 +55,11 @@ projects.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_Types_ResourceSelector_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector)" class="notranslate">ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSelector(IamPolicyAnalysisQuery.Types.ResourceSelector other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,7 +88,6 @@ projects.</p>
 of a resource of <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#analyzable_asset_types">supported resource
 types</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the IamPolicyAnalysisQuery message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>IAM policy analysis query message.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisQuery__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisQuery_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisQuery)" class="notranslate">IamPolicyAnalysisQuery(IamPolicyAnalysisQuery)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery(IamPolicyAnalysisQuery other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>Specifies roles or permissions for analysis. This is optional.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>Specifies an identity for analysis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,7 +128,6 @@
   </div>
   <div class="markdown level1 summary"><p>The query options.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -158,7 +150,6 @@
   </div>
   <div class="markdown level1 summary"><p>Specifies a resource for analysis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -189,7 +180,6 @@ folder number (such as &quot;folders/123&quot;), a project ID (such as
 <p>To know how to get folder or project id, visit <a href="https://cloud.google.com/resource-manager/docs/creating-managing-folders#viewing_or_listing_folders_and_projects">here
 </a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;oneof_access&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_OneofAccessOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>An IAM role or permission under analysis.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Access_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access)" class="notranslate">Access(IamPolicyAnalysisResult.Types.Access)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Access(IamPolicyAnalysisResult.Types.Access other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>The analysis state of this access.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,8 +104,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase OneofAccessCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,7 +126,6 @@
   </div>
   <div class="markdown level1 summary"><p>The permission.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +148,6 @@
   </div>
   <div class="markdown level1 summary"><p>The role.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -28,7 +28,6 @@ combinations.</p>
 <li>AccessControlList 2: [R2, R3], [P3]</li>
 </ul>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -69,15 +68,11 @@ combinations.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_AccessControlList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList)" class="notranslate">AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessControlList(IamPolicyAnalysisResult.Types.AccessControlList other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,7 +103,6 @@ combinations.</p>
 <li>Otherwise, access specifiers reachable from the policy binding&apos;s role.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,7 +129,6 @@ the full resource name of a parent resource and [Edge.target_node][]
 contains the full resource name of a child resource. This field is
 present only if the output_resource_edges option is enabled in request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -162,7 +155,6 @@ present only if the output_resource_edges option is enabled in request.</p>
 <li>Otherwise, resources reachable from the policy attached resource.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A directional edge.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Edge_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge)" class="notranslate">Edge(IamPolicyAnalysisResult.Types.Edge)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Edge(IamPolicyAnalysisResult.Types.Edge other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>The source node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +108,6 @@ name for a resource node or an email of an identity.</p>
   <div class="markdown level1 summary"><p>The target node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -15,7 +15,6 @@
 (-- api-linter: core::0123::resource-annotation=disabled
 aip.dev/not-precedent: Identity name is not a resource. --)</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -56,15 +55,11 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Identity_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity)" class="notranslate">Identity(IamPolicyAnalysisResult.Types.Identity)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Identity(IamPolicyAnalysisResult.Types.Identity other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +86,6 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
   </div>
   <div class="markdown level1 summary"><p>The analysis state of this identity.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -126,7 +120,6 @@ as:</p>
 <li>etc.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>The identities and group edges.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_IdentityList_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList)" class="notranslate">IdentityList(IamPolicyAnalysisResult.Types.IdentityList)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IdentityList(IamPolicyAnalysisResult.Types.IdentityList other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,7 +90,6 @@ such as <code>group:child@google.com</code> or <code>user:foo@google.com</code>.
 This field is present only if the output_group_edges option is enabled in
 request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,7 +117,6 @@ presented:</p>
 <li>Otherwise, identities reachable from the policy binding&apos;s members.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A Google Cloud resource under analysis.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_Types_Resource_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource)" class="notranslate">Resource(IamPolicyAnalysisResult.Types.Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(IamPolicyAnalysisResult.Types.Resource other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>The analysis state of this resource.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,7 +110,6 @@ name</a>
 aip.dev/not-precedent: full_resource_name is a public notion in GCP.
 --)</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the IamPolicyAnalysisResult message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>IAM Policy analysis result, consisting of one IAM policy binding and derived
 access control lists.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@ access control lists.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisResult__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisResult_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisResult)" class="notranslate">IamPolicyAnalysisResult(IamPolicyAnalysisResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult(IamPolicyAnalysisResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +87,6 @@ access control lists.</p>
 match or potentially match resource and access selectors specified in the
 request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,7 +114,6 @@ of the resource to which the [iam_binding][iam_binding] policy attaches.
 aip.dev/not-precedent: full_resource_name is a public notion in GCP.
 --)</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,7 +137,6 @@ aip.dev/not-precedent: full_resource_name is a public notion in GCP.
   <div class="markdown level1 summary"><p>Represents whether all analyses on the [iam_binding][iam_binding] have
 successfully finished.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -167,7 +159,6 @@ successfully finished.</p>
   </div>
   <div class="markdown level1 summary"><p>The Cloud IAM policy binding under analysis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,7 +182,6 @@ successfully finished.</p>
   <div class="markdown level1 summary"><p>The identity list derived from members of the [iam_binding][iam_binding]
 that match or potentially match identity selector specified in the request.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Represents the detailed state of an entity under analysis, such as a
 resource, an identity or an access.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@ resource, an identity or an access.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicyAnalysisState__ctor_Google_Cloud_Asset_V1_IamPolicyAnalysisState_" data-uid="Google.Cloud.Asset.V1.IamPolicyAnalysisState.#ctor(Google.Cloud.Asset.V1.IamPolicyAnalysisState)" class="notranslate">IamPolicyAnalysisState(IamPolicyAnalysisState)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState(IamPolicyAnalysisState other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@ resource, an identity or an access.</p>
   </div>
   <div class="markdown level1 summary"><p>The human-readable description of the cause of failure.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,7 +114,6 @@ For example:</p>
 in time;</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>IAM permissions</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_Types_Permissions_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions)" class="notranslate">Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Permissions(IamPolicySearchResult.Types.Explanation.Types.Permissions other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>A list of permissions. A sample permission string: <code>compute.disk.get</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the Explanation message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Explanation about the IAM policy search result.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_Types_Explanation_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation)" class="notranslate">Explanation(IamPolicySearchResult.Types.Explanation)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Explanation(IamPolicySearchResult.Types.Explanation other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -95,7 +90,6 @@ matched_permissions will be <code>{&amp;quot;roles/owner&amp;quot;: [&amp;quot;c
 roles can also be found in the returned <code>policy</code> bindings. Note that the
 map is populated only for requests with permission queries.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the IamPolicySearchResult message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A result of IAM Policy search, containing information of an IAM policy.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_IamPolicySearchResult__ctor_Google_Cloud_Asset_V1_IamPolicySearchResult_" data-uid="Google.Cloud.Asset.V1.IamPolicySearchResult.#ctor(Google.Cloud.Asset.V1.IamPolicySearchResult)" class="notranslate">IamPolicySearchResult(IamPolicySearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult(IamPolicySearchResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>Explanation about the IAM policy search result. It contains additional
 information to explain why the search result matches the query.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -126,7 +120,6 @@ policies (e.g., an empty query), this contains all the bindings.</p>
 <code>policy.role.permissions:compute.instances.create</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +150,6 @@ orgnization, the project field will be empty.</p>
 <li>specify the <code>scope</code> field as this project in your search request.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -189,7 +181,6 @@ for more information.</p>
 <li>use a field query. Example: <code>resource:organizations/123</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>List asset feeds request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsRequest__ctor_Google_Cloud_Asset_V1_ListFeedsRequest_" data-uid="Google.Cloud.Asset.V1.ListFeedsRequest.#ctor(Google.Cloud.Asset.V1.ListFeedsRequest)" class="notranslate">ListFeedsRequest(ListFeedsRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsRequest(ListFeedsRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -91,7 +86,6 @@
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -53,15 +51,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ListFeedsResponse__ctor_Google_Cloud_Asset_V1_ListFeedsResponse_" data-uid="Google.Cloud.Asset.V1.ListFeedsResponse.#ctor(Google.Cloud.Asset.V1.ListFeedsResponse)" class="notranslate">ListFeedsResponse(ListFeedsResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListFeedsResponse(ListFeedsResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -88,7 +82,6 @@
   </div>
   <div class="markdown level1 summary"><p>A list of feeds.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.DestinationOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.DestinationOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;destination&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_OutputConfig_DestinationOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Output configuration for export assets destination.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputConfig__ctor_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputConfig__ctor_Google_Cloud_Asset_V1_OutputConfig_" data-uid="Google.Cloud.Asset.V1.OutputConfig.#ctor(Google.Cloud.Asset.V1.OutputConfig)" class="notranslate">OutputConfig(OutputConfig)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig(OutputConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>Destination on BigQuery. The output table stores the fields in asset
 proto as columns in BigQuery.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@ proto as columns in BigQuery.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig.DestinationOneofCase DestinationCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,7 +127,6 @@ proto as columns in BigQuery.</p>
   </div>
   <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.ResultOneofCase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.ResultOneofCase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Enum of possible cases for the &quot;result&quot; oneof.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_OutputResult_ResultOneofCase_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Output result of export assets.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_OutputResult__ctor_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_OutputResult__ctor_Google_Cloud_Asset_V1_OutputResult_" data-uid="Google.Cloud.Asset.V1.OutputResult.#ctor(Google.Cloud.Asset.V1.OutputResult)" class="notranslate">OutputResult(OutputResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult(OutputResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +84,6 @@
   </div>
   <div class="markdown level1 summary"><p>Export result on Cloud Storage.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,8 +104,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult.ResultOneofCase ResultCase { get; }</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A Pub/Sub destination.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_PubsubDestination__ctor_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_PubsubDestination__ctor_Google_Cloud_Asset_V1_PubsubDestination_" data-uid="Google.Cloud.Asset.V1.PubsubDestination.#ctor(Google.Cloud.Asset.V1.PubsubDestination)" class="notranslate">PubsubDestination(PubsubDestination)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination(PubsubDestination other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>The name of the Pub/Sub topic to publish to.
 Example: <code>projects/PROJECT_ID/topics/TOPIC_ID</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A representation of a Google Cloud resource.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_Resource__ctor_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_Resource__ctor_Google_Cloud_Asset_V1_Resource_" data-uid="Google.Cloud.Asset.V1.Resource.#ctor(Google.Cloud.Asset.V1.Resource)" class="notranslate">Resource(Resource)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource(Resource other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>The content of the resource, in which some sensitive fields are removed
 and may not be present.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +111,6 @@ Example:
 <p>This value is unspecified for resources that do not have an API based on a
 discovery document, such as Cloud Bigtable.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +136,6 @@ discovery document, such as Cloud Bigtable.</p>
 <p>This value is unspecified for resources that do not have an API based on a
 discovery document, such as Cloud Bigtable.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -167,7 +159,6 @@ discovery document, such as Cloud Bigtable.</p>
   <div class="markdown level1 summary"><p>The location of the resource in Google Cloud, such as its zone and region.
 For more information, see <a href="https://cloud.google.com/about/locations/">https://cloud.google.com/about/locations/</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,7 +190,6 @@ Example:
 <code>//cloudresourcemanager.googleapis.com/projects/my_project_123</code></p>
 <p>For third-party assets, this field may be set differently.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,7 +215,6 @@ URL returns the resource itself. Example:
 <code>https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123</code></p>
 <p>This value is unspecified for resources without a REST API.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,7 +237,6 @@ URL returns the resource itself. Example:
   </div>
   <div class="markdown level1 summary"><p>The API version. Example: <code>v1</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A result of Resource Search, containing information of a cloud resource.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_ResourceSearchResult__ctor_Google_Cloud_Asset_V1_ResourceSearchResult_" data-uid="Google.Cloud.Asset.V1.ResourceSearchResult.#ctor(Google.Cloud.Asset.V1.ResourceSearchResult)" class="notranslate">ResourceSearchResult(ResourceSearchResult)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ResourceSearchResult(ResourceSearchResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,7 +101,6 @@ version.</p>
 <code>foobar</code>.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,7 +127,6 @@ version.</p>
 <li>specify the <code>asset_type</code> field in your search request.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -162,7 +155,6 @@ could be up to 1M bytes.</p>
 <li>use a free text query. Example: <code>&amp;quot;*important instance*&amp;quot;</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -190,7 +182,6 @@ could be up to 1M bytes.</p>
 <li>use a free text query. Example: <code>&amp;quot;My Instance&amp;quot;</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,7 +214,6 @@ for more information.</p>
 <li>use a free text query. Example: <code>prod</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -252,7 +242,6 @@ for more information.</p>
 <li>use a free text query. Example: <code>us-west*</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -284,7 +273,6 @@ for more information.</p>
 <li>use a free text query. Example: <code>instance1</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +303,6 @@ for more information.</p>
 <li>use a free text query. Example: <code>internal</code></li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,7 +330,6 @@ projects/{PROJECT_NUMBER}.</p>
 <li>specify the <code>scope</code> field as this project in your search request.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Search all IAM policies request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest)" class="notranslate">SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesRequest(SearchAllIamPoliciesRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,7 +88,6 @@ if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +113,6 @@ this method. <code>page_token</code> must be the value of <code>next_page_token<
 previous response. The values of all other method parameters must be
 identical to those in the previous call.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -167,7 +160,6 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
 &quot;instance2&quot; and also specify user &quot;amy&quot;.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -201,7 +193,6 @@ permission on the desired scope.</p>
 <li>organizations/{ORGANIZATION_NUMBER} (e.g., &quot;organizations/123456&quot;)</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Search all IAM policies response.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -57,15 +56,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse__ctor_Google_Cloud_Asset_V1_SearchAllIamPoliciesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse)" class="notranslate">SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllIamPoliciesResponse(SearchAllIamPoliciesResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +89,6 @@
 the next set of results, call this method again, using this value as the
 <code>page_token</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +112,6 @@ the next set of results, call this method again, using this value as the
   <div class="markdown level1 summary"><p>A list of IamPolicy that match the search query. Related information such
 as the associated resource is returned along with the policy.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +136,6 @@ as the associated resource is returned along with the policy.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,8 +158,6 @@ as the associated resource is returned along with the policy.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Search all resources request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesRequest__ctor_Google_Cloud_Asset_V1_SearchAllResourcesRequest_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesRequest.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesRequest)" class="notranslate">SearchAllResourcesRequest(SearchAllResourcesRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesRequest(SearchAllResourcesRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +87,6 @@
 search all the <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types">searchable asset
 types</a>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,7 +116,6 @@ the other fields such as repeated fields (e.g., <code>networkTags</code>), map
 fields (e.g., <code>labels</code>) and struct fields (e.g., <code>additionalAttributes</code>)
 are not supported.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,7 +141,6 @@ if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +166,6 @@ to this method. <code>page_token</code> must be the value of <code>next_page_tok
 the previous response. The values of all other method parameters, must be
 identical to those in the previous call.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +222,6 @@ fields and are also located in the &quot;us-west1&quot; region or the &quot;glob
 location.</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,7 +254,6 @@ permission on the desired scope.</p>
 <li>organizations/{ORGANIZATION_NUMBER} (e.g., &quot;organizations/123456&quot;)</li>
 </ul>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Search all resources response.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -57,15 +56,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_SearchAllResourcesResponse__ctor_Google_Cloud_Asset_V1_SearchAllResourcesResponse_" data-uid="Google.Cloud.Asset.V1.SearchAllResourcesResponse.#ctor(Google.Cloud.Asset.V1.SearchAllResourcesResponse)" class="notranslate">SearchAllResourcesResponse(SearchAllResourcesResponse)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public SearchAllResourcesResponse(SearchAllResourcesResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +89,6 @@
 <code>next_page_token</code> is included. To get the next set of results, call this
 method again using the value of <code>next_page_token</code> as <code>page_token</code>.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +112,6 @@ method again using the value of <code>next_page_token</code> as <code>page_token
   <div class="markdown level1 summary"><p>A list of Resources that match the search query. It contains the resource
 standard metadata information.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +136,6 @@ standard metadata information.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,8 +158,6 @@ standard metadata information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">IEnumerator IEnumerable.GetEnumerator()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.PriorAssetState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.PriorAssetState.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>State of prior asset.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Namespace</strong>: <a class="xref" href="Google.Cloud.Asset.V1.html">Google.Cloud.Asset.V1</a></h6>
   <h6><strong>Assembly</strong>: Google.Cloud.Asset.V1.dll</h6>
   <h5 id="Google_Cloud_Asset_V1_TemporalAsset_Types_PriorAssetState_syntax">Syntax</h5>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Container for nested types declared in the TemporalAsset message type.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>An asset in Google Cloud and its temporal metadata, including the time window
 when it was observed and its status during that window.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -55,15 +54,11 @@ when it was observed and its status during that window.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TemporalAsset__ctor_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_TemporalAsset__ctor_Google_Cloud_Asset_V1_TemporalAsset_" data-uid="Google.Cloud.Asset.V1.TemporalAsset.#ctor(Google.Cloud.Asset.V1.TemporalAsset)" class="notranslate">TemporalAsset(TemporalAsset)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset(TemporalAsset other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@ when it was observed and its status during that window.</p>
   </div>
   <div class="markdown level1 summary"><p>An asset in Google Cloud.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,7 +107,6 @@ when it was observed and its status during that window.</p>
   </div>
   <div class="markdown level1 summary"><p>Whether the asset has been deleted or not.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,7 +130,6 @@ when it was observed and its status during that window.</p>
   <div class="markdown level1 summary"><p>Prior copy of the asset. Populated if prior_asset_state is PRESENT.
 Currently this is only set for responses in Real-Time Feed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,7 +152,6 @@ Currently this is only set for responses in Real-Time Feed.</p>
   </div>
   <div class="markdown level1 summary"><p>State of prior_asset.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,7 +174,6 @@ Currently this is only set for responses in Real-Time Feed.</p>
   </div>
   <div class="markdown level1 summary"><p>The time window when the asset data and state was observed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>A time window specified by its <code>start_time</code> and <code>end_time</code>.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_TimeWindow__ctor_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_TimeWindow__ctor_Google_Cloud_Asset_V1_TimeWindow_" data-uid="Google.Cloud.Asset.V1.TimeWindow.#ctor(Google.Cloud.Asset.V1.TimeWindow)" class="notranslate">TimeWindow(TimeWindow)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow(TimeWindow other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +85,6 @@
   <div class="markdown level1 summary"><p>End time of the time window (inclusive). If not specified, the current
 timestamp is used instead.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,7 +107,6 @@ timestamp is used instead.</p>
   </div>
   <div class="markdown level1 summary"><p>Start time of the time window (exclusive).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Update asset feed request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">System.Object</span></span> <span> &gt; </span>
@@ -54,15 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_UpdateFeedRequest__ctor_Google_Cloud_Asset_V1_UpdateFeedRequest_" data-uid="Google.Cloud.Asset.V1.UpdateFeedRequest.#ctor(Google.Cloud.Asset.V1.UpdateFeedRequest)" class="notranslate">UpdateFeedRequest(UpdateFeedRequest)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateFeedRequest(UpdateFeedRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -93,7 +88,6 @@ projects/project_number/feeds/feed_id or
 folders/folder_number/feeds/feed_id or
 organizations/organization_number/feeds/feed_id.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +112,6 @@ organizations/organization_number/feeds/feed_id.</p>
 The field mask must not be empty, and it must not contain fields that
 are immutable or only set by the server.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.html
@@ -11,9 +11,6 @@
 </h1>
   
   {% verbatim %}
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
-  <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes
   
   </h2>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -232,8 +231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -278,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,8 +337,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,8 +399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,7 +466,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +486,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,8 +508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,8 +548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,7 +573,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,7 +597,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,7 +620,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -671,7 +644,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +668,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,7 +692,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +715,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,7 +738,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,7 +762,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,8 +783,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -840,8 +805,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -864,8 +827,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(LongRunningRecognizeMetadata other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,8 +864,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,8 +923,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1008,7 +965,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,7 +1005,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1087,8 +1042,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeMetadata.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1128,8 +1081,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1177,7 +1128,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1218,7 +1168,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1260,7 +1209,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1300,8 +1248,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1354,7 +1300,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1395,7 +1340,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1433,8 +1377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeMetadata.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LAST_UPDATE_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROGRESS_PERCENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int START_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,8 +394,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,8 +414,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -452,7 +437,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +461,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeMetadata&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +507,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +553,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,7 +577,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +622,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,7 +646,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -695,8 +667,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,8 +689,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -743,8 +711,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,8 +753,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata.Builder newBuilder(LongRunningRecognizeMetadata prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,8 +790,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,8 +810,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeMetadata.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,8 +849,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,8 +888,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -986,8 +940,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,8 +997,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1099,8 +1049,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,8 +1106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1212,8 +1158,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1271,8 +1215,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1325,8 +1267,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1384,8 +1324,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1438,8 +1376,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1497,8 +1433,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1551,8 +1485,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1610,8 +1542,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeMetadata&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1632,8 +1562,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1654,8 +1582,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,7 +101,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,7 +148,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,7 +172,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
@@ -15,7 +15,6 @@
  method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +339,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,7 +363,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,8 +383,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,7 +486,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +510,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,7 +533,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +557,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,7 +582,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -628,7 +606,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,8 +626,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -671,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,8 +666,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,7 +691,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -746,7 +716,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +737,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -792,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -819,7 +784,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,7 +825,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,8 +862,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(LongRunningRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -938,8 +899,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +958,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,8 +997,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,7 +1039,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1125,7 +1079,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,7 +1120,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1209,7 +1161,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,8 +1198,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1293,8 +1242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1291,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
@@ -15,7 +15,6 @@
  method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,7 +357,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,7 +381,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,7 +405,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,7 +430,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,8 +450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +532,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +579,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -628,7 +604,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,8 +625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +647,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,8 +669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -744,8 +711,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest.Builder newBuilder(LongRunningRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,8 +748,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,8 +768,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,8 +807,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -887,8 +846,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,8 +898,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1000,8 +955,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,8 +1007,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1113,8 +1064,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1116,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,8 +1173,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1280,8 +1225,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,8 +1282,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1393,8 +1334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1452,8 +1391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,8 +1443,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1565,8 +1500,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1587,8 +1520,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,8 +1540,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,7 +102,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +150,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
@@ -18,7 +18,6 @@
  service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -238,7 +237,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,7 +322,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +363,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +404,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +450,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +496,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +520,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -567,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -589,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -676,8 +658,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,7 +701,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,8 +721,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,8 +743,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +763,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +783,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,7 +809,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +850,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,7 +891,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -947,7 +915,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,7 +939,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -997,7 +963,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,7 +1004,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,8 +1024,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,8 +1046,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,8 +1068,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(LongRunningRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,8 +1105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,8 +1164,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1249,8 +1203,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,7 +1246,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1332,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1378,8 +1327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1433,7 +1380,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,7 +1426,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1523,8 +1468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
@@ -18,7 +18,6 @@
  service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.LongRunningRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -278,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,8 +299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,8 +338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,8 +358,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,8 +378,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,8 +398,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +424,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +465,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +489,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +513,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -571,7 +554,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,8 +574,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,8 +596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -640,8 +618,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,8 +662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -734,8 +704,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse.Builder newBuilder(LongRunningRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -773,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +800,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -877,8 +839,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,8 +891,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,8 +948,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +1000,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1103,8 +1057,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,8 +1109,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1216,8 +1166,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1218,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1329,8 +1275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1383,8 +1327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1442,8 +1384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1496,8 +1436,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1555,8 +1493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1577,8 +1513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1599,8 +1533,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span>,</span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
@@ -17,7 +17,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -233,8 +232,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -279,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +316,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,8 +338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearAudioSource()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +363,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,8 +384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +423,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,7 +471,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,8 +492,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,8 +514,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,7 +539,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,8 +560,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -604,8 +580,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,8 +600,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,7 +631,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,7 +661,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +687,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +717,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -770,8 +738,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,8 +760,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,8 +782,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(RecognitionAudio other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,8 +819,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -959,8 +917,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,7 +961,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,8 +1000,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,8 +1044,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,8 +1093,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1192,7 +1141,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1241,7 +1189,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
@@ -17,7 +17,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -277,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int URI_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +381,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionAudio&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,8 +506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,7 +537,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,7 +567,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,7 +593,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +623,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +644,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,8 +666,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -718,8 +688,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,8 +710,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +730,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder(RecognitionAudio prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -803,8 +767,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,8 +787,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionAudio.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -866,8 +826,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -907,8 +865,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -961,8 +917,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1020,8 +974,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1074,8 +1026,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1133,8 +1083,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1187,8 +1135,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1246,8 +1192,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1300,8 +1244,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1359,8 +1301,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1413,8 +1353,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1472,8 +1410,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1526,8 +1462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1585,8 +1519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionAudio&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1607,8 +1539,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1629,8 +1559,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -28,8 +26,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +51,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,7 +81,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +111,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,7 +137,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -175,7 +167,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
@@ -32,7 +32,6 @@
  [google.rpc.Code.INVALID_ARGUMENT][google.rpc.Code.INVALID_ARGUMENT] error code.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.RecognitionConfig.AudioEncoding</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -238,7 +237,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -329,7 +325,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +369,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -419,7 +413,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -469,7 +462,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,7 +511,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +538,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,8 +595,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,8 +615,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,7 +648,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +679,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,7 +708,6 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,7 +737,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -784,7 +764,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,7 +790,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -833,8 +811,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -882,7 +858,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -912,7 +887,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,7 +911,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -992,7 +965,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,8 +986,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,7 +1031,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,7 +1061,6 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,7 +1089,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1151,7 +1118,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1173,8 +1139,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,7 +1172,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1230,8 +1193,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1252,8 +1213,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1308,7 +1265,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1340,7 +1296,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1371,7 +1326,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1401,7 +1355,6 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,7 +1384,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1459,7 +1411,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1486,7 +1437,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,7 +1463,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1543,7 +1492,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1573,7 +1521,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1603,7 +1550,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1628,7 +1574,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1653,7 +1598,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1677,7 +1621,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1732,7 +1675,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1788,7 +1730,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1816,7 +1757,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1847,7 +1787,6 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1876,7 +1815,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1921,7 +1859,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1966,7 +1903,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1994,7 +1930,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2022,7 +1957,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2050,7 +1984,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2095,7 +2028,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2125,7 +2057,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2157,7 +2088,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2182,7 +2112,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2204,8 +2133,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2228,8 +2155,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2262,7 +2187,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2300,8 +2224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(RecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2339,8 +2261,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2400,8 +2320,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2444,7 +2362,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2482,8 +2399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2530,7 +2445,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2579,7 +2493,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2629,7 +2542,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2677,7 +2589,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2724,7 +2635,6 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2772,7 +2682,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2818,7 +2727,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2863,7 +2771,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2908,7 +2815,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2948,8 +2854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3002,7 +2906,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3050,7 +2953,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3098,7 +3000,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3141,7 +3042,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3182,7 +3082,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3254,7 +3153,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3328,7 +3226,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3374,7 +3271,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3414,8 +3310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3474,7 +3368,6 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3521,7 +3414,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3571,7 +3463,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3614,8 +3505,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3664,7 +3553,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_CHANNEL_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int DIARIZATION_CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_AUTOMATIC_PUNCTUATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_SEPARATE_RECOGNITION_PER_CHANNEL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_WORD_TIME_OFFSETS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENCODING_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -401,8 +388,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -422,8 +407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MAX_ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -443,8 +426,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int METADATA_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,8 +445,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MODEL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,8 +464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROFANITY_FILTER_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,8 +483,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SAMPLE_RATE_HERTZ_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEECH_CONTEXTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +521,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int USE_ENHANCED_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,8 +543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,7 +593,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +614,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +634,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,8 +654,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,7 +684,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,7 +715,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -784,7 +744,6 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +773,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,7 +800,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,7 +826,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,7 +852,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -926,7 +881,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -956,7 +910,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -986,7 +939,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1011,7 +963,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1036,7 +987,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,7 +1041,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,7 +1096,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1169,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1199,7 +1145,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1230,7 +1175,6 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1252,8 +1196,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1283,7 +1225,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1328,7 +1269,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,7 +1296,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1384,7 +1323,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1429,7 +1367,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1450,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1483,7 +1418,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1515,7 +1449,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1540,7 +1473,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1562,8 +1494,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1586,8 +1516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1610,8 +1538,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1634,8 +1560,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1656,8 +1580,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder(RecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1695,8 +1617,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1717,8 +1637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1758,8 +1676,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1799,8 +1715,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1853,8 +1767,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1912,8 +1824,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1966,8 +1876,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2025,8 +1933,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2079,8 +1985,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2138,8 +2042,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2192,8 +2094,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2251,8 +2151,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2305,8 +2203,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2364,8 +2260,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2418,8 +2312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2477,8 +2369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2499,8 +2389,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2521,8 +2409,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -39,7 +37,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -71,7 +68,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,7 +99,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,7 +128,6 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,7 +157,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,7 +184,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +210,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,7 +236,6 @@
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,7 +265,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -305,7 +294,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -335,7 +323,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,7 +347,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +371,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,7 +425,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -496,7 +480,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,7 +507,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,7 +537,6 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +565,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,7 +609,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,7 +636,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,7 +663,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,7 +707,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -760,7 +736,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -792,7 +767,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,7 +791,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Description of audio data to be recognized.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +339,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +360,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -442,7 +429,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +453,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -489,8 +474,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,7 +516,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -561,7 +543,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,7 +569,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -613,7 +593,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,8 +614,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,7 +640,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,7 +665,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -711,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -733,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,8 +726,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -785,7 +754,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,7 +778,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,7 +802,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,7 +826,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -885,7 +850,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,7 +874,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,7 +898,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,7 +925,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -991,7 +952,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1018,7 +978,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,7 +1004,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1070,7 +1028,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1095,7 +1052,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1117,8 +1073,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1141,8 +1095,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1165,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(RecognitionMetadata other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1204,8 +1154,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1265,8 +1213,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1306,8 +1252,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionMetadata.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1351,7 +1295,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1395,7 +1338,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1435,8 +1377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1487,7 +1427,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1530,7 +1469,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1573,7 +1511,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1616,7 +1553,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1659,7 +1595,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1702,7 +1637,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1745,7 +1679,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1791,7 +1724,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1837,7 +1769,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1882,7 +1813,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1927,7 +1857,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1970,7 +1899,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2013,7 +1941,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2053,8 +1980,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2104,8 +2029,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionMetadata.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
@@ -15,7 +15,6 @@
  by.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.RecognitionMetadata.InteractionType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Enumerates the types of capture settings describing an audio file.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Description of audio data to be recognized.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognitionMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_TOPIC_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INDUSTRY_NAICS_CODE_OF_AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INTERACTION_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MICROPHONE_DISTANCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,8 +349,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ORIGINAL_MEDIA_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +368,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ORIGINAL_MIME_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,8 +387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RECORDING_DEVICE_NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,8 +406,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RECORDING_DEVICE_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -445,8 +428,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -490,7 +471,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,7 +496,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,8 +517,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,8 +537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,7 +583,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +607,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,7 +631,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,7 +655,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,7 +679,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -735,7 +703,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -760,7 +727,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,7 +754,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,7 +781,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,8 +802,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionMetadata&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -867,7 +829,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,7 +855,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,7 +879,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,7 +903,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,8 +924,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,8 +946,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1038,8 +990,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,8 +1012,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1086,8 +1034,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,8 +1054,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata.Builder newBuilder(RecognitionMetadata prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,8 +1091,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1169,8 +1111,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionMetadata.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,8 +1150,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1251,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1305,8 +1241,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1364,8 +1298,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1418,8 +1350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1477,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1531,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1590,8 +1516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1644,8 +1568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1703,8 +1625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1757,8 +1677,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1816,8 +1734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1870,8 +1786,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1929,8 +1843,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionMetadata&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1951,8 +1863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1973,8 +1883,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,7 +82,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,7 +130,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,7 +154,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -186,7 +178,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -211,7 +202,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -236,7 +226,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,7 +253,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -292,7 +280,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,7 +306,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +332,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,7 +380,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `Recognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,7 +338,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,7 +362,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,8 +382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +485,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +509,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,7 +532,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,7 +556,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +581,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,7 +605,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,8 +625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +645,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,8 +665,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,7 +690,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +715,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,8 +736,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,8 +758,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,7 +783,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,7 +824,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -898,8 +861,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(RecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +898,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,8 +957,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,8 +996,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,7 +1038,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1124,7 +1078,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,7 +1119,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,7 +1160,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1246,8 +1197,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,8 +1241,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1343,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `Recognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,7 +380,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +404,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,7 +429,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,8 +449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,8 +469,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,8 +509,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,8 +553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,7 +578,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,7 +603,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,8 +624,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,8 +668,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,8 +690,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -743,8 +710,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest.Builder newBuilder(RecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,8 +747,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,8 +767,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -845,8 +806,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,8 +845,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +897,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +954,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,8 +1006,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,8 +1063,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,8 +1115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1225,8 +1172,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1451,8 +1390,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1564,8 +1499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1586,8 +1519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1608,8 +1539,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,7 +102,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +150,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,8 +272,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +320,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +361,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +402,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +448,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +494,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +518,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,8 +555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +595,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +617,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,7 +699,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,8 +781,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,7 +807,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,7 +848,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,7 +889,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,7 +913,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,7 +937,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,7 +961,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,7 +1002,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1058,8 +1022,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1082,8 +1044,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1106,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(RecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1145,8 +1103,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,7 +1244,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1330,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1376,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,7 +1378,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1478,7 +1424,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1521,8 +1466,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.RecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +376,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,8 +396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +422,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +463,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +487,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +511,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,7 +552,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,8 +572,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,8 +616,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,8 +638,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,8 +702,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse.Builder newBuilder(RecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -771,8 +739,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -834,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -875,8 +837,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -929,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,8 +946,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1055,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,8 +1107,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,8 +1164,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1268,8 +1216,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1327,8 +1273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1381,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1440,8 +1382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1494,8 +1434,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1553,8 +1491,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1575,8 +1511,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1597,8 +1531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Config to enable speaker diarization.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeakerDiarizationConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +340,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,8 +361,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +431,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,8 +452,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,7 +494,6 @@
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,8 +515,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,7 +604,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,7 +630,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,7 +656,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,7 +680,6 @@
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,8 +701,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,8 +723,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,8 +745,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(SpeakerDiarizationConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,8 +782,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,8 +880,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeakerDiarizationConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,7 +924,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,7 +1012,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,7 +1056,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1141,8 +1095,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1195,7 +1147,6 @@
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1235,8 +1186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeakerDiarizationConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Config to enable speaker diarization.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeakerDiarizationConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_SPEAKER_DIARIZATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MAX_SPEAKER_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MIN_SPEAKER_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEAKER_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +352,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,8 +411,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,8 +431,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -473,7 +456,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,7 +482,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +508,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,8 +529,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeakerDiarizationConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,7 +576,6 @@
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +641,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -718,8 +685,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +705,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig.Builder newBuilder(SpeakerDiarizationConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -779,8 +742,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeakerDiarizationConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,8 +840,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +892,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -996,8 +949,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,8 +1001,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,8 +1058,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1222,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1276,8 +1219,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1335,8 +1276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,8 +1328,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1448,8 +1385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1502,8 +1437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1561,8 +1494,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeakerDiarizationConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1583,8 +1514,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1605,8 +1534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +83,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,7 +107,6 @@
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
@@ -39,7 +39,6 @@
  SpeechClient speechClient = SpeechClient.create(speechSettings);
 </code></pre><p>Please refer to the GitHub repository&#39;s samples for more quickstart code snippets.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -98,7 +97,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,8 +119,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechClient(SpeechStub stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,8 +143,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,8 +200,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_SpeechClient_create_" data-uid="com.google.cloud.speech.v1.SpeechClient.create*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechClient_create__" data-uid="com.google.cloud.speech.v1.SpeechClient.create()" class="notranslate">create()</h3>
   <div class="codewrapper">
@@ -215,7 +207,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient with default settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -253,7 +244,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -308,7 +298,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given stub for making calls. This is for advanced usage - prefer using create(SpeechSettings).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the OperationsClient that can be used to query the status of a long-running operation returned by another API method call.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,8 +357,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechSettings getSettings()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,8 +377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub getStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,8 +397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,8 +417,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,7 +448,6 @@
    LongRunningRecognizeResponse response = speechClient.longRunningRecognizeAsync(request).get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,7 +495,6 @@
        speechClient.longRunningRecognizeAsync(config, audio).get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +553,6 @@
    Operation response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,7 +587,6 @@
    LongRunningRecognizeResponse response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,7 +615,6 @@
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +671,6 @@
    RecognizeResponse response = speechClient.recognize(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +722,6 @@
    RecognizeResponse response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,15 +742,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_SpeechClient_shutdownNow_" data-uid="com.google.cloud.speech.v1.SpeechClient.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechClient_shutdownNow__" data-uid="com.google.cloud.speech.v1.SpeechClient.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_SpeechClient_streamingRecognizeCallable_" data-uid="com.google.cloud.speech.v1.SpeechClient.streamingRecognizeCallable*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechClient_streamingRecognizeCallable__" data-uid="com.google.cloud.speech.v1.SpeechClient.streamingRecognizeCallable()" class="notranslate">streamingRecognizeCallable()</h3>
   <div class="codewrapper">
@@ -795,7 +764,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -244,7 +243,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,7 +295,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -350,7 +347,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,8 +386,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +430,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,8 +492,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -545,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,7 +583,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +604,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,8 +626,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -667,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,8 +666,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,7 +701,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -779,7 +753,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -832,7 +805,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -867,7 +839,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,8 +860,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -913,8 +882,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +904,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(SpeechContext other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,8 +941,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,8 +1000,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1078,8 +1039,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1119,8 +1078,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1178,7 +1135,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1224,8 +1180,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1275,8 +1229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -362,8 +355,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -384,8 +375,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,8 +395,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechContext&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -443,7 +430,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -496,7 +482,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,7 +534,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +568,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,8 +589,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,8 +611,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,8 +633,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,8 +677,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +699,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder(SpeechContext prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +756,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -809,8 +776,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechContext.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,8 +815,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,8 +906,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1004,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1058,8 +1015,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1117,8 +1072,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,8 +1124,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1230,8 +1181,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1284,8 +1233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1343,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,8 +1342,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1456,8 +1399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1510,8 +1451,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1569,8 +1508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechContext&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1591,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1613,8 +1548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -41,7 +39,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +91,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,7 +143,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -182,7 +177,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechBlockingStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -210,7 +206,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechFutureStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -210,7 +206,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -70,8 +69,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechImplBase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_bindService_" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.bindService*"></a>
@@ -79,8 +76,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ServerServiceDefinition bindService()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,7 +103,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,7 +133,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,7 +163,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,7 +196,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +226,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +64,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final String SERVICE_NAME</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,8 +86,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;LongRunningRecognizeRequest,Operation&gt; getLongRunningRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;RecognizeRequest,RecognizeResponse&gt; getRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,8 +126,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServiceDescriptor getServiceDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,8 +146,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; getStreamingRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,7 +168,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,7 +207,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -259,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +63,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Descriptors.FileDescriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistry registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistryLite registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -235,7 +234,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,8 +271,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +320,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -367,7 +362,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +404,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,7 +451,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,7 +498,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,7 +523,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,8 +560,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,8 +580,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +600,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,7 +631,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,7 +733,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,7 +759,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -802,8 +779,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,7 +810,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -879,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,8 +871,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -928,7 +896,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,7 +920,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -980,7 +946,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,7 +988,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1066,7 +1030,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,7 +1055,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,7 +1080,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1144,7 +1105,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1187,7 +1147,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1232,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,8 +1211,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(SpeechRecognitionAlternative other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1295,8 +1248,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,8 +1307,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,8 +1346,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1443,7 +1390,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,7 +1436,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1530,8 +1475,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1576,8 +1519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1630,7 +1571,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1673,7 +1613,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1713,8 +1652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1759,7 +1696,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1807,7 +1743,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIDENCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int TRANSCRIPT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int WORDS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +381,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionAlternative&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +509,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,7 +533,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,7 +581,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +623,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,7 +648,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,7 +673,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -743,7 +715,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +735,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +757,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -812,8 +779,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder(SpeechRecognitionAlternative prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionAlternative.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,8 +917,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,8 +956,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1055,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1114,8 +1065,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1168,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1174,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1281,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1340,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1394,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1453,8 +1392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1507,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1566,8 +1501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1620,8 +1553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1679,8 +1610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionAlternative&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1701,8 +1630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1723,8 +1650,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -37,7 +35,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +83,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +109,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +151,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,7 +176,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +201,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -252,7 +243,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -280,7 +278,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +321,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +364,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +412,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +460,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,7 +486,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +523,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +567,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +587,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -651,7 +635,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -677,7 +660,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,8 +681,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +720,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,7 +787,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -855,7 +830,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,7 +873,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -926,7 +899,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,7 +925,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -980,7 +951,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1024,7 +994,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,7 +1019,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1072,8 +1040,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1094,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1116,8 +1080,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,8 +1102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1164,8 +1124,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1188,8 +1146,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(SpeechRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1183,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,8 +1242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1329,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1376,7 +1326,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1420,7 +1369,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1469,7 +1417,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1517,7 +1464,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1557,8 +1503,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1603,8 +1547,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1654,8 +1596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CHANNEL_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +359,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +402,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +428,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,7 +454,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,7 +497,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,7 +522,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +603,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +647,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,8 +669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -718,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,8 +713,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,8 +735,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +755,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder(SpeechRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -827,8 +792,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -849,8 +812,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,8 +890,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -985,8 +942,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +999,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1098,8 +1051,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,8 +1108,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1211,8 +1160,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1217,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1324,8 +1269,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1383,8 +1326,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,8 +1378,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1496,8 +1435,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,8 +1487,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,8 +1544,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1631,8 +1564,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1653,8 +1584,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,7 +75,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,7 +127,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for SpeechSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -139,15 +138,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,8 +165,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,8 +187,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechStubSettings.Builder stubSettings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,7 +214,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,8 +303,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder getStubSettingsBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,7 +325,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -362,7 +347,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +369,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +391,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
@@ -32,7 +32,6 @@
              .build());
  SpeechSettings speechSettings = speechSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechSettings(SpeechSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechSettings create(SpeechStubSettings stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,8 +197,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -226,7 +219,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,7 +241,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,7 +263,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,8 +283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,7 +305,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,7 +327,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +349,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +371,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,7 +393,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +415,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,7 +476,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,7 +498,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +340,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +360,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,8 +426,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -492,7 +477,6 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,8 +498,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,7 +524,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -568,7 +549,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +573,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +593,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -636,8 +613,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,8 +633,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,7 +661,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,7 +694,6 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +719,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -770,8 +740,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,8 +762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,7 +788,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,8 +825,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(StreamingRecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,8 +862,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,8 +921,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,8 +960,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1046,7 +1003,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1088,7 +1044,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1126,8 +1081,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1178,7 +1131,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1218,8 +1170,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1281,7 +1231,6 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1321,8 +1270,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INTERIM_RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SINGLE_UTTERANCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +377,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +402,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,7 +488,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +509,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,7 +565,6 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +586,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -637,7 +612,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,8 +633,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -707,8 +677,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,8 +699,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder(StreamingRecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -792,8 +756,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,8 +776,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -855,8 +815,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -950,8 +906,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1009,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1063,8 +1015,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,8 +1072,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1176,8 +1124,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1235,8 +1181,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1289,8 +1233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1348,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1402,8 +1342,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1461,8 +1399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1515,8 +1451,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1574,8 +1508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1596,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1618,8 +1548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,7 +139,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -237,7 +236,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,7 +279,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,7 +322,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +365,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,7 +413,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +461,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -494,7 +487,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,8 +524,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +588,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +608,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,7 +636,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,7 +661,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,8 +682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +728,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,7 +754,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,8 +775,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,7 +818,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -870,7 +845,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -892,8 +866,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,7 +894,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,7 +937,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,7 +980,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,7 +1006,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1064,7 +1032,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,7 +1058,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,7 +1101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,7 +1126,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1183,8 +1147,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1205,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1187,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1258,7 +1216,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1285,7 +1242,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,7 +1268,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,7 +1293,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1364,7 +1318,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,7 +1342,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1417,7 +1369,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1443,7 +1394,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1465,8 +1415,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1489,8 +1437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(StreamingRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1552,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1613,8 +1555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1658,7 +1598,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1696,8 +1635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1743,7 +1680,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1787,7 +1723,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1836,7 +1771,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1884,7 +1818,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1924,8 +1857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1977,7 +1908,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2022,7 +1952,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2067,7 +1996,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2107,8 +2035,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2162,7 +2088,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2204,7 +2129,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2249,7 +2173,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2289,8 +2212,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CHANNEL_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int IS_FINAL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULT_END_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STABILITY_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,7 +436,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,7 +479,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,7 +505,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,7 +531,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +574,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +599,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,8 +620,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,8 +660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -714,7 +687,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,7 +713,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,7 +739,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,8 +760,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,7 +786,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -844,7 +811,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -865,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,7 +860,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,8 +881,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,7 +907,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -968,8 +928,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -992,8 +950,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +972,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,8 +994,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,8 +1014,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder(StreamingRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1051,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1123,8 +1071,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1164,8 +1110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1205,8 +1149,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1259,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1318,8 +1258,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1372,8 +1310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,8 +1367,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1485,8 +1419,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1544,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1598,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1657,8 +1585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1711,8 +1637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1770,8 +1694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1824,8 +1746,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1883,8 +1803,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1905,8 +1823,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1927,8 +1843,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,7 +75,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,7 +127,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +223,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,7 +249,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,7 +275,6 @@
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,7 +300,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,7 +325,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,7 +352,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +377,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
@@ -18,7 +18,6 @@
  must not contain a `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -234,8 +233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -280,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,7 +349,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +370,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,8 +409,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +453,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,8 +473,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -544,7 +525,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,8 +546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,8 +566,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,8 +586,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,7 +613,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,7 +639,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,7 +664,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +714,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,7 +740,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,8 +783,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,8 +805,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(StreamingRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,8 +901,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,7 +945,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1026,8 +982,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,7 +1031,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1117,8 +1070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1114,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1219,7 +1168,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1262,7 +1210,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1300,8 +1247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span>,</span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
@@ -18,7 +18,6 @@
  must not contain a `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -278,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STREAMING_CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +318,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +367,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,8 +388,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,8 +408,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,8 +428,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,8 +448,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,7 +497,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,7 +523,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,8 +543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +595,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,7 +621,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,8 +664,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +708,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,8 +728,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder(StreamingRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +765,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -864,8 +824,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -905,8 +863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -959,8 +915,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1018,8 +972,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1072,8 +1024,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1131,8 +1081,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1185,8 +1133,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1244,8 +1190,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1298,8 +1242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1357,8 +1299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1411,8 +1351,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,8 +1408,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1524,8 +1460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1583,8 +1517,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1605,8 +1537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1627,8 +1557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -38,7 +36,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -65,7 +62,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +88,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,8 +108,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,7 +138,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +164,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
@@ -49,7 +49,6 @@
      one or more (repeated) `results`.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -271,7 +270,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,8 +307,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,7 +357,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,7 +400,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,7 +443,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,7 +491,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +539,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,7 +565,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,8 +602,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,8 +622,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,7 +668,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +688,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -746,8 +727,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,7 +772,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,7 +795,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,8 +816,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,8 +838,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -885,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -907,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,7 +904,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -961,7 +929,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -986,7 +953,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1013,7 +979,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,7 +1022,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,7 +1065,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1128,7 +1091,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,7 +1117,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1182,7 +1143,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,7 +1186,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1250,7 +1209,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1275,7 +1233,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1301,7 +1258,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1323,8 +1279,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1347,8 +1301,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1375,7 +1327,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1413,8 +1364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(StreamingRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1452,8 +1401,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1554,8 +1499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1601,7 +1544,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1643,7 +1585,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1685,7 +1626,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1723,8 +1663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1769,8 +1707,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1826,7 +1762,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1875,7 +1810,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1921,7 +1855,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1964,7 +1897,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2004,8 +1936,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
@@ -49,7 +49,6 @@
      one or more (repeated) `results`.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -309,8 +308,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ERROR_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,8 +327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,8 +346,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEECH_EVENT_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,8 +368,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -416,8 +407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,8 +427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,7 +471,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,7 +496,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,8 +516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +544,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,7 +587,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,7 +613,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -661,7 +639,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,7 +682,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +702,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,7 +727,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,7 +751,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,8 +772,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,7 +798,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,8 +819,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -898,8 +863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,8 +885,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,8 +905,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder(StreamingRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -983,8 +942,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +962,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1046,8 +1001,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1087,8 +1040,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1141,8 +1092,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1200,8 +1149,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1254,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1313,8 +1258,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1367,8 +1310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1426,8 +1367,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,8 +1419,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1539,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1593,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1652,8 +1585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1706,8 +1637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1765,8 +1694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1787,8 +1714,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1809,8 +1734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +124,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -156,7 +150,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,7 +176,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -227,7 +219,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,7 +242,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,7 +266,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,7 +291,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Word-specific information for recognized words.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.WordInfo</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -352,7 +343,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,8 +363,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,7 +448,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -492,7 +477,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,7 +500,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,8 +521,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -562,8 +543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,8 +583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,7 +613,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,7 +642,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,7 +670,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,7 +697,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,7 +726,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -785,7 +755,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +783,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,7 +806,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,7 +830,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -893,7 +859,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -923,7 +888,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,8 +909,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -969,8 +931,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,7 +961,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(WordInfo other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1078,8 +1035,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1139,8 +1094,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1188,7 +1141,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,8 +1178,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final WordInfo.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1275,7 +1225,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1321,7 +1270,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1359,8 +1307,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1405,8 +1351,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1463,7 +1407,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,7 +1454,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1557,7 +1499,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1595,8 +1536,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final WordInfo.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1639,7 +1578,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1682,7 +1620,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Word-specific information for recognized words.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1.WordInfo</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int END_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEAKER_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int START_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int WORD_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +352,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,8 +411,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,8 +431,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,7 +459,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,7 +488,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;WordInfo&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +530,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,7 +559,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,7 +588,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -642,7 +617,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,8 +637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,7 +662,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,7 +686,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +715,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,7 +744,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,8 +765,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -821,8 +787,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -845,8 +809,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo.Builder newBuilder(WordInfo prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -930,8 +888,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -952,8 +908,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected WordInfo.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -993,8 +947,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,8 +986,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1088,8 +1038,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,8 +1095,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1201,8 +1147,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1260,8 +1204,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1314,8 +1256,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1373,8 +1313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1427,8 +1365,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1486,8 +1422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1540,8 +1474,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1599,8 +1531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1653,8 +1583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1712,8 +1640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;WordInfo&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1734,8 +1660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1756,8 +1680,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -36,7 +34,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -66,7 +63,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +90,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,7 +148,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -178,7 +171,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -203,7 +195,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,7 +224,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -263,7 +253,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC callable factory implementation for the Speech service API.</p>
 <p>This class is for advanced usage.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcSpeechCallableFactory()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1_stub_GrpcSpeechCallableFactory_createOperationCallable_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.createOperationCallable*"></a>
@@ -80,8 +77,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;RequestT,ResponseT,MetadataT&gt; &lt;RequestT,ResponseT,MetadataT&gt;createOperationCallable(GrpcCallSettings&lt;RequestT,Operation&gt; grpcCallSettings, OperationCallSettings&lt;RequestT,ResponseT,MetadataT&gt; callSettings, ClientContext clientContext, OperationsStub operationsStub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,8 +129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,PagedListResponseT&gt; &lt;RequestT,ResponseT,PagedListResponseT&gt;createPagedCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, PagedCallSettings&lt;RequestT,ResponseT,PagedListResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,8 +176,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBatchingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, BatchingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,8 +223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBidiStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,8 +270,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ClientStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createClientStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServerStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createServerStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, ServerStreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createUnaryCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, UnaryCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC stub implementation for the Speech service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -88,7 +87,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +116,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,8 +150,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,8 +207,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Overrides</strong>
   <div><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStub.html#com_google_cloud_speech_v1_stub_SpeechStub_close__">SpeechStub.close()</a></div>
   <a id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_create_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.create*"></a>
@@ -221,8 +214,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -334,8 +323,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(SpeechStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,8 +375,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcOperationsStub getOperationsStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +417,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,22 +503,16 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_shutdownNow_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_shutdownNow__" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_streamingRecognizeCallable_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.streamingRecognizeCallable*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_streamingRecognizeCallable__" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.streamingRecognizeCallable()" class="notranslate">streamingRecognizeCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Base stub class for the Speech service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1_stub_SpeechStub_close_" data-uid="com.google.cloud.speech.v1.stub.SpeechStub.close*"></a>
@@ -80,15 +77,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_stub_SpeechStub_getOperationsStub_" data-uid="com.google.cloud.speech.v1.stub.SpeechStub.getOperationsStub*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_SpeechStub_getOperationsStub__" data-uid="com.google.cloud.speech.v1.stub.SpeechStub.getOperationsStub()" class="notranslate">getOperationsStub()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsStub getOperationsStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,8 +102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,8 +122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,8 +142,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -175,8 +162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for SpeechStubSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -142,15 +141,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,8 +168,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,8 +247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,7 +286,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,7 +308,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,7 +330,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,7 +352,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,8 +372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ImmutableList&lt;UnaryCallSettings.Builder&lt;?,?&gt;&gt; unaryMethodSettingsBuilders()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
@@ -32,7 +32,6 @@
              .build());
  SpeechStubSettings speechSettings = speechSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechStubSettings(SpeechStubSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub createStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,8 +180,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +202,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,7 +224,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,7 +288,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,7 +310,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +332,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +354,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,7 +376,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,7 +398,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +437,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,7 +459,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,7 +481,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.html
@@ -11,9 +11,6 @@
 </h1>
   
   {% verbatim %}
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
-  <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes
   
   </h2>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -232,8 +231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -278,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,8 +337,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,8 +399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,7 +465,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,8 +485,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,8 +507,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,8 +527,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,8 +547,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -596,7 +572,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -620,7 +595,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,7 +618,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,7 +642,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,7 +665,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +688,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,7 +711,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,7 +734,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,7 +757,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +777,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -834,8 +799,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder mergeFrom(AsyncRecognizeMetadata other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,8 +917,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1002,7 +959,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1043,7 +999,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1081,8 +1036,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeMetadata.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,8 +1075,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,7 +1122,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1212,7 +1162,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1254,7 +1203,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,8 +1240,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,7 +1292,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,7 +1332,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1425,8 +1369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeMetadata.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LAST_UPDATE_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROGRESS_PERCENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int START_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,8 +394,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,8 +414,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -452,7 +437,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,7 +460,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,8 +480,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;AsyncRecognizeMetadata&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,7 +506,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,8 +526,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,7 +551,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,7 +574,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -618,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,7 +619,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,7 +642,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,8 +662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -714,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -738,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,8 +728,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -784,8 +748,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata.Builder newBuilder(AsyncRecognizeMetadata prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -845,8 +805,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AsyncRecognizeMetadata.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,8 +844,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +896,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,8 +1005,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,8 +1062,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,8 +1114,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1225,8 +1171,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1280,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1332,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1451,8 +1389,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1441,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeMetadata parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1564,8 +1498,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;AsyncRecognizeMetadata&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1586,8 +1518,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1608,8 +1538,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +52,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,7 +76,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,7 +99,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,7 +122,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,7 +145,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +168,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `AsyncRecognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,7 +338,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,7 +362,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,8 +382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +485,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +508,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +531,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +555,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,7 +579,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,7 +603,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +623,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +643,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +688,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,7 +712,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,8 +732,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +779,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -856,7 +820,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder mergeFrom(AsyncRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1035,8 +992,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,7 +1034,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,7 +1074,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1162,7 +1115,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1204,7 +1156,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1242,8 +1193,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,8 +1237,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,8 +1286,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `AsyncRecognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,7 +379,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +403,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +427,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +467,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +487,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,8 +507,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;AsyncRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +529,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,7 +576,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,7 +600,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,8 +620,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,8 +664,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest.Builder newBuilder(AsyncRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,8 +743,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,8 +763,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AsyncRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -841,8 +802,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -895,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -954,8 +911,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1008,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,8 +1020,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,8 +1072,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1180,8 +1129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,8 +1181,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1293,8 +1238,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1347,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1406,8 +1347,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1460,8 +1399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1519,8 +1456,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;AsyncRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1541,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1563,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +52,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,7 +76,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +100,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +123,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,7 +147,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
@@ -17,7 +17,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -237,7 +236,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,7 +321,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -367,7 +362,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,7 +403,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +449,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,7 +495,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +519,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,8 +576,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,8 +596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,8 +618,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -675,8 +657,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,7 +700,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,8 +720,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,8 +742,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -809,8 +782,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -837,7 +808,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -879,7 +849,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -921,7 +890,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,7 +914,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -971,7 +938,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -996,7 +962,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1038,7 +1003,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1059,8 +1023,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,8 +1045,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1067,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder mergeFrom(AsyncRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1146,8 +1104,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,8 +1163,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1248,8 +1202,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1293,7 +1245,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1331,8 +1282,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1377,8 +1326,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1432,7 +1379,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1479,7 +1425,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1522,8 +1467,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AsyncRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
@@ -17,7 +17,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.AsyncRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -277,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,8 +298,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,8 +337,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,8 +357,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,8 +377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,8 +397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;AsyncRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,7 +423,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,7 +464,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,7 +488,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +512,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,7 +553,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -591,8 +573,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -615,8 +595,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,8 +617,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,8 +639,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -687,8 +661,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -711,8 +683,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -733,8 +703,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse.Builder newBuilder(AsyncRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,8 +740,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,8 +760,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AsyncRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,8 +799,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,8 +908,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1002,8 +960,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,8 +1017,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1115,8 +1069,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1174,8 +1126,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1228,8 +1178,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1287,8 +1235,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1341,8 +1287,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1400,8 +1344,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1454,8 +1396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AsyncRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1453,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;AsyncRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1535,8 +1473,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1557,8 +1493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
@@ -17,7 +17,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -233,8 +232,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -279,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +316,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,8 +338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearAudioSource()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +363,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,8 +383,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,7 +469,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,8 +511,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,7 +536,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +576,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,7 +626,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,7 +654,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -704,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,8 +696,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,8 +718,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(RecognitionAudio other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,8 +755,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -852,8 +814,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -893,8 +853,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -939,7 +897,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,8 +934,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,8 +978,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1074,8 +1027,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1123,7 +1074,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1169,7 +1119,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
@@ -17,7 +17,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -277,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int URI_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +381,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,8 +401,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,8 +441,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionAudio&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,8 +483,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,8 +505,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,7 +535,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,7 +563,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,8 +583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,8 +605,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,8 +627,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,8 +649,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -701,8 +669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder(RecognitionAudio prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,8 +726,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionAudio.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -803,8 +765,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,8 +817,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -916,8 +874,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,8 +926,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1029,8 +983,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,8 +1035,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,8 +1092,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1196,8 +1144,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1309,8 +1253,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1368,8 +1310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1422,8 +1362,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1481,8 +1419,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionAudio&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1503,8 +1439,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1525,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -28,8 +26,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +51,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,7 +79,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,7 +107,6 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
@@ -21,7 +21,6 @@
  or transmit the audio, particularly if background noise is present.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +339,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,8 +359,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,7 +433,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,8 +453,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,7 +498,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,7 +525,6 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,7 +548,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,8 +568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,8 +590,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,8 +630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -682,7 +655,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,7 +678,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -734,7 +705,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,7 +732,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,7 +760,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,7 +786,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,7 +813,6 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -870,7 +836,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,7 +859,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,7 +882,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,7 +905,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,8 +925,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -987,8 +947,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1011,8 +969,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(RecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,8 +1006,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1111,8 +1065,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,7 +1107,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1193,8 +1144,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1237,7 +1186,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1278,7 +1226,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1316,8 +1263,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1369,7 +1314,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1414,7 +1358,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1460,7 +1403,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1504,7 +1446,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1542,8 +1483,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1600,7 +1539,6 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1641,7 +1579,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1682,7 +1619,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1720,8 +1656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENCODING_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MAX_ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROFANITY_FILTER_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SAMPLE_RATE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEECH_CONTEXT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -445,8 +430,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,8 +450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -489,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,7 +493,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,7 +516,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,7 +543,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,7 +570,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,7 +598,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,8 +618,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,7 +646,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,7 +673,6 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,8 +693,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -750,7 +718,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,7 +741,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,7 +786,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -843,8 +806,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -867,8 +828,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -915,8 +872,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +892,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder(RecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,8 +929,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,8 +949,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,8 +988,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1093,8 +1040,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1152,8 +1097,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1149,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1265,8 +1206,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1319,8 +1258,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1378,8 +1315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1432,8 +1367,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1491,8 +1424,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1545,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1604,8 +1533,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1658,8 +1585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1717,8 +1642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1739,8 +1662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1761,8 +1682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +52,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -83,7 +79,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,7 +134,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -167,7 +160,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -195,7 +187,6 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,7 +210,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,7 +233,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -267,7 +256,6 @@
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -239,7 +238,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,7 +283,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,7 +328,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,8 +365,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,8 +409,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +429,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +471,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,7 +557,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -618,8 +599,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -640,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,8 +639,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,7 +669,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,7 +714,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,7 +759,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -815,7 +787,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +807,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,8 +829,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -884,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(SpeechContext other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -923,8 +888,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -984,8 +947,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1025,8 +986,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1066,8 +1025,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,7 +1077,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1119,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,8 +1168,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -362,8 +355,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -384,8 +375,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,8 +395,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechContext&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,7 +425,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,7 +470,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,7 +515,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,7 +543,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -604,8 +585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -628,8 +607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,8 +629,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -676,8 +651,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,8 +673,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,8 +693,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder(SpeechContext prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -761,8 +730,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,8 +750,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechContext.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,8 +789,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +898,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -991,8 +950,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,8 +1007,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1104,8 +1059,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1116,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1217,8 +1168,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1276,8 +1225,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1330,8 +1277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,8 +1334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1443,8 +1386,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1502,8 +1443,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechContext&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1524,8 +1463,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1546,8 +1483,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -36,7 +34,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -82,7 +79,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,7 +124,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +152,6 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,7 +121,6 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,8 +158,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechBlockingStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +205,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,7 +121,6 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,8 +158,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechFutureStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +205,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -70,8 +69,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechImplBase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechImplBase_asyncRecognize_" data-uid="com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.asyncRecognize*"></a>
@@ -86,7 +83,6 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,8 +110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ServerServiceDefinition bindService()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,7 +133,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,7 +173,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,7 +121,6 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,8 +148,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,7 +195,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +235,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +64,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final MethodDescriptor&lt;AsyncRecognizeRequest,Operation&gt; METHOD_ASYNC_RECOGNIZE</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final MethodDescriptor&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; METHOD_STREAMING_RECOGNIZE</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,8 +102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final MethodDescriptor&lt;SyncRecognizeRequest,SyncRecognizeResponse&gt; METHOD_SYNC_RECOGNIZE</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final String SERVICE_NAME</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,8 +143,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;AsyncRecognizeRequest,Operation&gt; getAsyncRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,8 +163,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServiceDescriptor getServiceDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,8 +183,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; getStreamingRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,8 +203,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;SyncRecognizeRequest,SyncRecognizeResponse&gt; getSyncRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -242,7 +225,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -282,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,7 +303,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +63,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Descriptors.FileDescriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistry registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistryLite registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,7 +344,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,8 +364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,8 +403,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,7 +445,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +465,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -513,7 +496,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,8 +516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +536,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,7 +581,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,7 +604,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,8 +624,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,8 +668,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(SpeechRecognitionAlternative other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,8 +705,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -798,8 +764,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,8 +803,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,7 +851,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -927,8 +888,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -973,8 +932,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1027,7 +984,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1068,7 +1024,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1106,8 +1061,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIDENCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int TRANSCRIPT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +362,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,8 +382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionAlternative&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,7 +489,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,7 +512,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,8 +532,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +576,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,8 +598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,8 +620,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder(SpeechRecognitionAlternative prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,8 +677,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,8 +697,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionAlternative.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,8 +736,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,8 +788,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -885,8 +845,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -939,8 +897,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,8 +954,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1052,8 +1006,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1111,8 +1063,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1165,8 +1115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1224,8 +1172,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1278,8 +1224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1337,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1450,8 +1390,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionAlternative&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1472,8 +1410,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1494,8 +1430,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -37,7 +35,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -61,7 +58,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -234,7 +233,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,7 +274,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,7 +315,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,7 +356,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,7 +402,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,7 +448,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +472,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -517,8 +509,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,8 +553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +573,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,8 +593,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +619,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,8 +639,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,8 +678,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -738,8 +717,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,7 +743,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,7 +784,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,7 +825,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -875,7 +849,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -900,7 +873,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +897,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -967,7 +938,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,8 +958,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,8 +978,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1032,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,8 +1020,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1080,8 +1042,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1104,8 +1064,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(SpeechRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1143,8 +1101,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1204,8 +1160,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1245,8 +1199,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1290,7 +1242,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1332,7 +1283,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1379,7 +1329,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1422,8 +1371,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1415,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1519,8 +1464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,7 +338,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +379,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +403,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +427,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +468,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,8 +488,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -520,8 +508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,8 +528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,8 +548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,8 +570,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,8 +592,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -636,8 +614,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,8 +636,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,8 +658,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,8 +680,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,8 +700,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder(SpeechRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,8 +737,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,8 +757,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -832,8 +796,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,8 +848,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,8 +905,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +957,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1058,8 +1014,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,8 +1123,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1225,8 +1175,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1284,8 +1232,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1284,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,8 +1341,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1451,8 +1393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1510,8 +1450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1532,8 +1470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1554,8 +1490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +340,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +360,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,8 +425,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -490,7 +475,6 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -511,8 +495,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -539,7 +521,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,7 +545,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -589,7 +569,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,8 +589,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,8 +609,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,8 +629,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,7 +657,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,7 +688,6 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,7 +712,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,8 +732,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +780,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -852,8 +817,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(StreamingRecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -952,8 +913,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -993,8 +952,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1038,7 +995,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1080,7 +1036,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,8 +1073,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1170,7 +1123,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,8 +1160,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,7 +1220,6 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1308,8 +1257,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INTERIM_RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SINGLE_UTTERANCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +377,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,7 +401,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,8 +441,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +487,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,8 +507,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,8 +529,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +562,6 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,8 +582,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,7 +608,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,8 +628,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,8 +650,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,8 +672,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,8 +714,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder(StreamingRecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +751,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -809,8 +771,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,8 +810,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -904,8 +862,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,8 +919,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1017,8 +971,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,8 +1028,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,8 +1080,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1189,8 +1137,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1243,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1302,8 +1246,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,8 +1298,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1415,8 +1355,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1469,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1528,8 +1464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,8 +1484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1572,8 +1504,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -57,7 +54,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,7 +80,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,7 +111,6 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -235,7 +234,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,7 +275,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,7 +316,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,7 +357,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +403,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +449,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,7 +473,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,8 +574,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -636,7 +620,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,7 +686,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,7 +752,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,8 +772,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,7 +798,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -865,7 +839,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -907,7 +880,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,7 +904,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -957,7 +928,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -982,7 +952,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1024,7 +993,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,8 +1013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,8 +1033,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1089,8 +1053,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,7 +1082,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1148,7 +1109,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1169,8 +1129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1193,8 +1151,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1217,8 +1173,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(StreamingRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,8 +1210,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1317,8 +1269,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1358,8 +1308,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1403,7 +1351,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1445,7 +1392,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1492,7 +1438,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1535,8 +1480,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1588,7 +1531,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1626,8 +1568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1684,7 +1624,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1722,8 +1661,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int IS_FINAL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STABILITY_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +377,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -428,7 +418,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,7 +442,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,7 +466,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -520,7 +507,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,8 +527,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,8 +547,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +567,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,7 +594,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,8 +614,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,8 +636,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,7 +665,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -711,8 +685,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -735,8 +707,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,8 +729,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,8 +751,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -807,8 +773,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +793,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder(StreamingRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -868,8 +830,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -985,8 +941,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1098,8 +1050,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,8 +1107,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1211,8 +1159,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1216,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1324,8 +1268,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1383,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,8 +1377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1496,8 +1434,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,8 +1486,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,8 +1543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1631,8 +1563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1653,8 +1583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,7 +187,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -222,7 +214,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
@@ -18,7 +18,6 @@
  `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -234,8 +233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -280,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,7 +349,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -420,8 +408,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +452,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,8 +472,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,8 +492,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -543,7 +524,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,8 +544,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,8 +564,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,8 +584,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -637,7 +611,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,7 +636,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,7 +661,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +681,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,7 +706,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -758,8 +726,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,8 +748,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -806,8 +770,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(StreamingRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -845,8 +807,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -906,8 +866,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -952,7 +910,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,8 +947,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1041,7 +996,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,8 +1033,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1125,8 +1077,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1181,7 +1131,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1224,7 +1173,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1262,8 +1210,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
@@ -18,7 +18,6 @@
  `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -278,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STREAMING_CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +318,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +367,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,8 +387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,8 +407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,8 +427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,8 +469,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,7 +496,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,7 +521,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -561,8 +541,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -583,8 +561,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,7 +588,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +608,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,8 +630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder(StreamingRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,8 +731,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +751,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +790,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,8 +899,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -996,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1055,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1168,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1222,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1281,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1335,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1394,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1448,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1507,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1529,8 +1464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1551,8 +1484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -38,7 +36,6 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,7 +61,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +86,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +131,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
@@ -57,7 +57,6 @@
    &quot;to be or not to be&quot;.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -279,7 +278,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +365,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +408,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +451,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,7 +499,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,7 +547,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,7 +573,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -620,8 +610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -642,8 +630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +650,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,7 +675,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,7 +699,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,8 +758,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,7 +802,6 @@
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -851,7 +828,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -872,8 +848,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,8 +870,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,8 +890,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +910,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -967,7 +935,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -991,7 +958,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,7 +982,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1041,7 +1006,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1066,7 +1030,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,7 +1055,6 @@
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1119,7 +1081,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,7 +1124,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,7 +1167,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,7 +1193,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1261,7 +1219,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,7 +1245,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1332,7 +1288,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1357,7 +1312,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1378,8 +1332,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1402,8 +1354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1430,7 +1380,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1417,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(StreamingRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1507,8 +1454,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1568,8 +1513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,8 +1552,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1656,7 +1597,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1697,7 +1637,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1738,7 +1677,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1780,7 +1718,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1822,7 +1759,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1860,8 +1796,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1906,8 +1840,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1962,7 +1894,6 @@
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2006,7 +1937,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2055,7 +1985,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2098,8 +2027,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Indicates the type of endpointer event.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
@@ -57,7 +57,6 @@
    &quot;to be or not to be&quot;.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -317,8 +316,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENDPOINTER_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ERROR_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +373,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULT_INDEX_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +395,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -445,8 +434,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,8 +454,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -489,8 +474,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,7 +497,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,7 +520,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +544,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,7 +568,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +588,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,7 +615,6 @@
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -665,7 +641,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,7 +684,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -736,7 +710,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,7 +736,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -807,7 +779,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,8 +799,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -852,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +847,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,8 +867,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -949,8 +911,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -973,8 +933,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder(StreamingRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,8 +990,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,8 +1010,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1097,8 +1049,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1151,8 +1101,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,8 +1158,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1264,8 +1210,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1323,8 +1267,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1377,8 +1319,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1436,8 +1376,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,8 +1428,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1549,8 +1485,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1603,8 +1537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1662,8 +1594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1716,8 +1646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1775,8 +1703,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1797,8 +1723,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1819,8 +1743,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +52,6 @@
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,7 +76,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +100,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -158,7 +151,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +194,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,7 +220,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,7 +246,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,7 +289,6 @@
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,7 +313,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `SyncRecognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SyncRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,7 +338,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,7 +362,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,8 +382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +485,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +508,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +531,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +555,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,7 +579,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,7 +603,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +623,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +643,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +688,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,7 +712,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,8 +732,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +779,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -856,7 +820,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder mergeFrom(SyncRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1035,8 +992,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SyncRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,7 +1034,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,7 +1074,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1162,7 +1115,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1204,7 +1156,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1242,8 +1193,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,8 +1237,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,8 +1286,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SyncRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `SyncRecognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SyncRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,7 +379,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +403,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +427,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +467,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +487,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,8 +507,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SyncRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +529,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,7 +576,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,7 +600,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,8 +620,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,8 +664,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest.Builder newBuilder(SyncRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,8 +743,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,8 +763,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SyncRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -841,8 +802,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -895,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -954,8 +911,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1008,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,8 +1020,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,8 +1072,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1180,8 +1129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,8 +1181,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1293,8 +1238,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1347,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1406,8 +1347,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1460,8 +1399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1519,8 +1456,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SyncRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1541,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1563,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +52,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,7 +76,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +100,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +123,6 @@
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,7 +147,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SyncRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,8 +272,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +320,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +361,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +402,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +448,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +494,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +518,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,8 +555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +595,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +617,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,7 +699,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,8 +781,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,7 +807,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,7 +848,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,7 +889,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,7 +913,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,7 +937,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,7 +961,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,7 +1002,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1058,8 +1022,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1082,8 +1044,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1106,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder mergeFrom(SyncRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1145,8 +1103,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SyncRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,7 +1244,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1330,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1376,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,7 +1378,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1478,7 +1424,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1521,8 +1466,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SyncRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1beta1.SyncRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +376,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,8 +396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SyncRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +422,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +463,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +487,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +511,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,7 +552,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,8 +572,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,8 +616,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,8 +638,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,8 +702,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse.Builder newBuilder(SyncRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -771,8 +739,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SyncRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -834,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -888,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -947,8 +907,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,8 +959,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,8 +1016,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1114,8 +1068,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1173,8 +1125,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1177,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1286,8 +1234,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1340,8 +1286,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1399,8 +1343,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1453,8 +1395,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SyncRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1512,8 +1452,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SyncRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1534,8 +1472,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1556,8 +1492,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.html
@@ -11,9 +11,6 @@
 </h1>
   
   {% verbatim %}
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
-  <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes
   
   </h2>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -84,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient.ListCustomClassesFixedSizeCollection createCollection(List&lt;AdaptationClient.ListCustomClassesPage&gt; pages, int collectionSize)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -102,8 +100,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient.ListCustomClassesPage createPage(PageContext&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass&gt; context, ListCustomClassesResponse response)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +144,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ApiFuture&lt;AdaptationClient.ListCustomClassesPage&gt; createPageAsync(PageContext&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass&gt; context, ApiFuture&lt;ListCustomClassesResponse&gt; futureResponse)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -84,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiFuture&lt;AdaptationClient.ListCustomClassesPagedResponse&gt; createAsync(PageContext&lt;ListCustomClassesRequest,ListCustomClassesResponse,CustomClass&gt; context, ApiFuture&lt;ListCustomClassesResponse&gt; futureResponse)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -84,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient.ListPhraseSetFixedSizeCollection createCollection(List&lt;AdaptationClient.ListPhraseSetPage&gt; pages, int collectionSize)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -102,8 +100,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient.ListPhraseSetPage createPage(PageContext&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet&gt; context, ListPhraseSetResponse response)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +144,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ApiFuture&lt;AdaptationClient.ListPhraseSetPage&gt; createPageAsync(PageContext&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet&gt; context, ApiFuture&lt;ListPhraseSetResponse&gt; futureResponse)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -84,8 +82,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiFuture&lt;AdaptationClient.ListPhraseSetPagedResponse&gt; createAsync(PageContext&lt;ListPhraseSetRequest,ListPhraseSetResponse,PhraseSet&gt; context, ApiFuture&lt;ListPhraseSetResponse&gt; futureResponse)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
@@ -41,7 +41,6 @@
  AdaptationClient adaptationClient = AdaptationClient.create(adaptationSettings);
 </code></pre><p>Please refer to the GitHub repository&#39;s samples for more quickstart code snippets.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -100,7 +99,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient(AdaptationStub stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -149,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -208,8 +202,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_create_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.create*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_create__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.create()" class="notranslate">create()</h3>
   <div class="codewrapper">
@@ -217,7 +209,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient with default settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -310,7 +300,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given stub for making calls. This is for advanced usage - prefer using create(AdaptationSettings).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,7 +349,6 @@
    CustomClass response = adaptationClient.createCustomClass(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +396,6 @@
    CustomClass response = adaptationClient.createCustomClass(parent, customClass, customClassId);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -471,7 +458,6 @@
    CustomClass response = adaptationClient.createCustomClass(parent, customClass, customClassId);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,7 +526,6 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,7 +558,6 @@
    PhraseSet response = adaptationClient.createPhraseSet(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,7 +605,6 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,7 +667,6 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,7 +734,6 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -780,7 +761,6 @@
    adaptationClient.deleteCustomClass(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -815,7 +795,6 @@
    adaptationClient.deleteCustomClass(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,7 +825,6 @@
    adaptationClient.deleteCustomClass(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,7 +861,6 @@
    future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -914,7 +891,6 @@
    adaptationClient.deletePhraseSet(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,7 +921,6 @@
    adaptationClient.deletePhraseSet(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,7 +952,6 @@
    adaptationClient.deletePhraseSet(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,7 +988,6 @@
    future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,7 +1015,6 @@
    CustomClass response = adaptationClient.getCustomClass(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,7 +1064,6 @@
    CustomClass response = adaptationClient.getCustomClass(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1138,7 +1109,6 @@
    CustomClass response = adaptationClient.getCustomClass(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1190,7 +1160,6 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,7 +1190,6 @@
    PhraseSet response = adaptationClient.getPhraseSet(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1267,7 +1235,6 @@
    PhraseSet response = adaptationClient.getPhraseSet(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1314,7 +1281,6 @@
    PhraseSet response = adaptationClient.getPhraseSet(name);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1366,7 +1332,6 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1352,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationSettings getSettings()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1409,8 +1372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStub getStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,8 +1392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1453,8 +1412,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1489,7 +1446,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1537,7 +1493,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1586,7 +1541,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1644,7 +1598,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1682,7 +1635,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1717,7 +1669,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1765,7 +1716,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1814,7 +1764,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1871,7 +1820,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1909,7 +1857,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1930,15 +1877,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_shutdownNow_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_shutdownNow__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_updateCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.updateCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_updateCustomClass_com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequest_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.updateCustomClass(com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest)" class="notranslate">updateCustomClass(UpdateCustomClassRequest request)</h3>
   <div class="codewrapper">
@@ -1955,7 +1898,6 @@
    CustomClass response = adaptationClient.updateCustomClass(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2008,7 +1950,6 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2040,7 +1981,6 @@
    PhraseSet response = adaptationClient.updatePhraseSet(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2092,7 +2032,6 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech Adaptation API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationGrpc.AdaptationBlockingStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,7 +161,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,7 +202,6 @@
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,7 +241,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,7 +280,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,7 +319,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +358,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,7 +397,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,7 +436,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,7 +475,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +514,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech Adaptation API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationGrpc.AdaptationFutureStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,7 +161,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,7 +202,6 @@
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,7 +241,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,7 +280,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,7 +319,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +358,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,7 +397,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,7 +436,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,7 +475,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +514,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech Adaptation API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -70,8 +69,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationImplBase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_bindService_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.bindService*"></a>
@@ -79,8 +76,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ServerServiceDefinition bindService()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,7 +98,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,7 +129,6 @@
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +158,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -195,7 +187,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,7 +216,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,7 +245,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,7 +274,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +303,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -345,7 +332,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,7 +361,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech Adaptation API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationGrpc.AdaptationStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,7 +161,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +192,6 @@
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -226,7 +221,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,7 +250,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,7 +279,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,7 +308,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,7 +366,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,7 +395,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,7 +424,6 @@
   </div>
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech Adaptation API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +64,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final String SERVICE_NAME</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,8 +86,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;CreateCustomClassRequest,CustomClass&gt; getCreateCustomClassMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;CreatePhraseSetRequest,PhraseSet&gt; getCreatePhraseSetMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,8 +126,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;DeleteCustomClassRequest,Empty&gt; getDeleteCustomClassMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,8 +146,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;DeletePhraseSetRequest,Empty&gt; getDeletePhraseSetMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,8 +166,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;GetCustomClassRequest,CustomClass&gt; getGetCustomClassMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,8 +186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;GetPhraseSetRequest,PhraseSet&gt; getGetPhraseSetMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -221,8 +206,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;ListCustomClassesRequest,ListCustomClassesResponse&gt; getListCustomClassesMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,8 +226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;ListPhraseSetRequest,ListPhraseSetResponse&gt; getListPhraseSetMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -265,8 +246,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServiceDescriptor getServiceDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;UpdateCustomClassRequest,CustomClass&gt; getUpdateCustomClassMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,8 +286,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;UpdatePhraseSetRequest,PhraseSet&gt; getUpdatePhraseSetMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -333,7 +308,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,7 +347,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +386,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for AdaptationSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -139,15 +138,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,8 +165,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(AdaptationSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,8 +187,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(AdaptationStubSettings.Builder stubSettings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,7 +214,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,7 +305,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,7 +327,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +349,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deleteCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +371,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deletePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,7 +393,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +415,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +435,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStubSettings.Builder getStubSettingsBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +457,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listCustomClasses.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,7 +479,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,7 +501,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updateCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,7 +523,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updatePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
@@ -32,7 +32,6 @@
              .build());
  AdaptationSettings adaptationSettings = adaptationSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationSettings(AdaptationSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final AdaptationSettings create(AdaptationStubSettings stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -204,7 +199,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -227,7 +221,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,8 +241,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,7 +263,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,7 +307,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +349,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deleteCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +371,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deletePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,7 +393,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +415,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +437,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,7 +459,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,7 +481,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listCustomClasses.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,7 +503,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +525,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,7 +547,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,7 +586,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +610,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updateCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,7 +632,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updatePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `CreateCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CreateCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,7 +338,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +364,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,8 +385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +424,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,7 +468,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,7 +514,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,7 +538,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +564,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,7 +591,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -637,7 +615,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,8 +675,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,7 +702,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -758,7 +728,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,7 +752,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,8 +773,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +795,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -856,7 +820,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder mergeFrom(CreateCustomClassRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1035,8 +992,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CreateCustomClassRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,7 +1034,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,7 +1074,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1164,7 +1117,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,7 +1162,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1250,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1301,7 +1250,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,7 +1294,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,8 +1382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CreateCustomClassRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `CreateCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CreateCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASS_ID_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PARENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -384,7 +375,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +402,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,7 +429,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -465,7 +453,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,8 +473,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,8 +513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,7 +538,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +564,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,8 +585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;CreateCustomClassRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,8 +607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,8 +629,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,7 +654,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,8 +675,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +697,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest.Builder newBuilder(CreateCustomClassRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,8 +818,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected CreateCustomClassRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,8 +857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +896,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +948,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,8 +1005,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1057,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,8 +1114,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1166,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1332,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1441,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1559,8 +1493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreateCustomClassRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1618,8 +1550,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;CreateCustomClassRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1640,8 +1570,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1662,8 +1590,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -59,7 +56,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +83,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,7 +107,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +132,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +158,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -190,7 +182,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `CreatePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CreatePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -431,7 +418,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,7 +468,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +511,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +578,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,7 +604,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,7 +628,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,7 +652,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,7 +678,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -734,7 +705,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,7 +729,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,7 +752,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,8 +773,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +795,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,8 +817,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder mergeFrom(CreatePhraseSetRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -892,8 +854,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,8 +913,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -997,7 +955,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1035,8 +992,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CreatePhraseSetRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,8 +1031,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1127,7 +1080,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,7 +1124,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1215,7 +1166,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,7 +1206,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1300,7 +1249,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,7 +1294,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,8 +1382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CreatePhraseSetRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `CreatePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CreatePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PARENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SET_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SET_ID_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,8 +372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,8 +392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -425,8 +412,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -452,7 +437,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +463,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;CreatePhraseSetRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +509,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,7 +536,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +563,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,7 +587,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,8 +607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,8 +629,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,7 +654,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,8 +675,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +697,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest.Builder newBuilder(CreatePhraseSetRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,8 +818,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected CreatePhraseSetRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,8 +857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +896,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +948,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,8 +1005,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1057,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,8 +1114,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1166,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1332,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1441,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1559,8 +1493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CreatePhraseSetRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1618,8 +1550,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;CreatePhraseSetRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1640,8 +1570,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1662,8 +1590,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,7 +108,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +159,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -190,7 +182,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
@@ -16,7 +16,6 @@
  can be substituted into placeholders that you set in PhraseSet phrases.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CustomClass</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -235,7 +234,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,7 +274,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,7 +314,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,7 +354,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,7 +399,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -450,7 +444,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -474,7 +467,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,8 +504,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,8 +548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,8 +568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,8 +588,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,7 +614,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +677,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,7 +700,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,8 +721,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,8 +760,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,7 +786,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -837,7 +811,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,8 +832,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +852,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,8 +872,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -930,7 +897,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -971,7 +937,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1012,7 +977,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1036,7 +1000,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,7 +1023,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,7 +1046,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1125,7 +1086,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1149,7 +1109,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1174,7 +1133,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1196,8 +1154,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1176,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1244,8 +1198,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder mergeFrom(CustomClass other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1283,8 +1235,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1385,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1429,7 +1375,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1471,7 +1416,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1515,7 +1459,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1555,8 +1498,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1604,7 +1545,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1650,7 +1590,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1696,7 +1635,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1739,7 +1677,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1779,8 +1716,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1830,8 +1765,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>An item of the class.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CustomClass.ClassItem</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,7 +416,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,8 +437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,8 +479,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,8 +499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,7 +524,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -571,7 +548,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,8 +569,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,8 +591,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,8 +613,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder mergeFrom(CustomClass.ClassItem other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,8 +650,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,8 +709,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,8 +748,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass.ClassItem.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,8 +787,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,8 +880,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass.ClassItem.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,7 +922,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,7 +964,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>An item of the class.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CustomClass.ClassItem</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int VALUE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,8 +394,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;CustomClass.ClassItem&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,8 +416,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +438,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,7 +463,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,7 +487,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +508,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +530,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,8 +552,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +574,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem.Builder newBuilder(CustomClass.ClassItem prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,8 +631,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -682,8 +651,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected CustomClass.ClassItem.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,8 +690,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +729,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,8 +781,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -877,8 +838,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,8 +890,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,8 +947,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +999,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1103,8 +1056,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,8 +1108,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1216,8 +1165,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1217,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1329,8 +1274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1383,8 +1326,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.ClassItem parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1442,8 +1383,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;CustomClass.ClassItem&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1464,8 +1403,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1486,8 +1423,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
@@ -16,7 +16,6 @@
  can be substituted into placeholders that you set in PhraseSet phrases.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.CustomClass</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASS_ID_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ITEMS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,7 +378,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +403,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,8 +424,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,8 +444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,8 +464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +487,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -545,7 +527,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,7 +550,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +573,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,7 +613,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,7 +636,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,7 +660,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +681,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;CustomClass&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -729,8 +703,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,8 +725,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,8 +747,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +769,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,8 +791,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -849,8 +813,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -871,8 +833,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass.Builder newBuilder(CustomClass prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,8 +870,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,8 +890,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected CustomClass.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -973,8 +929,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1068,8 +1020,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1127,8 +1077,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1181,8 +1129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1240,8 +1186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,8 +1238,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1353,8 +1295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1407,8 +1347,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1466,8 +1404,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1520,8 +1456,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1579,8 +1513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1633,8 +1565,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClass parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1692,8 +1622,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;CustomClass&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1714,8 +1642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1736,8 +1662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for projects/{project}/locations/{location}/customClasses/{custom_class}.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -66,8 +65,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_CustomClassName_Builder_build_" data-uid="com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.build*"></a>
@@ -75,8 +72,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassName build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,8 +92,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClass()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,8 +132,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,8 +152,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassName.Builder setCustomClass(String customClass)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,8 +189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassName.Builder setLocation(String location)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,8 +226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassName.Builder setProject(String project)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -69,8 +67,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected CustomClassName()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_CustomClassName_equals_" data-uid="com.google.cloud.speech.v1p1beta1.CustomClassName.equals*"></a>
@@ -78,8 +74,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object o)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +113,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String format(String project, String location, String customClass)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,8 +160,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClass()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -190,8 +180,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getFieldValue(String fieldName)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,8 +217,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Map&lt;String,String&gt; getFieldValuesMap()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,8 +237,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,8 +257,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static boolean isParsableFrom(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,8 +336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClassName.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClassName of(String project, String location, String customClass)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,8 +403,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static CustomClassName parse(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,8 +440,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;CustomClassName&gt; parseList(List&lt;String&gt; formattedStrings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +477,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassName.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +497,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String toString()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,8 +519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; toStringList(List&lt;CustomClassName&gt; values)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -83,7 +79,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,7 +142,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +165,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -213,7 +205,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -237,7 +228,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +252,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `DeleteCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.DeleteCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +400,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +439,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -499,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,8 +501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +528,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +554,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder mergeFrom(DeleteCustomClassRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,8 +715,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final DeleteCustomClassRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +793,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +842,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +886,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,8 +925,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +974,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final DeleteCustomClassRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `DeleteCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.DeleteCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +399,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +425,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +446,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;DeleteCustomClassRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +512,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,8 +598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest.Builder newBuilder(DeleteCustomClassRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected DeleteCustomClassRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1048,8 +1003,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,8 +1112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1221,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeleteCustomClassRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;DeleteCustomClassRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,8 +1427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `DeletePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.DeletePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +400,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +439,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -499,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,8 +501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +528,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +554,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder mergeFrom(DeletePhraseSetRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,8 +715,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final DeletePhraseSetRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +793,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +842,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +886,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,8 +925,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +974,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final DeletePhraseSetRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `DeletePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.DeletePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +399,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +425,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +446,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;DeletePhraseSetRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +512,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,8 +598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest.Builder newBuilder(DeletePhraseSetRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected DeletePhraseSetRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1048,8 +1003,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,8 +1112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1221,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static DeletePhraseSetRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;DeletePhraseSetRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,8 +1427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `GetCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.GetCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +400,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +439,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -499,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,8 +501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +528,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +554,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder mergeFrom(GetCustomClassRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,8 +715,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final GetCustomClassRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +793,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +842,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +886,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,8 +925,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +974,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final GetCustomClassRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `GetCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.GetCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +399,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +425,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +446,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;GetCustomClassRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +512,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,8 +598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest.Builder newBuilder(GetCustomClassRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GetCustomClassRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1048,8 +1003,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,8 +1112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1221,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetCustomClassRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;GetCustomClassRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,8 +1427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `GetPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.GetPhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +400,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,8 +439,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -499,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,8 +501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +528,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +554,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder mergeFrom(GetPhraseSetRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,8 +715,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final GetPhraseSetRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +793,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +842,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +886,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,8 +925,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +974,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final GetPhraseSetRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `GetPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.GetPhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +399,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +425,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +446,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;GetPhraseSetRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +512,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,8 +598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest.Builder newBuilder(GetPhraseSetRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GetPhraseSetRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,8 +894,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1048,8 +1003,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,8 +1112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1221,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GetPhraseSetRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;GetPhraseSetRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1468,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,8 +1427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `ListCustomClasses` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListCustomClassesRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +419,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,7 +446,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,7 +472,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,8 +515,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +535,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,7 +583,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +610,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,7 +637,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,7 +663,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +689,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,8 +710,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,8 +732,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder mergeFrom(ListCustomClassesRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,8 +791,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -887,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -928,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListCustomClassesRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -969,8 +928,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,7 +978,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,7 +1023,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1113,7 +1068,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,7 +1112,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1203,7 +1156,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1243,8 +1195,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,8 +1244,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListCustomClassesRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `ListCustomClasses` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListCustomClassesRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PAGE_SIZE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PAGE_TOKEN_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PARENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,8 +372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,8 +392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -425,8 +412,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,7 +438,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,7 +465,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,7 +492,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,7 +518,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +544,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +565,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;ListCustomClassesRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +587,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +609,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,8 +631,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,8 +653,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +675,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -729,8 +697,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,8 +717,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest.Builder newBuilder(ListCustomClassesRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -812,8 +774,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected ListCustomClassesRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,8 +813,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +852,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,8 +904,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,8 +961,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,8 +1013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,8 +1070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1174,8 +1122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1233,8 +1179,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1287,8 +1231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,8 +1288,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1400,8 +1340,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1459,8 +1397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1572,8 +1506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;ListCustomClassesRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1594,8 +1526,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1616,8 +1546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +86,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +112,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,7 +138,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message returned to the client by the `ListCustomClasses` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListCustomClassesResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -233,7 +232,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,7 +272,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +312,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -356,7 +352,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,7 +397,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -448,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,7 +465,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,8 +502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +566,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +586,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,7 +611,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,8 +631,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,7 +674,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,8 +695,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,8 +734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,7 +759,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,7 +799,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -865,7 +839,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,7 +862,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -913,7 +885,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,7 +908,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -978,7 +948,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,8 +988,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1043,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1071,7 +1034,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1097,7 +1059,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1119,8 +1080,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1143,8 +1102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1124,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder mergeFrom(ListCustomClassesResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1161,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1267,8 +1220,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1308,8 +1259,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListCustomClassesResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1352,7 +1301,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1393,7 +1341,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1439,7 +1386,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1482,8 +1428,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1532,7 +1476,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1576,7 +1519,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1616,8 +1558,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1667,8 +1607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListCustomClassesResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message returned to the client by the `ListCustomClasses` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListCustomClassesResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASSES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,7 +396,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -428,7 +419,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -452,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,7 +482,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,8 +502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,8 +522,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,8 +542,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,7 +566,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,7 +591,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,8 +612,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;ListCustomClassesResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,8 +634,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -704,8 +678,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,8 +700,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,8 +722,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,8 +744,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -798,8 +764,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse.Builder newBuilder(ListCustomClassesResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -837,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected ListCustomClassesResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -900,8 +860,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,8 +899,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1280,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1334,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1393,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1447,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1560,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListCustomClassesResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1619,8 +1553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;ListCustomClassesResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1641,8 +1573,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1663,8 +1593,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,7 +69,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,7 +92,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,7 +115,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,7 +155,6 @@
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -186,7 +179,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,7 +204,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `ListPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListPhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +419,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,7 +446,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,7 +472,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,8 +515,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,8 +535,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,7 +583,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +610,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,7 +637,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,7 +663,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,7 +689,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,8 +710,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,8 +732,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder mergeFrom(ListPhraseSetRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,8 +791,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -887,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -928,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListPhraseSetRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -969,8 +928,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,7 +978,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,7 +1023,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1113,7 +1068,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,7 +1112,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1203,7 +1156,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1243,8 +1195,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,8 +1244,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListPhraseSetRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `ListPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListPhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PAGE_SIZE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PAGE_TOKEN_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PARENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,8 +372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,8 +392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -425,8 +412,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,7 +438,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,7 +465,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,7 +492,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,7 +518,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +544,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +565,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;ListPhraseSetRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +587,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +609,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,8 +631,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,8 +653,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +675,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -729,8 +697,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,8 +717,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest.Builder newBuilder(ListPhraseSetRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -812,8 +774,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected ListPhraseSetRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,8 +813,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +852,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,8 +904,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,8 +961,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,8 +1013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,8 +1070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1174,8 +1122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1233,8 +1179,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1287,8 +1231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,8 +1288,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1400,8 +1340,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1459,8 +1397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1572,8 +1506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;ListPhraseSetRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1594,8 +1526,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1616,8 +1546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +86,6 @@
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -117,7 +112,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,7 +138,6 @@
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message returned to the client by the `ListPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListPhraseSetResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -233,7 +232,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,7 +272,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +312,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -356,7 +352,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,7 +397,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -448,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,7 +465,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,8 +502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +566,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +586,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,8 +608,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,7 +651,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,8 +672,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -735,7 +714,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,8 +734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -780,8 +756,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -802,8 +776,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,8 +796,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -852,7 +822,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,7 +847,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,7 +871,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,7 +911,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -985,7 +951,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1009,7 +974,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1033,7 +997,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,7 +1020,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1098,7 +1060,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1119,8 +1080,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1143,8 +1102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1124,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder mergeFrom(ListPhraseSetResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1161,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1267,8 +1220,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1308,8 +1259,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListPhraseSetResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1352,7 +1301,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1390,8 +1338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1440,7 +1386,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1484,7 +1429,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1527,7 +1471,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1573,7 +1516,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1616,8 +1558,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1667,8 +1607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ListPhraseSetResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message returned to the client by the `ListPhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.ListPhraseSetResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NEXT_PAGE_TOKEN_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SETS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,8 +353,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -382,8 +373,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -430,7 +417,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +463,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;ListPhraseSetResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,7 +488,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,7 +528,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,7 +551,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,7 +574,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,7 +614,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,8 +634,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -704,8 +678,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,8 +700,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,8 +722,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,8 +744,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -798,8 +764,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse.Builder newBuilder(ListPhraseSetResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -837,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected ListPhraseSetResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -900,8 +860,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,8 +899,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,8 +951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,8 +1060,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,8 +1169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1280,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1334,8 +1278,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1393,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1447,8 +1387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1560,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ListPhraseSetResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1619,8 +1553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;ListPhraseSetResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1641,8 +1573,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1663,8 +1593,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -83,7 +79,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,7 +142,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +165,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -213,7 +205,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for projects/{project}/locations/{location}.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -66,8 +65,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_LocationName_Builder_build_" data-uid="com.google.cloud.speech.v1p1beta1.LocationName.Builder.build*"></a>
@@ -75,8 +72,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LocationName build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,8 +92,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,8 +132,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LocationName.Builder setLocation(String location)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,8 +169,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LocationName.Builder setProject(String project)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -69,8 +67,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LocationName()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_LocationName_equals_" data-uid="com.google.cloud.speech.v1p1beta1.LocationName.equals*"></a>
@@ -78,8 +74,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object o)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +113,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String format(String project, String location)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,8 +155,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getFieldValue(String fieldName)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,8 +192,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Map&lt;String,String&gt; getFieldValuesMap()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -224,8 +212,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,8 +232,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -268,8 +252,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -292,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static boolean isParsableFrom(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LocationName.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LocationName of(String project, String location)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,8 +373,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LocationName parse(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +410,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;LocationName&gt; parseList(List&lt;String&gt; formattedStrings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LocationName.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,8 +467,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String toString()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; toStringList(List&lt;LocationName&gt; values)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -232,8 +231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -278,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,8 +337,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,8 +399,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,7 +466,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,7 +490,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,8 +511,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,8 +533,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,8 +553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -596,8 +573,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,7 +598,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +622,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -672,7 +645,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,7 +669,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,7 +693,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,7 +717,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -771,7 +740,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -796,7 +764,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,7 +789,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -847,7 +813,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -872,7 +837,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,8 +880,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,8 +902,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(LongRunningRecognizeMetadata other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -981,8 +939,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1086,7 +1040,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1127,7 +1080,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1165,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeMetadata.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1156,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,7 +1203,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1296,7 +1243,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,7 +1284,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1378,8 +1323,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1432,7 +1375,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1473,7 +1415,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,8 +1452,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeMetadata.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1556,7 +1495,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1600,7 +1538,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
@@ -16,7 +16,6 @@
  `GetOperation` call of the `google::longrunning::Operations` service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LAST_UPDATE_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROGRESS_PERCENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int START_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,8 +332,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int URI_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +354,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,8 +413,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -448,8 +433,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -473,7 +456,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,7 +480,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,8 +500,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeMetadata&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +526,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,8 +547,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -596,7 +572,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,7 +596,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -642,8 +616,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,7 +642,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +667,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,7 +691,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -746,7 +715,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +736,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -792,8 +758,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,8 +780,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -840,8 +802,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,8 +822,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata.Builder newBuilder(LongRunningRecognizeMetadata prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,8 +859,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -923,8 +879,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeMetadata.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,8 +918,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +957,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1059,8 +1009,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,8 +1118,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,8 +1175,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1285,8 +1227,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1284,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1398,8 +1336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,8 +1393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,8 +1445,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1570,8 +1502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1624,8 +1554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeMetadata parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1683,8 +1611,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeMetadata&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1705,8 +1631,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1727,8 +1651,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,7 +101,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -156,7 +149,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -182,7 +174,6 @@
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,7 +198,6 @@
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,7 +222,6 @@
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
@@ -15,7 +15,6 @@
  method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +339,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,7 +363,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,8 +383,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,8 +461,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,7 +486,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +510,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,7 +533,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +557,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,7 +582,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -628,7 +606,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,8 +626,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -671,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,8 +666,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,7 +691,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -746,7 +716,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,8 +737,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -792,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -819,7 +784,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,7 +825,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -899,8 +862,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(LongRunningRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -938,8 +899,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +958,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,8 +997,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,7 +1039,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1125,7 +1079,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,7 +1120,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1209,7 +1161,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,8 +1198,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1293,8 +1242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1291,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
@@ -15,7 +15,6 @@
  method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,7 +357,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,7 +381,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,7 +405,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,7 +430,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,8 +450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +532,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +579,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -628,7 +604,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,8 +625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +647,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,8 +669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -744,8 +711,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest.Builder newBuilder(LongRunningRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,8 +748,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,8 +768,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,8 +807,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -887,8 +846,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,8 +898,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1000,8 +955,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,8 +1007,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1113,8 +1064,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,8 +1116,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,8 +1173,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1280,8 +1225,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,8 +1282,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1393,8 +1334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1452,8 +1391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,8 +1443,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1565,8 +1500,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1587,8 +1520,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,8 +1540,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,7 +102,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +150,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
@@ -18,7 +18,6 @@
  service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -238,7 +237,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,7 +322,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +363,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +404,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +450,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +496,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +520,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -567,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -589,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -676,8 +658,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,7 +701,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,8 +721,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,8 +743,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +763,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +783,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,7 +809,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,7 +850,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,7 +891,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -947,7 +915,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,7 +939,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -997,7 +963,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,7 +1004,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,8 +1024,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,8 +1046,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,8 +1068,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(LongRunningRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,8 +1105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,8 +1164,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1249,8 +1203,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,7 +1246,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1332,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1378,8 +1327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1433,7 +1380,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,7 +1426,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1523,8 +1468,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final LongRunningRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
@@ -18,7 +18,6 @@
  service.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -278,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,8 +299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,8 +338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,8 +358,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,8 +378,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,8 +398,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;LongRunningRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,7 +424,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +465,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,7 +489,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +513,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -571,7 +554,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,8 +574,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,8 +596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -640,8 +618,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,8 +662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -734,8 +704,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse.Builder newBuilder(LongRunningRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -773,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected LongRunningRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +800,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -877,8 +839,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,8 +891,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,8 +948,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +1000,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1103,8 +1057,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,8 +1109,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1216,8 +1166,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1218,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1329,8 +1275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1383,8 +1327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1442,8 +1384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1496,8 +1436,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static LongRunningRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1555,8 +1493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;LongRunningRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1577,8 +1513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1599,8 +1533,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.PhraseSet</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -234,7 +233,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,7 +273,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,7 +313,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -357,7 +353,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,7 +398,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,7 +443,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -473,7 +466,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -511,8 +503,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,8 +547,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +567,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,8 +587,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -636,7 +620,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,8 +641,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,7 +683,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -724,8 +704,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,7 +746,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,8 +766,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,7 +799,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,8 +820,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -868,8 +840,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,8 +860,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -917,7 +885,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,7 +909,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -967,7 +933,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1008,7 +973,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,7 +1013,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1073,7 +1036,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1097,7 +1059,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,7 +1082,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1162,7 +1122,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1183,8 +1142,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,8 +1164,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,8 +1186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder mergeFrom(PhraseSet other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1270,8 +1223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1331,8 +1282,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1372,8 +1321,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1416,7 +1363,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1465,7 +1411,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1554,7 +1497,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1597,7 +1539,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1640,7 +1581,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1686,7 +1626,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1729,8 +1668,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1780,8 +1717,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
@@ -31,7 +31,6 @@
  id wrapped in `${}` (e.g. `${my-months}`).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.PhraseSet.Phrase</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -247,8 +246,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,8 +290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,8 +310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,7 +364,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,8 +385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +424,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,7 +466,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +487,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,7 +521,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,8 +542,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,8 +562,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -604,8 +582,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,7 +607,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,7 +631,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +696,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder mergeFrom(PhraseSet.Phrase other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,8 +792,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -867,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet.Phrase.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,7 +882,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,8 +921,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1006,8 +965,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,8 +1014,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet.Phrase.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,7 +1056,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1144,7 +1098,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
@@ -31,7 +31,6 @@
  id wrapped in `${}` (e.g. `${my-months}`).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.PhraseSet.Phrase</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -291,8 +290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int BOOST_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -312,8 +309,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int VALUE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -336,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,7 +382,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,8 +403,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,8 +423,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,8 +443,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +463,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;PhraseSet.Phrase&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,8 +485,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,8 +507,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,7 +532,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,7 +556,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,8 +599,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,8 +621,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -671,8 +643,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase.Builder newBuilder(PhraseSet.Phrase prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,8 +700,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,8 +720,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected PhraseSet.Phrase.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,8 +850,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -949,8 +907,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1003,8 +959,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,8 +1016,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1116,8 +1068,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1175,8 +1125,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1229,8 +1177,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,8 +1234,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1342,8 +1286,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1401,8 +1343,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1455,8 +1395,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Phrase parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1514,8 +1452,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;PhraseSet.Phrase&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1536,8 +1472,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1558,8 +1492,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -40,7 +38,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -65,7 +62,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,7 +86,6 @@
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.PhraseSet</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int BOOST_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,7 +384,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,8 +405,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +425,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +445,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,7 +468,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,7 +492,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +513,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;PhraseSet&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,7 +538,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,7 +578,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,7 +601,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,7 +624,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,7 +664,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -733,8 +706,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -757,8 +728,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,8 +750,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,8 +772,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -829,8 +794,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -851,8 +814,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet.Builder newBuilder(PhraseSet prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -912,8 +871,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected PhraseSet.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,8 +910,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -994,8 +949,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1048,8 +1001,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,8 +1058,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,8 +1110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1274,8 +1219,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1333,8 +1276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1387,8 +1328,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1446,8 +1385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1500,8 +1437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1559,8 +1494,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1613,8 +1546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSet parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1672,8 +1603,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;PhraseSet&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1694,8 +1623,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1716,8 +1643,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for projects/{project}/locations/{location}/phraseSets/{phrase_set}.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -66,8 +65,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_PhraseSetName_Builder_build_" data-uid="com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.build*"></a>
@@ -75,8 +72,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetName build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,8 +92,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +112,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSet()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,8 +132,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,8 +152,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetName.Builder setLocation(String location)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,8 +189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetName.Builder setPhraseSet(String phraseSet)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,8 +226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetName.Builder setProject(String project)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -69,8 +67,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected PhraseSetName()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_PhraseSetName_equals_" data-uid="com.google.cloud.speech.v1p1beta1.PhraseSetName.equals*"></a>
@@ -78,8 +74,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object o)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,8 +113,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String format(String project, String location, String phraseSet)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,8 +160,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getFieldValue(String fieldName)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,8 +197,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Map&lt;String,String&gt; getFieldValuesMap()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,8 +217,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLocation()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,8 +237,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSet()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,8 +257,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getProject()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static boolean isParsableFrom(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,8 +336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSetName.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSetName of(String project, String location, String phraseSet)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,8 +403,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static PhraseSetName parse(String formattedString)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,8 +440,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;PhraseSetName&gt; parseList(List&lt;String&gt; formattedStrings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +477,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetName.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +497,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String toString()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,8 +519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; toStringList(List&lt;PhraseSetName&gt; values)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -39,7 +37,6 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,7 +61,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +109,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,7 +149,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,7 +172,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -203,7 +195,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -244,7 +235,6 @@
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span>,</span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
@@ -17,7 +17,6 @@
  See [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -233,8 +232,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -279,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +316,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,8 +338,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearAudioSource()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +363,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,8 +384,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +423,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,7 +472,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,8 +515,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -561,7 +540,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -583,8 +561,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,8 +581,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,8 +601,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -661,7 +633,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,7 +664,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,7 +690,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,7 +721,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,8 +742,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -798,8 +764,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +786,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(RecognitionAudio other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,8 +823,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,8 +882,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,8 +921,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1009,7 +965,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,8 +1004,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1095,8 +1048,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1146,8 +1097,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionAudio.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1197,7 +1146,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,7 +1195,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
@@ -17,7 +17,6 @@
  See [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionAudio</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -277,8 +276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +295,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int URI_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +381,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionAudio&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,8 +506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,7 +538,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,7 +569,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +595,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -651,7 +626,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,8 +647,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,8 +669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,8 +713,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,8 +733,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio.Builder newBuilder(RecognitionAudio prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -806,8 +770,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,8 +790,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionAudio.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,8 +829,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,8 +868,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,8 +920,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,8 +977,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,8 +1029,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1136,8 +1086,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1190,8 +1138,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1249,8 +1195,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1303,8 +1247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1362,8 +1304,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1416,8 +1356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1475,8 +1413,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1529,8 +1465,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionAudio parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1588,8 +1522,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionAudio&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1610,8 +1542,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1632,8 +1562,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -28,8 +26,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio.AudioSourceCase getAudioSourceCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,7 +51,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +82,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +113,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,7 +139,6 @@
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -178,7 +170,6 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
@@ -33,7 +33,6 @@
  code.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -245,7 +244,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -292,7 +290,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,7 +341,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -398,7 +394,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,8 +433,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -491,7 +484,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,7 +528,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,7 +572,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,7 +621,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,7 +670,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,7 +697,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,8 +734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,8 +754,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,8 +774,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,7 +803,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,7 +837,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,7 +869,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,7 +900,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,7 +925,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,7 +952,6 @@
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1006,7 +981,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,7 +1008,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,7 +1034,6 @@
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1089,7 +1061,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1117,7 +1088,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1139,8 +1109,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1188,7 +1156,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1218,7 +1185,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1243,7 +1209,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1298,7 +1263,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1320,8 +1284,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1367,7 +1329,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1399,7 +1360,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1428,7 +1388,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1458,7 +1417,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,8 +1438,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,7 +1467,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1540,7 +1495,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1568,7 +1522,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1603,7 +1556,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1657,7 +1609,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1711,7 +1662,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1747,7 +1697,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1780,7 +1729,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1802,8 +1750,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1824,8 +1770,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1846,8 +1790,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1880,7 +1822,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1912,7 +1853,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1943,7 +1883,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1969,7 +1908,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1997,7 +1935,6 @@
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2027,7 +1964,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2055,7 +1991,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2082,7 +2017,6 @@
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2110,7 +2044,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2138,7 +2071,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2166,7 +2098,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2196,7 +2127,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2226,7 +2156,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2256,7 +2185,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2281,7 +2209,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2306,7 +2233,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2330,7 +2256,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2385,7 +2310,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2441,7 +2365,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2469,7 +2392,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2501,7 +2423,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2530,7 +2451,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2575,7 +2495,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2620,7 +2539,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2648,7 +2566,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2676,7 +2593,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2704,7 +2620,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2749,7 +2664,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2779,7 +2693,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2808,7 +2721,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2840,7 +2752,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2865,7 +2776,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2887,8 +2797,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2911,8 +2819,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2942,7 +2848,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2990,7 +2895,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3028,8 +2932,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(RecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3067,8 +2969,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3128,8 +3028,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3172,7 +3070,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3210,8 +3107,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3258,7 +3153,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3303,7 +3197,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3348,7 +3241,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3400,7 +3292,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3457,7 +3348,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3507,7 +3397,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3555,7 +3444,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3598,7 +3486,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3644,7 +3531,6 @@
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3692,7 +3578,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3738,7 +3623,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3783,7 +3667,6 @@
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3829,7 +3712,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3875,7 +3757,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3921,7 +3802,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3961,8 +3841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4015,7 +3893,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4063,7 +3940,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4111,7 +3987,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4154,7 +4029,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4195,7 +4069,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4267,7 +4140,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4341,7 +4213,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4387,7 +4258,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4427,8 +4297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4488,7 +4356,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4535,7 +4402,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4585,7 +4451,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4628,8 +4493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4678,7 +4541,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ADAPTATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVE_LANGUAGE_CODES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_CHANNEL_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int DIARIZATION_CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int DIARIZATION_SPEAKER_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_AUTOMATIC_PUNCTUATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -401,8 +388,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_SEPARATE_RECOGNITION_PER_CHANNEL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -422,8 +407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_SPEAKER_DIARIZATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -443,8 +426,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_WORD_CONFIDENCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,8 +445,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_WORD_TIME_OFFSETS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,8 +464,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENCODING_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,8 +483,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +502,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MAX_ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,8 +521,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int METADATA_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,8 +540,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MODEL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,8 +559,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PROFANITY_FILTER_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,8 +578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SAMPLE_RATE_HERTZ_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEECH_CONTEXTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,8 +616,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int USE_ENHANCED_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -677,8 +638,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,7 +684,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,7 +712,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,7 +746,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -843,7 +799,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,7 +852,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,7 +887,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,7 +919,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,8 +940,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,8 +960,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1032,8 +980,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1064,7 +1010,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1096,7 +1041,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,7 +1066,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1150,7 +1093,6 @@
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1180,7 +1122,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,7 +1149,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1235,7 +1175,6 @@
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1263,7 +1202,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1291,7 +1229,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1319,7 +1256,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1349,7 +1285,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1379,7 +1314,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1409,7 +1343,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1434,7 +1367,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1459,7 +1391,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1514,7 +1445,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1570,7 +1500,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1592,8 +1521,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1622,7 +1549,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1654,7 +1580,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1676,8 +1601,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1707,7 +1630,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1752,7 +1674,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1780,7 +1701,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1808,7 +1728,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1853,7 +1772,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1874,8 +1792,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1907,7 +1823,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1936,7 +1851,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1968,7 +1882,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1993,7 +1906,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2015,8 +1927,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2039,8 +1949,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2063,8 +1971,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2087,8 +1993,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2109,8 +2013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig.Builder newBuilder(RecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2148,8 +2050,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2170,8 +2070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2211,8 +2109,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2252,8 +2148,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2306,8 +2200,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2365,8 +2257,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2419,8 +2309,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2478,8 +2366,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2532,8 +2418,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2591,8 +2475,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2645,8 +2527,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2704,8 +2584,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2758,8 +2636,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2817,8 +2693,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2871,8 +2745,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2930,8 +2802,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2952,8 +2822,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2974,8 +2842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -35,7 +33,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -64,7 +61,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,7 +148,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,7 +201,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,7 +236,6 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,7 +268,6 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -308,7 +299,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,7 +330,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +355,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,7 +382,6 @@
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,7 +411,6 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -452,7 +438,6 @@
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +464,6 @@
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,7 +491,6 @@
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -535,7 +518,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +545,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +574,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,7 +603,6 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,7 +632,6 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,7 +656,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,7 +680,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -758,7 +734,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -814,7 +789,6 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,7 +816,6 @@
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,7 +847,6 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,7 +875,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,7 +919,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,7 +946,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1004,7 +973,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,7 +1017,6 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,7 +1046,6 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,7 +1074,6 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,7 +1105,6 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1165,7 +1129,6 @@
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Description of audio data to be recognized.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +339,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +360,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -442,7 +429,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +453,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,7 +478,6 @@
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,8 +499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,7 +541,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,7 +568,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,7 +594,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,7 +618,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -661,8 +639,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,7 +665,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,7 +690,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,8 +711,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,8 +731,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,8 +751,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,7 +779,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,7 +803,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,7 +827,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,7 +851,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -911,7 +875,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,7 +900,6 @@
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -962,7 +924,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -987,7 +948,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1015,7 +975,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1043,7 +1002,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1070,7 +1028,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1097,7 +1054,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,7 +1078,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1147,7 +1102,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1169,8 +1123,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1193,8 +1145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1217,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(RecognitionMetadata other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,8 +1204,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1317,8 +1263,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1358,8 +1302,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionMetadata.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1403,7 +1345,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1447,7 +1388,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1487,8 +1427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1539,7 +1477,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1582,7 +1519,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1625,7 +1561,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1668,7 +1603,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1711,7 +1645,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1755,7 +1688,6 @@
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1798,7 +1730,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1841,7 +1772,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1887,7 +1817,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1933,7 +1862,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1978,7 +1906,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2023,7 +1950,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2066,7 +1992,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2109,7 +2034,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2149,8 +2073,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2200,8 +2122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognitionMetadata.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
@@ -15,7 +15,6 @@
  by.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Enumerates the types of capture settings describing an audio file.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Description of audio data to be recognized.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognitionMetadata</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_TOPIC_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INDUSTRY_NAICS_CODE_OF_AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INTERACTION_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MICROPHONE_DISTANCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,8 +349,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int OBFUSCATED_ID_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +368,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ORIGINAL_MEDIA_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,8 +387,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ORIGINAL_MIME_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,8 +406,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RECORDING_DEVICE_NAME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -442,8 +425,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RECORDING_DEVICE_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -511,7 +490,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -537,7 +515,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,8 +536,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +576,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,7 +602,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,7 +626,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,7 +650,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,7 +674,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,7 +698,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -757,7 +723,6 @@
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,7 +747,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -807,7 +771,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,7 +798,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,7 +825,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -885,8 +846,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognitionMetadata&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -914,7 +873,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,7 +899,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,7 +923,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -991,7 +947,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1013,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,8 +990,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1061,8 +1012,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1085,8 +1034,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,8 +1056,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1133,8 +1078,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,8 +1098,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata.Builder newBuilder(RecognitionMetadata prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1194,8 +1135,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1216,8 +1155,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognitionMetadata.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1257,8 +1194,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1298,8 +1233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1352,8 +1285,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1411,8 +1342,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1465,8 +1394,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1524,8 +1451,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1578,8 +1503,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1637,8 +1560,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1691,8 +1612,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1750,8 +1669,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1804,8 +1721,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1863,8 +1778,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1917,8 +1830,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognitionMetadata parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1976,8 +1887,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognitionMetadata&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1998,8 +1907,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2020,8 +1927,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,7 +82,6 @@
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,7 +130,6 @@
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,7 +154,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -186,7 +178,6 @@
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,7 +203,6 @@
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -237,7 +227,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +251,6 @@
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -290,7 +278,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,7 +305,6 @@
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -345,7 +331,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,7 +357,6 @@
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,7 +381,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -422,7 +405,6 @@
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `Recognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -347,7 +338,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,7 +362,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,8 +382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +421,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +485,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +509,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,7 +532,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,7 +556,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +581,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,7 +605,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,8 +625,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +645,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,8 +665,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,7 +690,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +715,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,8 +736,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,8 +758,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,7 +783,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,7 +824,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -898,8 +861,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(RecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +898,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,8 +957,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1039,8 +996,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,7 +1038,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1124,7 +1078,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,7 +1119,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,7 +1160,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1246,8 +1197,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,8 +1241,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1343,8 +1290,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>The top-level message sent by the client for the `Recognize` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +356,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,7 +380,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +404,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,7 +429,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,8 +449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,8 +469,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,8 +489,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,8 +509,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,8 +553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,7 +578,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,7 +603,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,8 +624,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,8 +646,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,8 +668,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,8 +690,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -743,8 +710,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest.Builder newBuilder(RecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,8 +747,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,8 +767,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -845,8 +806,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,8 +845,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +897,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,8 +954,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,8 +1006,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,8 +1063,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1166,8 +1115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1225,8 +1172,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1451,8 +1390,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1564,8 +1499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1586,8 +1519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1608,8 +1539,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -31,7 +29,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,7 +53,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,7 +77,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,7 +102,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,7 +125,6 @@
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +150,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -274,8 +272,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +320,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +361,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +402,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +448,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +494,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +518,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,8 +555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -587,8 +575,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +595,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,8 +617,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,8 +656,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,7 +699,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +741,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,8 +781,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,7 +807,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,7 +848,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,7 +889,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,7 +913,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,7 +937,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,7 +961,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,7 +1002,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1058,8 +1022,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1082,8 +1044,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1106,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(RecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1145,8 +1103,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,8 +1162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1247,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,7 +1244,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1330,8 +1281,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1376,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,7 +1378,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1478,7 +1424,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1521,8 +1466,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
@@ -16,7 +16,6 @@
  messages.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.RecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -276,8 +275,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +336,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,8 +356,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +376,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,8 +396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;RecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +422,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,7 +463,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +487,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +511,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,7 +552,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,8 +572,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,8 +616,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,8 +638,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,8 +660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,8 +702,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse.Builder newBuilder(RecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -771,8 +739,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,8 +759,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected RecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -834,8 +798,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -875,8 +837,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -929,8 +889,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,8 +946,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,8 +998,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1055,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,8 +1107,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,8 +1164,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1268,8 +1216,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1327,8 +1273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1381,8 +1325,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1440,8 +1382,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1494,8 +1434,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static RecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1553,8 +1491,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;RecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1575,8 +1511,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1597,8 +1531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,7 +71,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,7 +119,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,7 +160,6 @@
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Config to enable speaker diarization.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +340,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,8 +361,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +431,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,8 +452,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,7 +494,6 @@
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,8 +515,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,8 +537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +577,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,7 +604,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,7 +630,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,7 +656,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,7 +680,6 @@
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,8 +701,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,8 +723,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,8 +745,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(SpeakerDiarizationConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,8 +782,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -878,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,8 +880,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeakerDiarizationConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,7 +924,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +963,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,7 +1012,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,7 +1056,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1141,8 +1095,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1195,7 +1147,6 @@
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1235,8 +1186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeakerDiarizationConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Config to enable speaker diarization.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ENABLE_SPEAKER_DIARIZATION_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MAX_SPEAKER_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int MIN_SPEAKER_COUNT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEAKER_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,8 +352,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,8 +411,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -446,8 +431,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -473,7 +456,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,7 +482,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,7 +508,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,8 +529,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeakerDiarizationConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -573,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,7 +576,6 @@
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +597,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +619,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,8 +641,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -718,8 +685,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +705,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig.Builder newBuilder(SpeakerDiarizationConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -779,8 +742,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeakerDiarizationConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,8 +840,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -937,8 +892,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -996,8 +949,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,8 +1001,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,8 +1058,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1222,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1276,8 +1219,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1335,8 +1276,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,8 +1328,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1448,8 +1385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1502,8 +1437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeakerDiarizationConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1561,8 +1494,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeakerDiarizationConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1583,8 +1514,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1605,8 +1534,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -33,7 +31,6 @@
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,7 +57,6 @@
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +83,6 @@
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,7 +107,6 @@
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Speech adaptation configuration.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechAdaptation</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,7 +275,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,7 +319,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +362,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +405,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,7 +448,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,7 +496,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,7 +544,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,7 +570,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -620,7 +610,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,7 +652,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,7 +696,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,7 +738,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,7 +780,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,7 +827,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -890,7 +874,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -916,7 +899,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -954,8 +936,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1000,8 +980,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1022,8 +1000,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,8 +1020,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1074,7 +1048,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1095,8 +1068,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1136,8 +1107,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1180,7 +1149,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,7 +1175,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1228,8 +1195,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1258,7 +1223,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1302,7 +1266,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1346,7 +1309,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1373,7 +1335,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1400,7 +1361,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1427,7 +1387,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1471,7 +1430,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1492,8 +1450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1514,8 +1470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1536,8 +1490,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1563,7 +1515,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1606,7 +1557,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1649,7 +1599,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1674,7 +1623,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1701,7 +1649,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1744,7 +1691,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1787,7 +1733,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1813,7 +1758,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1839,7 +1783,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1865,7 +1808,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1908,7 +1850,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1929,8 +1870,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1953,8 +1892,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1977,8 +1914,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder mergeFrom(SpeechAdaptation other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2016,8 +1951,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2077,8 +2010,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2118,8 +2049,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechAdaptation.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2165,7 +2094,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2208,7 +2136,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2252,7 +2179,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2301,7 +2227,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2344,8 +2269,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2393,7 +2316,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2444,7 +2366,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2492,7 +2413,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2535,8 +2455,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2586,8 +2504,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechAdaptation.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Speech adaptation configuration.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechAdaptation</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASSES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SETS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SET_REFERENCES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,7 +378,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -431,7 +421,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,7 +447,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,7 +473,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +516,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,8 +536,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,8 +556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,8 +576,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,8 +596,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechAdaptation&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -643,7 +621,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,7 +663,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -729,7 +705,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,7 +729,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,7 +755,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,7 +797,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,7 +822,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -876,7 +847,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,7 +889,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,8 +909,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,8 +931,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,8 +953,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1012,8 +975,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1036,8 +997,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,8 +1019,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1082,8 +1039,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation.Builder newBuilder(SpeechAdaptation prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,8 +1076,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1143,8 +1096,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechAdaptation.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1184,8 +1135,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1225,8 +1174,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1451,8 +1392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1505,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1564,8 +1501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1618,8 +1553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1677,8 +1610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1731,8 +1662,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1790,8 +1719,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1844,8 +1771,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechAdaptation parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1903,8 +1828,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechAdaptation&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1925,8 +1848,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1947,8 +1868,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,7 +75,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +101,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,7 +127,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,7 +193,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,7 +235,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,7 +277,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,7 +301,6 @@
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,7 +327,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,7 +369,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,7 +394,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,7 +419,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,7 +461,6 @@
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +63,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Descriptors.FileDescriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistry registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistryLite registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
@@ -39,7 +39,6 @@
  SpeechClient speechClient = SpeechClient.create(speechSettings);
 </code></pre><p>Please refer to the GitHub repository&#39;s samples for more quickstart code snippets.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -98,7 +97,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,8 +119,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechClient(SpeechStub stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,8 +143,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,8 +200,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechClient_create_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.create*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechClient_create__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.create()" class="notranslate">create()</h3>
   <div class="codewrapper">
@@ -215,7 +207,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient with default settings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -253,7 +244,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -308,7 +298,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given stub for making calls. This is for advanced usage - prefer using create(SpeechSettings).</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the OperationsClient that can be used to query the status of a long-running operation returned by another API method call.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,8 +357,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechSettings getSettings()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,8 +377,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub getStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,8 +397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,8 +417,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,7 +448,6 @@
    LongRunningRecognizeResponse response = speechClient.longRunningRecognizeAsync(request).get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,7 +495,6 @@
        speechClient.longRunningRecognizeAsync(config, audio).get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +553,6 @@
    Operation response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,7 +587,6 @@
    LongRunningRecognizeResponse response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,7 +615,6 @@
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +671,6 @@
    RecognizeResponse response = speechClient.recognize(request);
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +722,6 @@
    RecognizeResponse response = future.get();
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,15 +742,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechClient_shutdownNow_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechClient_shutdownNow__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechClient_streamingRecognizeCallable_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.streamingRecognizeCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechClient_streamingRecognizeCallable__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.streamingRecognizeCallable()" class="notranslate">streamingRecognizeCallable()</h3>
   <div class="codewrapper">
@@ -795,7 +764,6 @@
    }
  }
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -244,7 +243,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,7 +295,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -350,7 +347,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,8 +386,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +430,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +450,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,7 +502,6 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,8 +523,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +562,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,7 +614,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,8 +635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -687,7 +667,6 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,8 +688,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,8 +708,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,8 +728,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,7 +763,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -843,7 +815,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,7 +867,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,7 +901,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,8 +922,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,8 +944,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,8 +966,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(SpeechContext other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,8 +1003,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1062,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,8 +1101,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1193,7 +1150,6 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1233,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,7 +1246,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,8 +1291,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,8 +1340,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechContext.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
@@ -15,7 +15,6 @@
  in the results.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechContext</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int BOOST_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +315,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,7 +364,6 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,8 +385,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,8 +405,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +425,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +445,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechContext&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -496,7 +480,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,7 +532,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +584,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -637,7 +618,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,8 +639,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,8 +661,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -707,8 +683,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,8 +705,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,8 +727,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -779,8 +749,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +769,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext.Builder newBuilder(SpeechContext prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -840,8 +806,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,8 +826,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechContext.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,8 +865,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,8 +904,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,8 +956,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,8 +1013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1111,8 +1065,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1170,8 +1122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1224,8 +1174,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1283,8 +1231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1337,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1396,8 +1340,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1450,8 +1392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1509,8 +1449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1563,8 +1501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechContext parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1622,8 +1558,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechContext&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1644,8 +1578,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1666,8 +1598,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -38,7 +36,6 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,7 +70,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -126,7 +122,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,7 +174,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -214,7 +208,6 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechBlockingStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -210,7 +206,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechFutureStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -210,7 +206,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -70,8 +69,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechImplBase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_bindService_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.bindService*"></a>
@@ -79,8 +76,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final ServerServiceDefinition bindService()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,7 +103,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,7 +133,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,7 +163,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -116,8 +115,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechGrpc.SpeechStub build(Channel channel, CallOptions callOptions)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,7 +166,6 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,7 +196,6 @@
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +226,6 @@
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><pre><code>Service that implements Google Cloud Speech API.
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +64,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final String SERVICE_NAME</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,8 +86,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;LongRunningRecognizeRequest,Operation&gt; getLongRunningRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;RecognizeRequest,RecognizeResponse&gt; getRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,8 +126,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServiceDescriptor getServiceDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,8 +146,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static MethodDescriptor&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; getStreamingRecognizeMethod()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,7 +168,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,7 +207,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -259,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +63,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Descriptors.FileDescriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistry registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistryLite registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -235,7 +234,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,8 +271,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +320,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -367,7 +362,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,7 +404,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,7 +451,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,7 +498,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,7 +523,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,8 +560,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,8 +580,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +600,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,7 +631,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -710,8 +691,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,7 +733,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,7 +759,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -802,8 +779,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,7 +810,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -879,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,8 +871,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -928,7 +896,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,7 +920,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -980,7 +946,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,7 +988,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1066,7 +1030,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,7 +1055,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,7 +1080,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1144,7 +1105,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1187,7 +1147,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1208,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1232,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,8 +1211,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(SpeechRecognitionAlternative other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1295,8 +1248,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,8 +1307,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,8 +1346,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1443,7 +1390,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1490,7 +1436,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1530,8 +1475,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1576,8 +1519,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1630,7 +1571,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1673,7 +1613,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1713,8 +1652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionAlternative.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1759,7 +1696,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1807,7 +1743,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Alternative hypotheses (a.k.a. n-best list).
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIDENCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int TRANSCRIPT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int WORDS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +381,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +402,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionAlternative&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +509,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,7 +533,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,8 +554,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,7 +581,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +623,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,7 +648,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,7 +673,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -743,7 +715,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,8 +735,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +757,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -812,8 +779,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,8 +801,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,8 +821,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative.Builder newBuilder(SpeechRecognitionAlternative prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionAlternative.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,8 +917,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,8 +956,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1055,8 +1008,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1114,8 +1065,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1168,8 +1117,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1174,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1281,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1340,8 +1283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1394,8 +1335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1453,8 +1392,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1507,8 +1444,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1566,8 +1501,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1620,8 +1553,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionAlternative parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1679,8 +1610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionAlternative&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1701,8 +1630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1723,8 +1650,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -37,7 +35,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,7 +83,6 @@
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,7 +109,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +151,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,7 +176,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +201,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -252,7 +243,6 @@
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -236,7 +235,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -280,7 +278,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +321,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +364,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +412,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +460,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,7 +486,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,8 +523,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +567,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +587,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +607,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -651,7 +635,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -677,7 +660,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,8 +681,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +725,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,8 +746,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,7 +813,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -882,7 +856,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -926,7 +899,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -953,7 +925,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -980,7 +951,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,7 +977,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1051,7 +1020,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,7 +1045,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1099,8 +1066,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1121,8 +1086,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1143,8 +1106,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,7 +1133,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1199,7 +1159,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,8 +1180,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1245,8 +1202,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1269,8 +1224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(SpeechRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1308,8 +1261,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1369,8 +1320,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1410,8 +1359,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,7 +1404,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1501,7 +1447,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,7 +1495,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1598,7 +1542,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1638,8 +1581,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1689,7 +1630,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1734,7 +1674,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1774,8 +1713,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1825,8 +1762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final SpeechRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>A speech recognition result corresponding to a portion of the audio.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.SpeechRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CHANNEL_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +333,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -387,7 +378,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -431,7 +421,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,7 +447,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,7 +473,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,7 +516,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,7 +541,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,8 +562,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,8 +582,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,8 +602,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,7 +627,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -675,7 +653,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -697,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;SpeechRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,8 +696,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,8 +718,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,8 +740,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,8 +762,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,8 +784,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -841,8 +806,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,8 +826,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult.Builder newBuilder(SpeechRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -902,8 +863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -924,8 +883,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -965,8 +922,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1006,8 +961,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1060,8 +1013,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1119,8 +1070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1173,8 +1122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1232,8 +1179,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1286,8 +1231,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1345,8 +1288,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1399,8 +1340,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1458,8 +1397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1512,8 +1449,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1571,8 +1506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1625,8 +1558,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1684,8 +1615,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;SpeechRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1706,8 +1635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1728,8 +1655,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,7 +75,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,7 +127,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,7 +221,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,7 +247,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -65,8 +63,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Descriptors.FileDescriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -87,8 +83,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistry registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,8 +105,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void registerAllExtensions(ExtensionRegistryLite registry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for SpeechSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -139,15 +138,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,8 +165,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,8 +187,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechStubSettings.Builder stubSettings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,7 +214,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,8 +303,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder getStubSettingsBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,7 +325,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -362,7 +347,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +369,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,7 +391,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
@@ -32,7 +32,6 @@
              .build());
  SpeechSettings speechSettings = speechSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechSettings(SpeechSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechSettings create(SpeechStubSettings stub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,8 +197,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -226,7 +219,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,7 +241,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -272,7 +263,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,8 +283,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,7 +305,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,7 +327,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,7 +349,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +371,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,7 +393,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +415,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -472,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,7 +476,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,7 +498,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -231,8 +230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -277,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,7 +340,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +360,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,7 +405,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,8 +426,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,7 +485,6 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,8 +506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,7 +532,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,7 +557,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,7 +581,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +601,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,8 +621,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,8 +641,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,7 +669,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -738,7 +710,6 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,7 +735,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,8 +756,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +778,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,7 +804,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -876,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(StreamingRecognitionConfig other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -915,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,8 +937,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1017,8 +976,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,7 +1019,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1104,7 +1060,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,8 +1097,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1194,7 +1147,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,8 +1186,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1305,7 +1255,6 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1345,8 +1294,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionConfig.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
@@ -15,7 +15,6 @@
  request.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognitionConfig</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int INTERIM_RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SINGLE_UTTERANCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -341,8 +334,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,7 +377,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +402,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,8 +422,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,8 +442,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,7 +488,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -527,8 +509,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionConfig&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +531,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -595,7 +573,6 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,8 +594,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,7 +620,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -667,8 +641,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,8 +663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,8 +685,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,8 +707,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -761,8 +727,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig.Builder newBuilder(StreamingRecognitionConfig prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,8 +764,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,8 +784,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionConfig.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,8 +823,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -904,8 +862,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,8 +914,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1017,8 +971,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1071,8 +1023,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,8 +1080,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1184,8 +1132,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1243,8 +1189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1297,8 +1241,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,8 +1298,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1410,8 +1350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1469,8 +1407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1523,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionConfig parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1582,8 +1516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionConfig&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1604,8 +1536,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1626,8 +1556,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,7 +122,6 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,7 +147,6 @@
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -237,7 +236,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,7 +279,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,7 +322,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +365,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,7 +413,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +461,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -494,7 +487,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,8 +524,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,8 +568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,8 +588,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,8 +608,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,7 +636,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,7 +661,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,8 +682,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,7 +728,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,7 +754,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,8 +775,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,7 +818,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -870,7 +845,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -892,8 +866,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,7 +894,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,7 +937,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,7 +980,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1037,7 +1006,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1064,7 +1032,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,7 +1058,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,7 +1101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,7 +1126,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1183,8 +1147,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1205,8 +1167,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1227,8 +1187,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1258,7 +1216,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1285,7 +1242,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,7 +1268,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,7 +1293,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1364,7 +1318,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,7 +1342,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1417,7 +1369,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1443,7 +1394,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1465,8 +1415,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1489,8 +1437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(StreamingRecognitionResult other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1552,8 +1496,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1613,8 +1555,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1658,7 +1598,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1696,8 +1635,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1743,7 +1680,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1787,7 +1723,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1836,7 +1771,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1884,7 +1818,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1924,8 +1857,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1977,7 +1908,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2022,7 +1952,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2067,7 +1996,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2107,8 +2035,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2162,7 +2088,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2204,7 +2129,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2249,7 +2173,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2289,8 +2212,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognitionResult.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
@@ -15,7 +15,6 @@
  that is currently being processed.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognitionResult</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -275,8 +274,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ALTERNATIVES_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CHANNEL_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,8 +312,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int IS_FINAL_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,8 +331,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int LANGUAGE_CODE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,8 +350,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULT_END_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +369,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STABILITY_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +391,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,7 +436,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,7 +479,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,7 +505,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,7 +531,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +574,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +599,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,8 +620,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,8 +640,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,8 +660,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -714,7 +687,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,7 +713,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,7 +739,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,8 +760,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognitionResult&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,7 +786,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -844,7 +811,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -865,8 +831,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,7 +860,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,8 +881,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,7 +907,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -968,8 +928,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -992,8 +950,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,8 +972,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1040,8 +994,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,8 +1014,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult.Builder newBuilder(StreamingRecognitionResult prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1051,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1123,8 +1071,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognitionResult.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1164,8 +1110,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1205,8 +1149,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1259,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1318,8 +1258,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1372,8 +1310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1431,8 +1367,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1485,8 +1419,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1544,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1598,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1657,8 +1585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1711,8 +1637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1770,8 +1694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1824,8 +1746,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognitionResult parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1883,8 +1803,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognitionResult&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1905,8 +1823,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1927,8 +1843,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,7 +75,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,7 +101,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,7 +127,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,7 +170,6 @@
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,7 +223,6 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,7 +249,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,7 +275,6 @@
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,7 +300,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,7 +325,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,7 +352,6 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +377,6 @@
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
@@ -18,7 +18,6 @@
  must not contain a `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -234,8 +233,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -280,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,8 +297,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,7 +349,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,8 +370,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,8 +409,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -467,7 +453,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,8 +473,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingRequest()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,8 +493,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -544,7 +525,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,8 +546,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,8 +566,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,8 +586,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,7 +613,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,7 +639,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,7 +664,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,8 +684,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,7 +714,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,7 +740,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,8 +761,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,8 +783,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -842,8 +805,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(StreamingRecognizeRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,8 +842,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,8 +901,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,7 +945,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1026,8 +982,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,7 +1031,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1117,8 +1070,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1163,8 +1114,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1219,7 +1168,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1262,7 +1210,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1300,8 +1247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span>,</span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
@@ -18,7 +18,6 @@
  must not contain a `streaming_config` message.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognizeRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -278,8 +277,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int AUDIO_CONTENT_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,8 +296,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int STREAMING_CONFIG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,8 +318,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,7 +367,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,8 +388,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -418,8 +408,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,8 +428,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,8 +448,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,8 +470,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,7 +497,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,7 +523,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,8 +543,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +595,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,7 +621,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,8 +664,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -740,8 +708,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -762,8 +728,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest.Builder newBuilder(StreamingRecognizeRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +765,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,8 +785,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -864,8 +824,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -905,8 +863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -959,8 +915,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1018,8 +972,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1072,8 +1024,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1131,8 +1081,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1185,8 +1133,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1244,8 +1190,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1298,8 +1242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1357,8 +1299,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1411,8 +1351,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,8 +1408,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1524,8 +1460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1583,8 +1517,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1605,8 +1537,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1627,8 +1557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -38,7 +36,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -65,7 +62,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,7 +88,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,8 +108,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeRequest.StreamingRequestCase getStreamingRequestCase()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,7 +138,6 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,7 +164,6 @@
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
@@ -49,7 +49,6 @@
      one or more (repeated) `results`.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -271,7 +270,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,8 +307,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,7 +357,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,7 +400,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,7 +443,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,7 +491,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +539,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,7 +565,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -612,8 +602,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,8 +622,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,8 +642,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,7 +668,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,8 +688,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -746,8 +727,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,7 +772,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,7 +795,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,8 +816,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,8 +838,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -885,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -907,8 +878,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,7 +904,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -961,7 +929,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -986,7 +953,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1013,7 +979,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,7 +1022,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,7 +1065,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1128,7 +1091,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,7 +1117,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1182,7 +1143,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,7 +1186,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1250,7 +1209,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1275,7 +1233,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1301,7 +1258,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1323,8 +1279,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1347,8 +1301,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1375,7 +1327,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1413,8 +1364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(StreamingRecognizeResponse other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1452,8 +1401,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,8 +1460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1554,8 +1499,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1601,7 +1544,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1643,7 +1585,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1685,7 +1626,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1723,8 +1663,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1769,8 +1707,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1826,7 +1762,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1875,7 +1810,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1921,7 +1855,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1964,7 +1897,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2004,8 +1936,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final StreamingRecognizeResponse.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p>Protobuf enum <code>google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
@@ -49,7 +49,6 @@
      one or more (repeated) `results`.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.StreamingRecognizeResponse</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -309,8 +308,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int ERROR_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,8 +327,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int RESULTS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,8 +346,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEECH_EVENT_TYPE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,8 +368,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -416,8 +407,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,8 +427,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,8 +447,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,7 +471,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,7 +496,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,8 +516,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;StreamingRecognizeResponse&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,7 +544,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,7 +587,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,7 +613,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -661,7 +639,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,7 +682,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,8 +702,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,7 +727,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,7 +751,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,8 +772,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,7 +798,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,8 +819,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,8 +841,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -898,8 +863,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,8 +885,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,8 +905,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse.Builder newBuilder(StreamingRecognizeResponse prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -983,8 +942,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +962,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected StreamingRecognizeResponse.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1046,8 +1001,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1087,8 +1040,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1141,8 +1092,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1200,8 +1149,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1254,8 +1201,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1313,8 +1258,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1367,8 +1310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1426,8 +1367,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,8 +1419,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1539,8 +1476,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1593,8 +1528,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1652,8 +1585,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1706,8 +1637,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static StreamingRecognizeResponse parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1765,8 +1694,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;StreamingRecognizeResponse&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1787,8 +1714,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1809,8 +1734,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -32,7 +30,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,7 +55,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -85,7 +81,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,7 +124,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -156,7 +150,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,7 +176,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -227,7 +219,6 @@
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,7 +242,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,7 +266,6 @@
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,7 +291,6 @@
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `UpdateCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.UpdateCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -350,7 +341,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,8 +361,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +400,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,7 +490,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -535,7 +517,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -562,7 +543,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -583,8 +563,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,8 +583,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -627,8 +603,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,7 +628,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,7 +652,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,7 +675,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,7 +701,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,7 +725,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,8 +746,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +768,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -831,7 +796,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,8 +833,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder mergeFrom(UpdateCustomClassRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -908,8 +870,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -969,8 +929,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UpdateCustomClassRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,7 +1010,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1098,7 +1053,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,7 +1096,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1180,8 +1133,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,8 +1177,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1277,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UpdateCustomClassRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1321,7 +1268,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1362,7 +1308,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `UpdateCustomClass` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.UpdateCustomClassRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CUSTOM_CLASS_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int UPDATE_MASK_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,7 +359,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,7 +386,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,8 +406,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,8 +426,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,8 +446,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,8 +466,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;UpdateCustomClassRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +488,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,7 +535,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,7 +559,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,7 +585,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,7 +609,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,8 +630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +696,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,8 +716,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest.Builder newBuilder(UpdateCustomClassRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +753,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +773,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected UpdateCustomClassRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -851,8 +812,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -892,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,8 +903,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +960,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1059,8 +1012,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,8 +1069,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,8 +1121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,8 +1178,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1285,8 +1230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1287,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1398,8 +1339,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,8 +1396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,8 +1448,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdateCustomClassRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1570,8 +1505,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;UpdateCustomClassRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1592,8 +1525,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1614,8 +1545,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,7 +82,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +132,6 @@
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,7 +156,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `UpdatePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -344,8 +335,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,8 +374,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +419,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,8 +504,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -545,8 +524,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +552,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,7 +579,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,7 +605,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,7 +628,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,7 +652,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,7 +675,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,7 +701,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,7 +725,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,8 +746,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,8 +768,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,8 +790,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder mergeFrom(UpdatePhraseSetRequest other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -864,8 +827,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,8 +886,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,7 +931,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,8 +968,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UpdatePhraseSetRequest.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1054,7 +1010,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,8 +1047,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1144,7 +1097,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1188,7 +1140,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1226,8 +1177,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1277,8 +1226,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UpdatePhraseSetRequest.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1321,7 +1268,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1362,7 +1308,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Message sent by the client for the `UpdatePhraseSet` method.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int PHRASE_SET_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int UPDATE_MASK_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,8 +314,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,8 +353,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -382,8 +373,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,8 +413,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;UpdatePhraseSetRequest&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +441,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,7 +468,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +488,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +510,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,7 +535,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,7 +559,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,7 +585,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -633,7 +609,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,8 +630,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,8 +652,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -703,8 +674,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,8 +696,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,8 +716,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest.Builder newBuilder(UpdatePhraseSetRequest prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -788,8 +753,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,8 +773,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected UpdatePhraseSetRequest.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -851,8 +812,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -892,8 +851,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,8 +903,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1005,8 +960,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1059,8 +1012,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,8 +1069,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,8 +1121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,8 +1178,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1285,8 +1230,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,8 +1287,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1398,8 +1339,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,8 +1396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1511,8 +1448,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static UpdatePhraseSetRequest parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1570,8 +1505,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;UpdatePhraseSetRequest&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1592,8 +1525,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1614,8 +1545,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -34,7 +32,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -62,7 +59,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,7 +82,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,7 +132,6 @@
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,7 +156,6 @@
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Word-specific information for recognized words.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.WordInfo</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -230,8 +229,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addRepeatedField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -298,8 +293,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo buildPartial()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -320,8 +313,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clear()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,7 +344,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,7 +373,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,8 +393,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearField(Descriptors.FieldDescriptor field)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -445,8 +432,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearOneof(Descriptors.OneofDescriptor oneof)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,7 +478,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,7 +507,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,7 +530,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,8 +551,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clone()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,7 +582,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,8 +603,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,8 +623,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -668,8 +643,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Descriptors.Descriptor getDescriptorForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,7 +673,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,7 +702,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,7 +730,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -787,7 +757,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -817,7 +786,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -847,7 +815,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -876,7 +843,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -900,7 +866,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,7 +890,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -955,7 +919,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -985,7 +948,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,8 +969,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1031,8 +991,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1063,7 +1021,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,8 +1058,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(WordInfo other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,8 +1095,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1201,8 +1154,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeFrom(Message other)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1250,7 +1201,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1288,8 +1238,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final WordInfo.Builder mergeUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,7 +1286,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,7 +1333,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1432,7 +1378,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,8 +1415,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setField(Descriptors.FieldDescriptor field, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1516,8 +1459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setRepeatedField(Descriptors.FieldDescriptor field, int index, Object value)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1574,7 +1515,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1622,7 +1562,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1668,7 +1607,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1706,8 +1644,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final WordInfo.Builder setUnknownFields(UnknownFieldSet unknownFields)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1750,7 +1686,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1793,7 +1728,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><pre><code>Word-specific information for recognized words.
 </code></pre><p>Protobuf type <code>google.cloud.speech.v1p1beta1.WordInfo</code></p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -274,8 +273,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int CONFIDENCE_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,8 +292,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int END_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,8 +311,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int SPEAKER_TAG_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,8 +330,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int START_TIME_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,8 +349,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final int WORD_FIELD_NUMBER</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Field Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -382,8 +371,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean equals(Object obj)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -432,7 +419,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,8 +440,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo getDefaultInstance()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getDefaultInstanceForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,8 +480,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final Descriptors.Descriptor getDescriptor()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,7 +508,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,7 +537,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,8 +557,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Parser&lt;WordInfo&gt; getParserForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,8 +579,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSerializedSize()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,7 +608,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,7 +637,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -694,7 +666,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,8 +686,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnknownFieldSet getUnknownFields()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -742,7 +711,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,7 +735,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,7 +764,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -827,7 +793,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -849,8 +814,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int hashCode()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -873,8 +836,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,8 +858,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final boolean isInitialized()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -921,8 +880,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo.Builder newBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -943,8 +900,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo.Builder newBuilder(WordInfo prototype)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -982,8 +937,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder newBuilderForType()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1004,8 +957,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected WordInfo.Builder newBuilderForType(GeneratedMessageV3.BuilderParent parent)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,8 +996,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Object newInstance(GeneratedMessageV3.UnusedPrivateParameter unused)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1086,8 +1035,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseDelimitedFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,8 +1087,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseDelimitedFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1199,8 +1144,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(byte[] data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1253,8 +1196,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(byte[] data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,8 +1253,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteString data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1366,8 +1305,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteString data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1425,8 +1362,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(CodedInputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1479,8 +1414,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(CodedInputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1538,8 +1471,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(InputStream input)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1592,8 +1523,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(InputStream input, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1651,8 +1580,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteBuffer data)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1705,8 +1632,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static WordInfo parseFrom(ByteBuffer data, ExtensionRegistryLite extensionRegistry)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1764,8 +1689,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Parser&lt;WordInfo&gt; parser()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1786,8 +1709,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder toBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1808,8 +1729,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void writeTo(CodedOutputStream output)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
@@ -11,8 +11,6 @@
 </h1>
   
   
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
   <div classs="implements">
     <h5>Implements</h5>
     <span><span class="xref">com.google.protobuf.MessageOrBuilder</span></span>
@@ -37,7 +35,6 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -125,7 +120,6 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,7 +149,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,7 +178,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +201,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -234,7 +225,6 @@
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,7 +254,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -294,7 +283,6 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.html
@@ -34,8 +34,6 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
  </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
-  <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes
   
   </h2>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Base stub class for the Adaptation service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_close_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.close*"></a>
@@ -80,15 +77,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_createCustomClassCallable_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.createCustomClassCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_createCustomClassCallable__" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.createCustomClassCallable()" class="notranslate">createCustomClassCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,8 +102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,8 +122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,8 +142,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -175,8 +162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -197,8 +182,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,8 +202,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListCustomClassesRequest,ListCustomClassesResponse&gt; listCustomClassesCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,8 +222,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListCustomClassesRequest,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesPagedCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -263,8 +242,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListPhraseSetRequest,ListPhraseSetResponse&gt; listPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,8 +262,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListPhraseSetRequest,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetPagedCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,8 +282,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -329,8 +302,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for AdaptationStubSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -142,15 +141,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,8 +168,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(AdaptationStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,8 +247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStubSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,7 +286,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,7 +308,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,7 +330,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deleteCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,7 +352,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deletePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,7 +374,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,7 +396,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,7 +418,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listCustomClasses.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +440,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +460,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ImmutableList&lt;UnaryCallSettings.Builder&lt;?,?&gt;&gt; unaryMethodSettingsBuilders()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,7 +482,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updateCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,7 +504,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updatePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
@@ -32,7 +32,6 @@
              .build());
  AdaptationStubSettings adaptationSettings = adaptationSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationStubSettings(AdaptationStubSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,7 +147,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,8 +189,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStub createStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,8 +224,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -278,7 +268,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,7 +290,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,8 +310,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +332,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deleteCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +354,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deletePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,7 +376,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,7 +398,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,7 +420,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,7 +442,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,7 +464,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listCustomClasses.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,7 +486,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listPhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,7 +508,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,7 +530,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,7 +569,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -618,7 +593,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updateCustomClass.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,7 +615,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updatePhraseSet.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC callable factory implementation for the Adaptation service API.</p>
 <p>This class is for advanced usage.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcAdaptationCallableFactory()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationCallableFactory_createOperationCallable_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.createOperationCallable*"></a>
@@ -80,8 +77,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;RequestT,ResponseT,MetadataT&gt; &lt;RequestT,ResponseT,MetadataT&gt;createOperationCallable(GrpcCallSettings&lt;RequestT,Operation&gt; grpcCallSettings, OperationCallSettings&lt;RequestT,ResponseT,MetadataT&gt; callSettings, ClientContext clientContext, OperationsStub operationsStub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,8 +129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,PagedListResponseT&gt; &lt;RequestT,ResponseT,PagedListResponseT&gt;createPagedCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, PagedCallSettings&lt;RequestT,ResponseT,PagedListResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,8 +176,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBatchingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, BatchingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,8 +223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBidiStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,8 +270,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ClientStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createClientStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServerStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createServerStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, ServerStreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createUnaryCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, UnaryCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC stub implementation for the Adaptation service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -109,7 +108,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcAdaptationStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,7 +137,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcAdaptationStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,8 +171,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -233,8 +228,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Overrides</strong>
   <div><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html#com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_close__">AdaptationStub.close()</a></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_create_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.create*"></a>
@@ -242,8 +235,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcAdaptationStub create(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,8 +287,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcAdaptationStub create(ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -355,8 +344,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcAdaptationStub create(AdaptationStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,8 +396,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,8 +418,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,8 +440,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,8 +462,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -505,8 +484,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +506,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcOperationsStub getOperationsStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,8 +526,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,8 +548,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,8 +568,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,8 +588,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListCustomClassesRequest,ListCustomClassesResponse&gt; listCustomClassesCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -643,8 +610,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListCustomClassesRequest,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesPagedCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -667,8 +632,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListPhraseSetRequest,ListPhraseSetResponse&gt; listPhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,8 +654,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;ListPhraseSetRequest,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetPagedCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,22 +676,16 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_shutdownNow_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_shutdownNow__" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_updateCustomClassCallable_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.updateCustomClassCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_updateCustomClassCallable__" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.updateCustomClassCallable()" class="notranslate">updateCustomClassCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,8 +708,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC callable factory implementation for the Speech service API.</p>
 <p>This class is for advanced usage.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcSpeechCallableFactory()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechCallableFactory_createOperationCallable_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.createOperationCallable*"></a>
@@ -80,8 +77,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;RequestT,ResponseT,MetadataT&gt; &lt;RequestT,ResponseT,MetadataT&gt;createOperationCallable(GrpcCallSettings&lt;RequestT,Operation&gt; grpcCallSettings, OperationCallSettings&lt;RequestT,ResponseT,MetadataT&gt; callSettings, ClientContext clientContext, OperationsStub operationsStub)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,8 +129,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,PagedListResponseT&gt; &lt;RequestT,ResponseT,PagedListResponseT&gt;createPagedCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, PagedCallSettings&lt;RequestT,ResponseT,PagedListResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,8 +176,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBatchingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, BatchingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,8 +223,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createBidiStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,8 +270,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ClientStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createClientStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, StreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,8 +317,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServerStreamingCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createServerStreamingCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, ServerStreamingCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,8 +364,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RequestT,ResponseT&gt; &lt;RequestT,ResponseT&gt;createUnaryCallable(GrpcCallSettings&lt;RequestT,ResponseT&gt; grpcCallSettings, UnaryCallSettings&lt;RequestT,ResponseT&gt; callSettings, ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>gRPC stub implementation for the Speech service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -88,7 +87,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,7 +116,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,8 +150,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean awaitTermination(long duration, TimeUnit unit)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,8 +207,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Overrides</strong>
   <div><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html#com_google_cloud_speech_v1p1beta1_stub_SpeechStub_close__">SpeechStub.close()</a></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_create_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.create*"></a>
@@ -221,8 +214,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -334,8 +323,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final GrpcSpeechStub create(SpeechStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,8 +375,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GrpcOperationsStub getOperationsStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,8 +397,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isShutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,8 +417,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean isTerminated()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +437,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +459,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,8 +481,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,22 +503,16 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdown()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_shutdownNow_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.shutdownNow*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_shutdownNow__" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.shutdownNow()" class="notranslate">shutdownNow()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void shutdownNow()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_streamingRecognizeCallable_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.streamingRecognizeCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_streamingRecognizeCallable__" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.streamingRecognizeCallable()" class="notranslate">streamingRecognizeCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Base stub class for the Speech service API.</p>
 <p>This class is for advanced usage and reflects the underlying API directly.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -71,8 +70,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <h2 id="methods">Methods
   </h2>
   <a id="com_google_cloud_speech_v1p1beta1_stub_SpeechStub_close_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.close*"></a>
@@ -80,15 +77,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract void close()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_SpeechStub_getOperationsStub_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.getOperationsStub*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStub_getOperationsStub__" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.getOperationsStub()" class="notranslate">getOperationsStub()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsStub getOperationsStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,8 +102,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,8 +122,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -153,8 +142,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -175,8 +162,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Builder for SpeechStubSettings.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -142,15 +141,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <a id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_Builder_com_google_api_gax_rpc_ClientContext_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.Builder(com.google.api.gax.rpc.ClientContext)" class="notranslate">Builder(ClientContext clientContext)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(ClientContext clientContext)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,8 +168,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected Builder(SpeechStubSettings settings)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -202,7 +195,6 @@
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,8 +247,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings build()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -296,7 +286,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,7 +308,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -342,7 +330,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,7 +352,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -386,8 +372,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ImmutableList&lt;UnaryCallSettings.Builder&lt;?,?&gt;&gt; unaryMethodSettingsBuilders()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
@@ -32,7 +32,6 @@
              .build());
  SpeechStubSettings speechSettings = speechSettingsBuilder.build();
 </code></pre></div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
     <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
@@ -122,8 +121,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechStubSettings(SpeechStubSettings.Builder settingsBuilder)</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,8 +145,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStub createStub()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,8 +180,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ApiClientHeaderProvider.Builder defaultApiClientHeaderProviderBuilder()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +202,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,7 +224,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,7 +246,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,8 +266,6 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static TransportChannelProvider defaultTransportChannelProvider()</code></pre>
   </div>
-  <div class="markdown level1 summary"></div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,7 +288,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,7 +310,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +332,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,7 +354,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,7 +376,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,7 +398,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,7 +437,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,7 +459,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,7 +481,6 @@
   </div>
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.html
@@ -11,9 +11,6 @@
 </h1>
   
   {% verbatim %}
-  <div class="markdown level0 summary"></div>
-  <div class="markdown level0 conceptual"></div>
-  <div class="markdown level0 remarks"></div>
     <h2 id="classes">Classes
   
   </h2>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginehttptarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents an AppEngineHttpTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new AppEngineHttpTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget body.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget headers.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +158,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new AppEngineHttpTarget instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +201,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +253,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an AppEngineHttpTarget message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,7 +296,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,7 +348,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified AppEngineHttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginehttptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineHttpTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +400,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates an AppEngineHttpTarget message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +443,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this AppEngineHttpTarget to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +465,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineHttpTarget message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,7 +517,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies an AppEngineHttpTarget message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.appenginerouting.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents an AppEngineRouting.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new AppEngineRouting.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting host.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting instance.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting version.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +137,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new AppEngineRouting instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -187,7 +180,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +232,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an AppEngineRouting message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -284,7 +275,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,7 +327,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified AppEngineRouting message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.appenginerouting.html#_google_cloud_scheduler_google_cloud_scheduler_v1_AppEngineRouting_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +379,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates an AppEngineRouting message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,7 +422,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this AppEngineRouting to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -457,7 +444,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from an AppEngineRouting message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,7 +496,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies an AppEngineRouting message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.cloudscheduler-class.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a CloudScheduler</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
       <span>$protobuf.<span class="xref">rpc.Service</span></span>
@@ -29,7 +28,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new CloudScheduler service.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +75,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates new CloudScheduler service using the specified rpc implementation.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -139,7 +136,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls CreateJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,7 +187,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls CreateJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -235,7 +230,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,7 +281,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls DeleteJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,7 +324,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls GetJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -383,7 +375,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls GetJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,7 +418,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls ListJobs.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +469,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls ListJobs.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,7 +512,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls PauseJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,7 +563,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls PauseJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,7 +606,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -671,7 +657,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls ResumeJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,7 +700,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls RunJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -767,7 +751,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls RunJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,7 +794,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -863,7 +845,6 @@
   </div>
   <div class="markdown level1 summary"><p>Calls UpdateJob.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.createjobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a CreateJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new CreateJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>CreateJobRequest job.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>CreateJobRequest parent.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new CreateJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +138,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a CreateJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +233,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified CreateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.createjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_CreateJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a CreateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +380,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this CreateJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +402,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a CreateJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a CreateJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.deletejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a DeleteJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new DeleteJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>DeleteJobRequest name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +74,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new DeleteJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +117,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a DeleteJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +212,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified DeleteJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.deletejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_DeleteJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +316,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a DeleteJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +359,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this DeleteJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +381,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a DeleteJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +433,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a DeleteJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.getjobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a GetJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new GetJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>GetJobRequest name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +74,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new GetJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +117,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a GetJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +212,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified GetJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.getjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_GetJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +316,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a GetJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +359,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this GetJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +381,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a GetJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +433,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a GetJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>HttpMethod enum.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h5 id="_google_cloud_scheduler_google_cloud_scheduler_v1_HttpMethod_enum_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint"></code></pre>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httptarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a HttpTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new HttpTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget authorizationHeader.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget body.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget headers.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget httpMethod.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget oauthToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,7 +156,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget oidcToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,7 +177,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget uri.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +200,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new HttpTarget instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -253,7 +243,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,7 +295,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a HttpTarget message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -350,7 +338,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,7 +390,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified HttpTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.httptarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_HttpTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +442,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a HttpTarget message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,7 +485,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this HttpTarget to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,7 +507,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a HttpTarget message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,7 +559,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a HttpTarget message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginehttptarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of an AppEngineHttpTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget appEngineRouting</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget body</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget headers</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget httpMethod</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineHttpTarget relativeUri</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iappenginerouting.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of an AppEngineRouting.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting host</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting instance</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting service</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>AppEngineRouting version</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.icreatejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a CreateJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>CreateJobRequest job</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>CreateJobRequest parent</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ideletejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a DeleteJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>DeleteJobRequest name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.igetjobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a GetJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>GetJobRequest name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ihttptarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a HttpTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget body</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget headers</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget httpMethod</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget oauthToken</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget oidcToken</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,7 +127,6 @@
   </div>
   <div class="markdown level1 summary"><p>HttpTarget uri</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ijob.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a Job.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job appEngineHttpTarget</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job attemptDeadline</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job description</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job httpTarget</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job lastAttemptTime</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,7 +127,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,7 +148,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job pubsubTarget</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job retryConfig</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job schedule</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -221,7 +211,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job scheduleTime</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,7 +232,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job state</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -265,7 +253,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job status</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,7 +274,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job timeZone</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,7 +295,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job userUpdateTime</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a ListJobsRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest pageSize</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest pageToken</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest parent</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ilistjobsresponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a ListJobsResponse.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsResponse jobs</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioauthtoken.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a OAuthToken.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>OAuthToken scope</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ioidctoken.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of an OidcToken.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>OidcToken audience</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipausejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a PauseJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>PauseJobRequest name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.ipubsubtarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a PubsubTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget attributes</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget data</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget topicName</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iresumejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a ResumeJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>ResumeJobRequest name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iretryconfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a RetryConfig.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxDoublings</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -67,7 +64,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -89,7 +85,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,7 +106,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig retryCount</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.irunjobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of a RunJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>RunJobRequest name</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.iupdatejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Properties of an UpdateJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="properties">Properties
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>UpdateJobRequest job</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,7 +43,6 @@
   </div>
   <div class="markdown level1 summary"><p>UpdateJobRequest updateMask</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job-class.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a Job.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new Job.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job appEngineHttpTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job attemptDeadline.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job description.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job httpTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job lastAttemptTime.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,7 +156,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -185,7 +177,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job pubsubTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,7 +198,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job retryConfig.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -229,7 +219,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job schedule.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,7 +240,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job scheduleTime.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,7 +261,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job state.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -295,7 +282,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job status.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -317,7 +303,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job target.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,7 +324,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job timeZone.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -361,7 +345,6 @@
   </div>
   <div class="markdown level1 summary"><p>Job userUpdateTime.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,7 +368,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new Job instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -429,7 +411,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,7 +463,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a Job message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,7 +506,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified Job message. Does not implicitly  messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,7 +558,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified Job message, length delimited. Does not implicitly  messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,7 +610,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a Job message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -676,7 +653,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this Job to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,7 +675,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a Job message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -752,7 +727,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a Job message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>State enum.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h5 id="_google_cloud_scheduler_google_cloud_scheduler_v1_Job_State_enum_syntax">Syntax</h5>
   <div class="codewrapper">
     <pre><code class="prettyprint"></code></pre>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a ListJobsRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new ListJobsRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest pageSize.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest pageToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsRequest parent.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +116,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListJobsRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +159,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +211,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ListJobsRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +254,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +306,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ListJobsRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +358,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a ListJobsRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +401,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this ListJobsRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +423,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,7 +475,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a ListJobsRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.listjobsresponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a ListJobsResponse.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new ListJobsResponse.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsResponse jobs.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>ListJobsResponse nextPageToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ListJobsResponse instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +138,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ListJobsResponse message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +233,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ListJobsResponse message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.listjobsresponse.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ListJobsResponse_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a ListJobsResponse message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +380,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this ListJobsResponse to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +402,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a ListJobsResponse message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a ListJobsResponse message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oauthtoken.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a OAuthToken.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new OAuthToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>OAuthToken scope.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>OAuthToken serviceAccountEmail.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new OAuthToken instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +138,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a OAuthToken message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +233,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified OAuthToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oauthtoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OAuthToken_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a OAuthToken message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +380,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this OAuthToken to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +402,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a OAuthToken message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a OAuthToken message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.oidctoken.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents an OidcToken.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new OidcToken.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>OidcToken audience.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>OidcToken serviceAccountEmail.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new OidcToken instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +138,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an OidcToken message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +233,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified OidcToken message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified OidcToken message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.oidctoken.html#_google_cloud_scheduler_google_cloud_scheduler_v1_OidcToken_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates an OidcToken message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +380,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this OidcToken to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +402,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from an OidcToken message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies an OidcToken message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pausejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a PauseJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new PauseJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>PauseJobRequest name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +74,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new PauseJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +117,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a PauseJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +212,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified PauseJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pausejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PauseJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +316,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a PauseJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +359,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this PauseJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +381,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a PauseJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +433,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a PauseJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.pubsubtarget.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a PubsubTarget.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new PubsubTarget.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget attributes.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget data.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>PubsubTarget topicName.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +116,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new PubsubTarget instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +159,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +211,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a PubsubTarget message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +254,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -315,7 +306,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified PubsubTarget message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.pubsubtarget.html#_google_cloud_scheduler_google_cloud_scheduler_v1_PubsubTarget_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +358,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a PubsubTarget message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +401,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this PubsubTarget to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,7 +423,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a PubsubTarget message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,7 +475,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a PubsubTarget message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.resumejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a ResumeJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new ResumeJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>ResumeJobRequest name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +74,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new ResumeJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +117,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a ResumeJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +212,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified ResumeJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.resumejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_ResumeJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +316,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a ResumeJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +359,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this ResumeJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +381,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a ResumeJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +433,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a ResumeJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.retryconfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a RetryConfig.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new RetryConfig.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxBackoffDuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxDoublings.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,7 +93,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig maxRetryDuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,7 +114,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig minBackoffDuration.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,7 +135,6 @@
   </div>
   <div class="markdown level1 summary"><p>RetryConfig retryCount.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,7 +158,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new RetryConfig instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -209,7 +201,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,7 +253,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a RetryConfig message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,7 +296,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,7 +348,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified RetryConfig message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.retryconfig.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RetryConfig_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -412,7 +400,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a RetryConfig message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,7 +443,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this RetryConfig to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -479,7 +465,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a RetryConfig message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,7 +517,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a RetryConfig message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.runjobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents a RunJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new RunJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>RunJobRequest name.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,7 +74,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new RunJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,7 +117,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,7 +169,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes a RunJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,7 +212,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,7 +264,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified RunJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.runjobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_RunJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,7 +316,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a RunJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,7 +359,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this RunJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -391,7 +381,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from a RunJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -444,7 +433,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies a RunJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.updatejobrequest.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Represents an UpdateJobRequest.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <h6><strong>Package</strong>: <span class="xref">@google-cloud/scheduler!</span></h6>
   <h2 id="constructors">Constructors
   </h2>
@@ -23,7 +22,6 @@
   </div>
   <div class="markdown level1 summary"><p>Constructs a new UpdateJobRequest.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,7 +51,6 @@
   </div>
   <div class="markdown level1 summary"><p>UpdateJobRequest job.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,7 +72,6 @@
   </div>
   <div class="markdown level1 summary"><p>UpdateJobRequest updateMask.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,7 +95,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a new UpdateJobRequest instance using the specified properties.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,7 +138,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,7 +190,6 @@
   </div>
   <div class="markdown level1 summary"><p>Decodes an UpdateJobRequest message from the specified reader or buffer, length delimited.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,7 +233,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -293,7 +285,6 @@
   </div>
   <div class="markdown level1 summary"><p>Encodes the specified UpdateJobRequest message, length delimited. Does not implicitly <a class="xref" href="google.cloud.scheduler.v1.updatejobrequest.html#_google_cloud_scheduler_google_cloud_scheduler_v1_UpdateJobRequest_verify_member_1_">verify</a> messages.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,7 +337,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates an UpdateJobRequest message from a plain object. Also converts values to their respective internal types.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,7 +380,6 @@
   </div>
   <div class="markdown level1 summary"><p>Converts this UpdateJobRequest to JSON.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,7 +402,6 @@
   </div>
   <div class="markdown level1 summary"><p>Creates a plain object from an UpdateJobRequest message. Also converts values to other types if specified.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,7 +454,6 @@
   </div>
   <div class="markdown level1 summary"><p>Verifies an UpdateJobRequest message.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Service that implements Google Cloud Text-to-Speech API.</p>
 <p>Instantiate the text to speech client.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
       <span><span class="xref">builtins.object</span></span>
@@ -30,7 +29,6 @@
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +92,6 @@ file.</p>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +154,6 @@ file.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,7 +250,6 @@ method.</p>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.services.text_to_speech.TextToSpeechClient.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Service that implements Google Cloud Text-to-Speech API.</p>
 <p>Instantiate the text to speech client.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
       <span><span class="xref">builtins.object</span></span>
@@ -30,7 +29,6 @@
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +92,6 @@ file.</p>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +154,6 @@ file.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,7 +250,6 @@ method.</p>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.AudioConfig.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.AudioConfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of audio data to be synthesized.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The top-level message sent by the client for the <code>ListVoices</code>
 method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.ListVoicesResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>The message returned to the client by the <code>ListVoices</code> method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesisInput.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesisInput.html
@@ -16,7 +16,6 @@ must be supplied. Supplying both or neither returns
 [google.rpc.Code.INVALID_ARGUMENT][]. The input size is limited to
 5000 characters.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The top-level message sent by the client for the
 <code>SynthesizeSpeech</code> method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.SynthesizeSpeechResponse.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The message returned to the client by the <code>SynthesizeSpeech</code>
 method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.Voice.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.Voice.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of a voice supported by the TTS service.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.VoiceSelectionParams.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1.types.VoiceSelectionParams.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of which voice to use for a synthesis request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechAsyncClient.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Service that implements Google Cloud Text-to-Speech API.</p>
 <p>Instantiate the text to speech client.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
       <span><span class="xref">builtins.object</span></span>
@@ -30,7 +29,6 @@
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +92,6 @@ file.</p>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +154,6 @@ file.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,7 +250,6 @@ method.</p>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.services.text_to_speech.TextToSpeechClient.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>Service that implements Google Cloud Text-to-Speech API.</p>
 <p>Instantiate the text to speech client.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
       <span><span class="xref">builtins.object</span></span>
@@ -30,7 +29,6 @@
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,7 +92,6 @@ file.</p>
   <div class="markdown level1 summary"><p>Creates an instance of this client using the provided credentials
 file.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,7 +154,6 @@ file.</p>
   </div>
   <div class="markdown level1 summary"><p>Returns a list of Voice supported for synthesis.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,7 +250,6 @@ method.</p>
   <div class="markdown level1 summary"><p>Synthesizes speech synchronously: receive results
 after all text input has been processed.</p>
 </div>
-  <div class="markdown level1 conceptual"></div>
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.AudioConfig.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.AudioConfig.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of audio data to be synthesized.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The top-level message sent by the client for the <code>ListVoices</code>
 method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.ListVoicesResponse.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>The message returned to the client by the <code>ListVoices</code> method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesisInput.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesisInput.html
@@ -16,7 +16,6 @@ must be supplied. Supplying both or neither returns
 [google.rpc.Code.INVALID_ARGUMENT][]. The input size is limited to
 5000 characters.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.TimepointType.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The type of timepoint information that is returned in the
 response.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
                   <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechRequest.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The top-level message sent by the client for the
 <code>SynthesizeSpeech</code> method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.SynthesizeSpeechResponse.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>The message returned to the client by the <code>SynthesizeSpeech</code>
 method.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Timepoint.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Timepoint.html
@@ -14,7 +14,6 @@
   <div class="markdown level0 summary"><p>This contains a mapping between a certain point in the input
 text and a corresponding time in the output audio.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Voice.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.Voice.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of a voice supported by the TTS service.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.html
+++ b/testdata/goldens/python-small/google.cloud.texttospeech_v1beta1.types.VoiceSelectionParams.html
@@ -13,7 +13,6 @@
   
   <div class="markdown level0 summary"><p>Description of which voice to use for a synthesis request.</p>
 </div>
-  <div class="markdown level0 conceptual"></div>
   <div class="inheritance">
     <h5>Inheritance</h5>
           <span><span class="xref">builtins.object</span></span>

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -1,7 +1,11 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
 {{#inClass}}
 <div class="inheritance">
   <h5>{{__global.inheritance}}</h5>

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -24,8 +24,12 @@
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax}}
+{{#summary}}
 <div class="markdown level1 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
 <div class="markdown level1 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
 {{#syntax}}
 {{#parameters.0}}
 <strong>{{__global.parameters}}</strong>

--- a/third_party/docfx/templates/devsite/partials/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/namespace.tmpl.partial
@@ -1,9 +1,15 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 {% verbatim %}
+{{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
+{{#remarks}}
 <div class="markdown level0 remarks">{{{remarks}}}</div>
+{{/remarks}}
 {{#children}}
   <h2 id="{{id}}">{{>partials/namespaceSubtitle}}</h2>
   {{#children}}

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -1,7 +1,11 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
 <div class="markdown level0 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
 {{#inheritance.0}}
 <div class="inheritance">
   <h5>{{__global.inheritance}}</h5>

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -24,8 +24,12 @@
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
 {{/syntax}}
+{{#summary}}
 <div class="markdown level1 summary">{{{summary}}}</div>
+{{/summary}}
+{{#conceptual}}
 <div class="markdown level1 conceptual">{{{conceptual}}}</div>
+{{/conceptual}}
 {{#syntax}}
 {{#parameters.0}}
 <strong>{{__global.parameters}}</strong>


### PR DESCRIPTION
When digging into the html I noticed that our html often includes these unused 'summary' and 'conceptual' divs - this change only includes these divs when the information that goes inside them is available.

updates in:
third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
third_party/docfx/templates/devsite/partials/class.tmpl.partial
third_party/docfx/templates/devsite/partials/namespace.tmpl.partial
third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial