### PR TITLE
fix: display code element only when necessary

### DIFF
--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.httpmethod.html
@@ -12,9 +12,6 @@
   
   
   {% verbatim %}
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level0 summary"><p>HttpMethod enum.</p>
 </div>
   {% endverbatim %}

--- a/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
+++ b/testdata/goldens/nodejs/google.cloud.scheduler.v1.job.state.html
@@ -12,9 +12,6 @@
   
   
   {% verbatim %}
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level0 summary"><p>State enum.</p>
 </div>
   {% endverbatim %}

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html
@@ -27,9 +27,6 @@
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_client_BigQueryReadClient_transport" data-uid="google.cloud.bigquery_storage_v1.client.BigQueryReadClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html
@@ -24,9 +24,6 @@
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsIterable_pages" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.pages" class="notranslate">pages</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>A generator of all pages in the stream.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html
@@ -24,15 +24,9 @@
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage_num_items" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.num_items" class="notranslate">num_items</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>int: Total items in the page.</p>
 </div>
   <h3 id="google_cloud_bigquery_storage_v1_reader_ReadRowsPage_remaining" data-uid="google.cloud.bigquery_storage_v1.reader.ReadRowsPage.remaining" class="notranslate">remaining</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>int: Remaining items in the page.</p>
 </div>
   <h2 id="methods">Methods

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.html
@@ -25,9 +25,6 @@ The Read API can be used to read data from BigQuery.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadAsyncClient_transport" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
@@ -25,9 +25,6 @@ The Read API can be used to read data from BigQuery.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1_services_big_query_read_BigQueryReadClient_transport" data-uid="google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html
@@ -27,9 +27,6 @@
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_client_BigQueryReadClient_transport" data-uid="google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.html
@@ -27,9 +27,6 @@ use Write API at the same time.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadAsyncClient_transport" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.html
@@ -27,9 +27,6 @@ use Write API at the same time.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_read_BigQueryReadClient_transport" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.html
@@ -25,9 +25,6 @@ The Write API can be used to write data to BigQuery.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteAsyncClient_transport" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.html
+++ b/testdata/goldens/python-small/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.html
@@ -25,9 +25,6 @@ The Write API can be used to write data to BigQuery.</p>
   <h2 id="properties">Properties
   </h2>
   <h3 id="google_cloud_bigquery_storage_v1beta2_services_big_query_write_BigQueryWriteClient_transport" data-uid="google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.transport" class="notranslate">transport</h3>
-  <div class="codewrapper">
-    <pre><code class="prettyprint"></code></pre>
-  </div>
   <div class="markdown level1 summary"><p>Return the transport used by the client instance.</p>
 </div>
   <strong>Returns</strong>

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -1,9 +1,11 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 {% verbatim %}
+{{#syntax.content.0}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
+{{/syntax.content.0}}
 {{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
 {{/summary}}

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -19,11 +19,11 @@
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
 <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h3>
-{{#syntax}}
+{{#syntax.content.0}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
-{{/syntax}}
+{{/syntax.content.0}}
 {{#summary}}
 <div class="markdown level1 summary">{{{summary}}}</div>
 {{/summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.tmpl.partial
@@ -19,11 +19,11 @@
 <a id="{{id}}" data-uid="{{uid}}"></a>
 {{/overload}}
 <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h3>
-{{#syntax}}
+{{#syntax.content.0}}
 <div class="codewrapper">
   <pre><code class="prettyprint">{{syntax.content.0.value}}</code></pre>
 </div>
-{{/syntax}}
+{{/syntax.content.0}}
 {{#summary}}
 <div class="markdown level1 summary">{{{summary}}}</div>
 {{/summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -46,11 +46,11 @@
       {{^inTypes}}
       <h3 id="{{id}}" data-uid="{{uid}}" class="notranslate">{{name.0.value}}</h3>
       {{/inTypes}}
-      {{#syntax}}
+      {{#syntax.content.0}}
       <div class="codewrapper">
         <pre><code class="prettyprint">{{{syntax.content.0.value}}}</code></pre>
       </div>
-      {{/syntax}}
+      {{/syntax.content.0}}
       <div class="markdown level1 summary">{{{summary}}}</div>
       <div class="markdown level1 conceptual">{{{conceptual}}}</div>
       {{#syntax}}


### PR DESCRIPTION
Adding in check guards to make sure that elements only get added in when necessary.

Simply checking for `{{#syntax}}` isn't good enough, and in case there's multiple entries we can't just check for `{{#syntax.content}}`. We'll simply check for existence of at least 1 entry under `syntax.content` by checking for `{{#syntax.content.0}}`.

Fixes #219 

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR