### PR TITLE
fix: include '+' with inherited members dropdown

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -31,7 +31,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html
@@ -42,7 +42,7 @@ unmatched_node_count(implicit)</li>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.Stats</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">AnalyzeIamPolicyResponse.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -31,7 +31,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -37,7 +37,7 @@ for more information.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -24,7 +24,7 @@ public abstract class AssetServiceBase</code></pre>
     <span class="xref">AssetService.AssetServiceBase</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -25,7 +25,7 @@
     <span class="xref">AssetService.AssetServiceClient</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">Grpc.Core.ClientBase&lt;Google.Cloud.Asset.V1.AssetService.AssetServiceClient&gt;.WithHost(System.String)</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -23,7 +23,7 @@
     <span class="xref">AssetService</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -23,7 +23,7 @@
     <span class="xref">AssetServiceClient</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -24,7 +24,7 @@
     <span class="xref">AssetServiceClientBuilder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">Google.Api.Gax.Grpc.ClientBuilderBase&lt;Google.Cloud.Asset.V1.AssetServiceClient&gt;.CopyCommonSettings&lt;TOther&gt;(Google.Api.Gax.Grpc.ClientBuilderBase&lt;TOther&gt;)</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -24,7 +24,7 @@
     <span class="xref">AssetServiceClientImpl</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DefaultEndpoint">AssetServiceClient.DefaultEndpoint</a>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -24,7 +24,7 @@
     <span class="xref">AssetServiceSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">Google.Api.Gax.Grpc.ServiceSettingsBase.VersionHeaderBuilder</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -28,7 +28,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -32,7 +32,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisRequest.html">ExportIamPolicyAnalysisRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ExportIamPolicyAnalysisResponse.html">ExportIamPolicyAnalysisResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -34,7 +34,7 @@ Pub/Sub topics.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -28,7 +28,7 @@
     <span><span class="xref">System.IEquatable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.GetType()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicyAnalysisOutputConfig.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -33,7 +33,7 @@ any of them.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -32,7 +32,7 @@ directly or indirectly.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -32,7 +32,7 @@ projects.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicyAnalysisQuery.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -45,7 +45,7 @@ combinations.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -32,7 +32,7 @@ aip.dev/not-precedent: Identity name is not a resource. --)</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicyAnalysisResult.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -31,7 +31,7 @@ access control lists.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -31,7 +31,7 @@ resource, an identity or an access.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicySearchResult.Types.Explanation.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">IamPolicySearchResult.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -28,7 +28,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -31,7 +31,7 @@
     <span><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -33,7 +33,7 @@
     <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -31,7 +31,7 @@
     <span><span class="xref">Google.Api.Gax.Grpc.IPageRequest</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -33,7 +33,7 @@
     <span><span class="xref">System.Collections.IEnumerable</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.Types.html
@@ -23,7 +23,7 @@
     <span class="xref">TemporalAsset.Types</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -31,7 +31,7 @@ when it was observed and its status during that window.</p>
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -30,7 +30,7 @@
     <span><span class="xref">Google.Protobuf.IDeepCloneable</span>&lt;<a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a>&gt;</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">System.Object.ToString()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
@@ -21,7 +21,7 @@
     <span><span class="xref">com.google.protobuf.AbstractMessageLite.InternalOneOfEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
@@ -41,7 +41,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
@@ -24,7 +24,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
@@ -53,7 +53,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechBlockingStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractBlockingStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechFutureStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractFutureStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
@@ -27,7 +27,7 @@
     <span><span class="xref">io.grpc.BindableService</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractAsyncStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
@@ -23,7 +23,7 @@
     <span class="xref">SpeechGrpc</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
@@ -21,7 +21,7 @@
     <span class="xref">SpeechProto</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.Builder.applyToAllUnaryMethods(java.lang.Iterable&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;&gt;,com.google.api.core.ApiFunction&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;,java.lang.Void&gt;)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">SpeechSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.&lt;B&gt;toBuilder()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -21,7 +21,7 @@
     <span><span class="xref">com.google.protobuf.AbstractMessageLite.InternalOneOfEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
@@ -66,7 +66,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
@@ -66,7 +66,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.WordInfoOrBuilder.html">WordInfoOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1.WordInfoOrBuilder.html">WordInfoOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.grpc.GrpcStubCallableFactory</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
@@ -25,7 +25,7 @@
     <span class="xref">GrpcSpeechStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStub.html#com_google_cloud_speech_v1_stub_SpeechStub_close__">SpeechStub.close()</a>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechStubSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.Builder.&lt;B&gt;build()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">SpeechStubSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.getClock()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html">AsyncRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html">AsyncRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html">AsyncRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html">AsyncRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html">AsyncRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html">AsyncRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
@@ -20,7 +20,7 @@
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
@@ -30,7 +30,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechGrpc.SpeechBlockingStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechGrpc.SpeechFutureStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
@@ -27,7 +27,7 @@
     <span><span class="xref">io.grpc.BindableService</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechGrpc.SpeechStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
@@ -23,7 +23,7 @@
     <span class="xref">SpeechGrpc</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
@@ -21,7 +21,7 @@
     <span class="xref">SpeechProto</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -20,7 +20,7 @@
     <span><span class="xref">com.google.protobuf.Internal.EnumLite</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
@@ -74,7 +74,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
@@ -74,7 +74,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html">SyncRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html">SyncRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html">SyncRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html">SyncRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListCustomClassesFixedSizeCollection</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractFixedSizeCollection.createCollection(java.util.List&lt;PageT&gt;,int)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListCustomClassesPage</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractPage.createPage(com.google.api.gax.rpc.PageContext&lt;RequestT,ResponseT,ResourceT&gt;,ResponseT)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListCustomClassesPagedResponse</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractPagedListResponse.expandToFixedSizeCollection(int)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListPhraseSetFixedSizeCollection</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractFixedSizeCollection.createCollection(java.util.List&lt;PageT&gt;,int)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListPhraseSetPage</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractPage.createPage(com.google.api.gax.rpc.PageContext&lt;RequestT,ResponseT,ResourceT&gt;,ResponseT)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
@@ -22,7 +22,7 @@
     <span class="xref">AdaptationClient.ListPhraseSetPagedResponse</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.paging.AbstractPagedListResponse.expandToFixedSizeCollection(int)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
@@ -55,7 +55,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
@@ -25,7 +25,7 @@
     <span class="xref">AdaptationGrpc.AdaptationBlockingStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractBlockingStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
@@ -25,7 +25,7 @@
     <span class="xref">AdaptationGrpc.AdaptationFutureStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractFutureStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
@@ -27,7 +27,7 @@
     <span><span class="xref">io.grpc.BindableService</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
@@ -25,7 +25,7 @@
     <span class="xref">AdaptationGrpc.AdaptationStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractAsyncStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
@@ -23,7 +23,7 @@
     <span class="xref">AdaptationGrpc</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">AdaptationSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.Builder.applyToAllUnaryMethods(java.lang.Iterable&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;&gt;,com.google.api.core.ApiFunction&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;,java.lang.Void&gt;)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">AdaptationSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.&lt;B&gt;toBuilder()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html">CreateCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html">CreateCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html">CreatePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html">CreatePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html">CustomClassOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html#com_google_cloud_speech_v1p1beta1_CustomClass_ClassItemOrBuilder">CustomClass.ClassItemOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html#com_google_cloud_speech_v1p1beta1_CustomClass_ClassItemOrBuilder">CustomClass.ClassItemOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html">CustomClassOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
@@ -23,7 +23,7 @@
     <span class="xref">CustomClassName.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
@@ -25,7 +25,7 @@
     <span><span class="xref">com.google.api.resourcenames.ResourceName</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html">DeleteCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html">DeleteCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html">DeletePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html">DeletePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html">GetCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html">GetCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html">GetPhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html">GetPhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html">ListCustomClassesRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html">ListCustomClassesRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html">ListCustomClassesResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html">ListCustomClassesResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html">ListPhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html">ListPhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html">ListPhraseSetResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html">ListPhraseSetResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
@@ -23,7 +23,7 @@
     <span class="xref">LocationName.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
@@ -25,7 +25,7 @@
     <span><span class="xref">com.google.api.resourcenames.ResourceName</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html">PhraseSetOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
@@ -48,7 +48,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html#com_google_cloud_speech_v1p1beta1_PhraseSet_PhraseOrBuilder">PhraseSet.PhraseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
@@ -48,7 +48,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html#com_google_cloud_speech_v1p1beta1_PhraseSet_PhraseOrBuilder">PhraseSet.PhraseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html">PhraseSetOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
@@ -23,7 +23,7 @@
     <span class="xref">PhraseSetName.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
@@ -25,7 +25,7 @@
     <span><span class="xref">com.google.api.resourcenames.ResourceName</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
@@ -21,7 +21,7 @@
     <span><span class="xref">com.google.protobuf.AbstractMessageLite.InternalOneOfEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
@@ -34,7 +34,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
@@ -42,7 +42,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
@@ -24,7 +24,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
@@ -33,7 +33,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html">SpeechAdaptationOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html">SpeechAdaptationOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
@@ -21,7 +21,7 @@
     <span class="xref">SpeechAdaptationProto</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
@@ -53,7 +53,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechBlockingStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractBlockingStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechFutureStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractFutureStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
@@ -27,7 +27,7 @@
     <span><span class="xref">io.grpc.BindableService</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
@@ -25,7 +25,7 @@
     <span class="xref">SpeechGrpc.SpeechStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">io.grpc.stub.AbstractAsyncStub.&lt;T&gt;newStub(io.grpc.stub.AbstractStub.StubFactory&lt;T&gt;,io.grpc.Channel)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
@@ -23,7 +23,7 @@
     <span class="xref">SpeechGrpc</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
@@ -21,7 +21,7 @@
     <span class="xref">SpeechProto</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
@@ -21,7 +21,7 @@
     <span class="xref">SpeechResourceProto</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.Builder.applyToAllUnaryMethods(java.lang.Iterable&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;&gt;,com.google.api.core.ApiFunction&lt;com.google.api.gax.rpc.UnaryCallSettings.Builder&lt;?,?&gt;,java.lang.Void&gt;)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">SpeechSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.ClientSettings.&lt;B&gt;toBuilder()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
@@ -32,7 +32,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
@@ -21,7 +21,7 @@
     <span><span class="xref">com.google.protobuf.AbstractMessageLite.InternalOneOfEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
@@ -35,7 +35,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
@@ -66,7 +66,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
@@ -23,7 +23,7 @@
     <span><span class="xref">com.google.protobuf.ProtocolMessageEnum</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Enum.&lt;T&gt;valueOf(java.lang.Class&lt;T&gt;,java.lang.String)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
@@ -66,7 +66,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html">UpdateCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html">UpdateCustomClassRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html">UpdatePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html">UpdatePhraseSetRequestOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html">WordInfoOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.Builder.findInitializationErrors()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
@@ -31,7 +31,7 @@
     <span><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html">WordInfoOrBuilder</a></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.protobuf.AbstractMessage.equals(java.lang.Object)</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">AdaptationStubSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.Builder.&lt;B&gt;build()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">AdaptationStubSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.getClock()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.grpc.GrpcStubCallableFactory</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
@@ -25,7 +25,7 @@
     <span class="xref">GrpcAdaptationStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html#com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_close__">AdaptationStub.close()</a>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.grpc.GrpcStubCallableFactory</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
@@ -25,7 +25,7 @@
     <span class="xref">GrpcSpeechStub</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html#com_google_cloud_speech_v1p1beta1_stub_SpeechStub_close__">SpeechStub.close()</a>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
@@ -28,7 +28,7 @@
     <span><span class="xref">com.google.api.gax.core.BackgroundResource</span></span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">java.lang.Object.clone()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
@@ -24,7 +24,7 @@
     <span class="xref">SpeechStubSettings.Builder</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.Builder.&lt;B&gt;build()</span>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
@@ -43,7 +43,7 @@
     <span class="xref">SpeechStubSettings</span>
   </div>
   <div class="inheritedMembers expandable">
-    <h2 class="expand-control">Inherited Members</h2>
+    <h2 class="showalways">Inherited Members</h2>
     <div>
       <span class="xref">com.google.api.gax.rpc.StubSettings.getClock()</span>
     </div>

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -31,7 +31,7 @@
 {{/implements.0}}
 {{#inheritedMembers.0}}
 <div class="inheritedMembers expandable">
-  <h2 class="expand-control">{{__global.inheritedMembers}}</h2>
+  <h2 class="showalways">{{__global.inheritedMembers}}</h2>
 {{/inheritedMembers.0}}
 {{#inheritedMembers}}
   <div>

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -19,7 +19,7 @@
 {{/inheritance.0}}
 {{#inheritedMembers.0}}
 <div class="inheritedMembers expandable">
-  <h2 class="expand-control">{{__global.inheritedMembers}}</h2>
+  <h2 class="showalways">{{__global.inheritedMembers}}</h2>
 {{/inheritedMembers.0}}
 {{#inheritedMembers}}
   <div>


### PR DESCRIPTION
Devsite-chat suggested using 'showalways' class rather than originally suggested 'expand-control' to get the dropdown button to display. Tested and staged example and is working correctly now