### PR TITLE
feat: support module types in template

### DIFF
--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -23,6 +23,7 @@ exports.transform = function (model) {
         if (model.children) groupChildren(model, namespaceCategory);
         model[getTypePropertyName(model.type)] = true;
         break;
+      case 'module':
       case 'class':
       case 'interface':
       case 'struct':
@@ -293,6 +294,7 @@ function getDefinitions(category) {
     "package":      { inPackage: true,      typePropertyName: "inPackage",      id: "packages" },
     "namespace":    { inNamespace: true,    typePropertyName: "inNamespace",    id: "namespaces" },
     "class":        { inClass: true,        typePropertyName: "inClass",        id: "classes" },
+    "module":       { inModule: true,       typePropertyName: "inModule",       id: "modules" },
     "struct":       { inStruct: true,       typePropertyName: "inStruct",       id: "structs" },
     "interface":    { inInterface: true,    typePropertyName: "inInterface",    id: "interfaces" },
     "enum":         { inEnum: true,         typePropertyName: "inEnum",         id: "enums" },

--- a/third_party/docfx/templates/devsite/partials/namespaceSubtitle.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/namespaceSubtitle.tmpl.partial
@@ -4,6 +4,9 @@
 {{__global.namespacesInSubtitle}}
 {{/inNamespace}}
 {{/isNamespace}}
+{{#inModule}}
+{{__global.modulesInSubtitle}}
+{{/inModule}}
 {{#inClass}}
 {{__global.classesInSubtitle}}
 {{/inClass}}

--- a/third_party/docfx/templates/devsite/partials/title.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/title.tmpl.partial
@@ -5,6 +5,9 @@ Package {{name.0.value}}
 {{#inNamespace}}
 Namespace {{name.0.value}}
 {{/inNamespace}}
+{{#inModule}}
+Module {{name.0.value}}
+{{/inModule}}
 {{#inClass}}
 Class {{name.0.value}}
 {{/inClass}}

--- a/third_party/docfx/templates/devsite/token.json
+++ b/third_party/docfx/templates/devsite/token.json
@@ -3,6 +3,7 @@
   "constsInSubtitle": "Constants",
 
   "namespacesInSubtitle": "Namespaces",
+  "modulesInSubtitle": "Modules",
   "classesInSubtitle": "Classes",
   "structsInSubtitle": "Structs",
   "interfacesInSubtitle": "Interfaces",


### PR DESCRIPTION
Adding handlers for `type: module` specified in YAML.

Since modules are similar to how classes are in Python, I decided to group them under `model.isClass` for now. May need to come back and revisit this section to better accommodate handling modules, but looking to handle that more on the YAML generator side.

Fixes #187 