### PR TITLE
fix(third_party): mark more fields as verbatim

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The request query.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,8 +112,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. Output configuration indicating where the results will be output to.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html">AnalyzeIamPolicyLongrunningResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="implements">Implements</h2>
   <div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The request query.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,6 +112,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration ExecutionTimeout { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. Amount of time executable has to complete.  See JSON representation of
 <a href="https://developers.google.com/protocol-buffers/docs/proto3#json">Duration</a>.</p>
 <p>If this field is set with a value less than the RPC deadline, and the
@@ -117,6 +122,7 @@ Otherwise, your query&apos;s execution will continue until the RPC deadline.
 If it&apos;s not finished until then, you will get a  DEADLINE_EXCEEDED error.</p>
 <p>Default is empty.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html">AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery AnalysisQuery { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The analysis query.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,9 +112,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult&gt; AnalysisResults { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of [IamPolicyAnalysisResult][google.cloud.asset.v1.IamPolicyAnalysisResult] that matches the analysis query, or
 empty if no result is found.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,9 +137,11 @@ empty if no result is found.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Represents whether all entries in the [analysis_results][google.cloud.asset.v1.AnalyzeIamPolicyResponse.IamPolicyAnalysis.analysis_results] have been
 fully explored to answer the query.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,8 +162,10 @@ fully explored to answer the query.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisState&gt; NonCriticalErrors { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of non-critical errors happened during the query handling.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html">AnalyzeIamPolicyResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,10 +88,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Represents whether all entries in the [main_analysis][google.cloud.asset.v1.AnalyzeIamPolicyResponse.main_analysis] and
 [service_account_impersonation_analysis][google.cloud.asset.v1.AnalyzeIamPolicyResponse.service_account_impersonation_analysis] have been fully explored to
 answer the query in the request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,8 +114,10 @@ answer the query in the request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis MainAnalysis { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The main analysis that matches the original request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,10 +138,12 @@ answer the query in the request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis&gt; ServiceAccountImpersonationAnalysis { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The service account impersonation analysis if
 [AnalyzeIamPolicyRequest.analyze_service_account_impersonation][] is
 enabled.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -80,12 +80,14 @@ for more information.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Asset.html">Asset</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -114,9 +116,11 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessLevel AccessLevel { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-levels">access level user
 guide</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,9 +141,11 @@ guide</a>.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AccessPolicy AccessPolicy { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/access-context-manager/docs/overview#access-policies">access policy user
 guide</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,6 +166,7 @@ guide</a>.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Ancestors { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The ancestry path of an asset in Google Cloud <a href="https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy">resource
 hierarchy</a>,
 represented as a list of relative resource names. An ancestry path starts
@@ -168,6 +175,7 @@ is a project, folder, or organization, the ancestry path starts from the
 asset itself.</p>
 <p>Example: <code>[&amp;quot;projects/123456789&amp;quot;, &amp;quot;folders/5432&amp;quot;, &amp;quot;organizations/1234&amp;quot;]</code></p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -188,11 +196,13 @@ asset itself.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The type of the asset. Example: <code>compute.googleapis.com/Disk</code></p>
 <p>See <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types">Supported asset
 types</a>
 for more information.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -213,6 +223,7 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy IamPolicy { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A representation of the Cloud IAM policy set on a Google Cloud resource.
 There can be a maximum of one Cloud IAM policy set on any given resource.
 In addition, Cloud IAM policies inherit their granted access scope from any
@@ -223,6 +234,7 @@ the hierarchy. See
 <a href="https://cloud.google.com/iam/docs/policies#inheritance">this topic</a> for
 more information.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,12 +255,14 @@ more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The full name of the asset. Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code></p>
 <p>See <a href="https://cloud.google.com/apis/design/resource_names#full_resource_name">Resource
 names</a>
 for more information.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -269,11 +283,13 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Policy&gt; OrgPolicy { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A representation of an <a href="https://cloud.google.com/resource-manager/docs/organization-policy/overview#organization_policy">organization
 policy</a>.
 There can be more than one organization policy with different constraints
 set on a given resource.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -294,10 +310,12 @@ set on a given resource.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Inventory OsInventory { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A representation of runtime OS Inventory information. See <a href="https://cloud.google.com/compute/docs/instances/os-inventory-management">this
 topic</a>
 for more information.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -318,8 +336,10 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Resource Resource { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A representation of the resource.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -340,8 +360,10 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Asset.html#Google_Cloud_Asset_V1_Asset_Name">Name</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -362,9 +384,11 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ServicePerimeter ServicePerimeter { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Please also refer to the <a href="https://cloud.google.com/vpc-service-controls/docs/overview">service perimeter user
 guide</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -385,9 +409,11 @@ guide</a>.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The last update timestamp of an asset. update_time is updated when
 create/update/delete operation is performed.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
@@ -50,9 +50,11 @@ public abstract class AssetServiceBase</code></pre>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -63,6 +65,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -76,6 +79,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -98,6 +102,7 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; AnalyzeIamPolicyLongrunning(AnalyzeIamPolicyLongrunningRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -108,6 +113,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -118,6 +124,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -131,6 +138,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -153,6 +161,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -161,6 +170,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,6 +181,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -184,6 +195,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -206,9 +218,11 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeed(CreateFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,6 +233,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -232,6 +247,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -254,8 +270,10 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Empty&gt; DeleteFeed(DeleteFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -266,6 +284,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -279,6 +298,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -301,6 +321,7 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&gt; ExportAssets(ExportAssetsRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -312,6 +333,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,6 +344,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -335,6 +358,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -357,8 +381,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeed(GetFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,6 +395,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -382,6 +409,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -404,9 +432,11 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListAssetsResponse&gt; ListAssets(ListAssetsRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,6 +447,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -430,6 +461,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -452,8 +484,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeeds(ListFeedsRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,6 +498,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -477,6 +512,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -499,11 +535,13 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,6 +552,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -527,6 +566,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -549,11 +589,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;SearchAllResourcesResponse&gt; SearchAllResources(SearchAllResourcesRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,6 +606,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -577,6 +620,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -599,8 +643,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeed(UpdateFeedRequest request, ServerCallContext context)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,6 +657,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -624,6 +671,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
@@ -57,15 +57,19 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Protected parameterless constructor to allow creation of test doubles.</p>
 </div>
+  {% endverbatim %}
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_CallInvoker_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.CallInvoker)" class="notranslate">AssetServiceClient(CallInvoker)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(CallInvoker callInvoker)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new client for AssetService that uses a custom <code>CallInvoker</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -76,6 +80,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.CallInvoker</span></td>
         <td><span class="parametername">callInvoker</span></td>
@@ -83,6 +88,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_Channel_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.Channel)" class="notranslate">AssetServiceClient(Channel)</h3>
@@ -90,8 +96,10 @@
     <pre><code class="prettyprint">[Obsolete(&quot;This constructor overload is present for compatibility only, and will be removed in the next major version&quot;)]
 public AssetServiceClient(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new client using a channel.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -102,6 +110,7 @@ public AssetServiceClient(Channel channel)</code></pre>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -109,14 +118,17 @@ public AssetServiceClient(Channel channel)</code></pre>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ChannelBase_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ChannelBase)" class="notranslate">AssetServiceClient(ChannelBase)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClient(ChannelBase channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new client for AssetService</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +139,7 @@ public AssetServiceClient(Channel channel)</code></pre>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.ChannelBase</span></td>
         <td><span class="parametername">channel</span></td>
@@ -134,14 +147,17 @@ public AssetServiceClient(Channel channel)</code></pre>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetService_AssetServiceClient__ctor_Grpc_Core_ClientBase_ClientBaseConfiguration_" data-uid="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.#ctor(Grpc.Core.ClientBase.ClientBaseConfiguration)" class="notranslate">AssetServiceClient(ClientBase.ClientBaseConfiguration)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AssetServiceClient(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Protected constructor to allow creation of configured clients.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,6 +168,7 @@ public AssetServiceClient(Channel channel)</code></pre>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.ClientBase.ClientBaseConfiguration</span></td>
         <td><span class="parametername">configuration</span></td>
@@ -159,6 +176,7 @@ public AssetServiceClient(Channel channel)</code></pre>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -167,9 +185,11 @@ public AssetServiceClient(Channel channel)</code></pre>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,6 +200,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -193,6 +214,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -215,9 +237,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -228,6 +252,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -253,6 +278,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -275,9 +301,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -288,6 +316,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -301,6 +330,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -323,9 +353,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -336,6 +368,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -361,6 +394,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -383,6 +417,7 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation AnalyzeIamPolicyLongrunning(AnalyzeIamPolicyLongrunningRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -393,6 +428,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,6 +439,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -416,6 +453,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -438,6 +476,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation AnalyzeIamPolicyLongrunning(AnalyzeIamPolicyLongrunningRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -448,6 +487,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,6 +498,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -483,6 +524,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -505,6 +547,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; AnalyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -515,6 +558,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,6 +569,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -538,6 +583,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -560,6 +606,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; AnalyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -570,6 +617,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,6 +628,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -605,6 +654,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -627,6 +677,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -635,6 +686,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -645,6 +697,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -658,6 +711,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -680,6 +734,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -688,6 +743,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,6 +754,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -723,6 +780,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -745,6 +803,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -753,6 +812,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -763,6 +823,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -776,6 +837,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -798,6 +860,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -806,6 +869,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,6 +880,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -841,6 +906,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -863,9 +929,11 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -876,6 +944,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -889,6 +958,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -911,9 +981,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -924,6 +996,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -949,6 +1022,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,9 +1045,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -984,6 +1060,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -997,6 +1074,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,9 +1097,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1032,6 +1112,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1057,6 +1138,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1079,9 +1161,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operations.OperationsClient CreateOperationsClient()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new instance of <span class="xref">Google.LongRunning.Operations.OperationsClient</span> using the same call invoker as
 this client.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1103,8 +1187,10 @@ this client.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1115,6 +1201,7 @@ this client.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1128,6 +1215,7 @@ this client.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1150,8 +1238,10 @@ this client.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Empty DeleteFeed(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1162,6 +1252,7 @@ this client.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1187,6 +1278,7 @@ this client.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1209,8 +1301,10 @@ this client.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,6 +1315,7 @@ this client.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1234,6 +1329,7 @@ this client.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1256,8 +1352,10 @@ this client.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Empty&gt; DeleteFeedAsync(DeleteFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1268,6 +1366,7 @@ this client.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1293,6 +1392,7 @@ this client.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1315,6 +1415,7 @@ this client.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1326,6 +1427,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1336,6 +1438,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1349,6 +1452,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1371,6 +1475,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation ExportAssets(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1382,6 +1487,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1392,6 +1498,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1417,6 +1524,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1439,6 +1547,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1450,6 +1559,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1460,6 +1570,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1473,6 +1584,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1495,6 +1607,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Operation&gt; ExportAssetsAsync(ExportAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1506,6 +1619,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1516,6 +1630,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1541,6 +1656,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1563,8 +1679,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1575,6 +1693,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1588,6 +1707,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1610,8 +1730,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1622,6 +1744,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1647,6 +1770,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1669,8 +1793,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1681,6 +1807,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1694,6 +1821,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1716,8 +1844,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1728,6 +1858,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1753,6 +1884,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1775,9 +1907,11 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListAssetsResponse ListAssets(ListAssetsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1788,6 +1922,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1801,6 +1936,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1823,9 +1959,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListAssetsResponse ListAssets(ListAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1836,6 +1974,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1861,6 +2000,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1883,9 +2023,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListAssetsResponse&gt; ListAssetsAsync(ListAssetsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1896,6 +2038,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1909,6 +2052,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1931,9 +2075,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListAssetsResponse&gt; ListAssetsAsync(ListAssetsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1944,6 +2090,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1969,6 +2116,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1991,8 +2139,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2003,6 +2153,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2016,6 +2167,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2038,8 +2190,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2050,6 +2204,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2075,6 +2230,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2097,8 +2253,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2109,6 +2267,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2122,6 +2281,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2144,8 +2304,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2156,6 +2318,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2181,6 +2344,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2203,8 +2367,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override AssetService.AssetServiceClient NewInstance(ClientBase.ClientBaseConfiguration configuration)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new instance of client from given <code>ClientBaseConfiguration</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2215,12 +2381,14 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.ClientBase.ClientBaseConfiguration</span></td>
         <td><span class="parametername">configuration</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2244,11 +2412,13 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2259,6 +2429,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2272,6 +2443,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2294,11 +2466,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllIamPoliciesResponse SearchAllIamPolicies(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2309,6 +2483,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2334,6 +2509,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2356,11 +2532,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2371,6 +2549,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2384,6 +2563,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2406,11 +2586,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllIamPoliciesResponse&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2421,6 +2603,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2446,6 +2629,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2468,11 +2652,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2483,6 +2669,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2496,6 +2683,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2518,11 +2706,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual SearchAllResourcesResponse SearchAllResources(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2533,6 +2723,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2558,6 +2749,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2580,11 +2772,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2595,6 +2789,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2608,6 +2803,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2630,11 +2826,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;SearchAllResourcesResponse&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2645,6 +2843,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2670,6 +2869,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2692,8 +2892,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2704,6 +2906,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2717,6 +2920,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2739,8 +2943,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2751,6 +2957,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2776,6 +2983,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2798,8 +3006,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallOptions options)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2810,6 +3020,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2823,6 +3034,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2845,8 +3057,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AsyncUnaryCall&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, Metadata headers = null, DateTime? deadline = default(DateTime? ), CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2857,6 +3071,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2882,6 +3097,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetService.html
@@ -49,8 +49,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static ServerServiceDefinition BindService(AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates service definition that can be registered with a server</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -61,6 +63,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html">AssetService.AssetServiceBase</a></td>
         <td><span class="parametername">serviceImpl</span></td>
@@ -68,6 +71,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -89,9 +93,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static void BindService(ServiceBinderBase serviceBinder, AssetService.AssetServiceBase serviceImpl)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Register service method with a service binder with or without implementation. Useful when customizing the  service binding logic.
 Note: this method is part of an experimental API that can change or be removed without any prior notice.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -102,6 +108,7 @@ Note: this method is part of an experimental API that can change or be removed w
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Grpc.Core.ServiceBinderBase</span></td>
         <td><span class="parametername">serviceBinder</span></td>
@@ -115,6 +122,7 @@ Note: this method is part of an experimental API that can change or be removed w
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClient.html
@@ -56,8 +56,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient AnalyzeIamPolicyLongrunningOperationsClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The long-running operations client for <code>AnalyzeIamPolicyLongrunning</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,9 +80,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string DefaultEndpoint { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The default endpoint for the AssetService service, which is a host of &quot;cloudasset.googleapis.com&quot; and a port
 of 443.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -101,8 +105,10 @@ of 443.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static IReadOnlyList&lt;string&gt; DefaultScopes { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The default AssetService scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,8 +133,10 @@ of 443.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -149,8 +157,10 @@ of 443.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -173,9 +183,11 @@ of 443.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -186,6 +198,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -199,6 +212,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -221,9 +235,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -234,6 +250,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -247,6 +264,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -269,9 +287,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -282,6 +302,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -295,6 +316,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,6 +339,7 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt; AnalyzeIamPolicyLongrunning(AnalyzeIamPolicyLongrunningRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -327,6 +350,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,6 +361,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -350,6 +375,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -372,6 +398,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt;&gt; AnalyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -382,6 +409,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,6 +420,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -405,6 +434,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -427,6 +457,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt;&gt; AnalyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -437,6 +468,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,6 +479,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -460,6 +493,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -482,6 +516,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -490,6 +525,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,6 +536,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -513,6 +550,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -535,6 +573,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -543,6 +582,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,6 +593,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -566,6 +607,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -588,6 +630,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -596,6 +639,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,6 +650,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -619,6 +664,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -641,9 +687,11 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceClient Create()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Synchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -665,9 +713,11 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task&lt;AssetServiceClient&gt; CreateAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asynchronously creates a <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html">AssetServiceClient</a> using the default credentials, endpoint and
 settings. To specify custom credentials or other settings, use <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClientBuilder.html">AssetServiceClientBuilder</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,6 +728,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.Threading.CancellationToken</span></td>
         <td><span class="parametername">cancellationToken</span></td>
@@ -685,6 +736,7 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -707,9 +759,11 @@ settings. To specify custom credentials or other settings, use <a class="xref" h
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,6 +774,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -733,6 +788,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -755,9 +811,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed CreateFeed(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -768,6 +826,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -785,6 +844,7 @@ should be created in. It can only be an organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -807,9 +867,11 @@ should be created in. It can only be an organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -820,6 +882,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -833,6 +896,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -855,9 +919,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -868,6 +934,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -881,6 +948,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -903,9 +971,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -916,6 +986,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -933,6 +1004,7 @@ should be created in. It can only be an organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -955,9 +1027,11 @@ should be created in. It can only be an organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; CreateFeedAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -968,6 +1042,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -985,6 +1060,7 @@ should be created in. It can only be an organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1007,8 +1083,10 @@ should be created in. It can only be an organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1019,6 +1097,7 @@ should be created in. It can only be an organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1032,14 +1111,17 @@ should be created in. It can only be an organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_FeedName_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(Google.Cloud.Asset.V1.FeedName,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(FeedName, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,6 +1132,7 @@ should be created in. It can only be an organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1066,14 +1149,17 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_System_String_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeed(System.String,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeed(String, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual void DeleteFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,6 +1170,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1100,14 +1187,17 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync*"></a>
   <h3 id="Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeedAsync_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceClient.DeleteFeedAsync(Google.Cloud.Asset.V1.DeleteFeedRequest,Google.Api.Gax.Grpc.CallSettings)" class="notranslate">DeleteFeedAsync(DeleteFeedRequest, CallSettings)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,6 +1208,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1131,6 +1222,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1153,8 +1245,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(DeleteFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1165,6 +1259,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1178,6 +1273,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,8 +1296,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1212,6 +1310,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1228,6 +1327,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1250,8 +1350,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1262,6 +1364,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1278,6 +1381,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1300,8 +1404,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,6 +1418,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1328,6 +1435,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1350,8 +1458,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task DeleteFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1362,6 +1472,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1378,6 +1489,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1400,6 +1512,7 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1411,6 +1524,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1421,6 +1535,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1434,6 +1549,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1456,6 +1572,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1467,6 +1584,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1477,6 +1595,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1490,6 +1609,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1512,6 +1632,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -1523,6 +1644,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1533,6 +1655,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1546,6 +1669,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1568,8 +1692,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1580,6 +1706,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1596,6 +1723,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1618,8 +1746,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1630,6 +1760,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1643,6 +1774,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1665,8 +1797,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed GetFeed(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1677,6 +1811,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1693,6 +1828,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1715,8 +1851,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1727,6 +1865,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1743,6 +1882,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1765,8 +1905,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(FeedName name, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1777,6 +1919,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1793,6 +1936,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1815,8 +1959,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1827,6 +1973,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1840,6 +1987,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1862,8 +2010,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1874,6 +2024,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1887,6 +2038,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1909,8 +2061,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1921,6 +2075,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1937,6 +2092,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1959,8 +2115,10 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; GetFeedAsync(string name, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1971,6 +2129,7 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1987,6 +2146,7 @@ organizations/organization_number/feeds/feed_id</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2009,9 +2169,11 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssets(IResourceName parent, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2022,6 +2184,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Google.Api.Gax.IResourceName</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2052,6 +2215,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2074,9 +2238,11 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssets(ListAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2087,6 +2253,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2100,6 +2267,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2122,9 +2290,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssets(string parent, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2135,6 +2305,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2165,6 +2336,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2187,9 +2359,11 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssetsAsync(IResourceName parent, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2200,6 +2374,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Google.Api.Gax.IResourceName</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2230,6 +2405,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2252,9 +2428,11 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssetsAsync(ListAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2265,6 +2443,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2278,6 +2457,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2300,9 +2480,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssetsAsync(string parent, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2313,6 +2495,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2343,6 +2526,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2365,8 +2549,10 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2377,6 +2563,7 @@ page.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2390,6 +2577,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2412,8 +2600,10 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual ListFeedsResponse ListFeeds(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2424,6 +2614,7 @@ page.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2439,6 +2630,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2461,8 +2653,10 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2473,6 +2667,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2486,6 +2681,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2508,8 +2704,10 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2520,6 +2718,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2533,6 +2732,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2555,8 +2755,10 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2567,6 +2769,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2582,6 +2785,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2604,8 +2808,10 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;ListFeedsResponse&gt; ListFeedsAsync(string parent, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2616,6 +2822,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -2631,6 +2838,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2653,9 +2861,11 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt; PollOnceAnalyzeIamPolicyLongrunning(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>AnalyzeIamPolicyLongrunning</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2666,6 +2876,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">operationName</span></td>
@@ -2679,6 +2890,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2701,9 +2913,11 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt;&gt; PollOnceAnalyzeIamPolicyLongrunningAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>AnalyzeIamPolicyLongrunning</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2714,6 +2928,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">operationName</span></td>
@@ -2727,6 +2942,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2749,8 +2965,10 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; PollOnceExportAssets(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Poll an operation once, using an <code>operationName</code> from a previous invocation of <code>ExportAssets</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2761,6 +2979,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">operationName</span></td>
@@ -2774,6 +2993,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2796,9 +3016,11 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; PollOnceExportAssetsAsync(string operationName, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asynchronously poll an operation once, using an <code>operationName</code> from a previous invocation of
 <code>ExportAssets</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2809,6 +3031,7 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">operationName</span></td>
@@ -2822,6 +3045,7 @@ listed. It can only be using project/folder/organization number (such as
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2844,11 +3068,13 @@ listed. It can only be using project/folder/organization number (such as
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2859,6 +3085,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -2872,6 +3099,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2894,11 +3122,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2909,6 +3139,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">scope</span></td>
@@ -2990,6 +3221,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3012,11 +3244,13 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3027,6 +3261,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3040,6 +3275,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3062,11 +3298,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(string scope, string query, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3077,6 +3315,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">scope</span></td>
@@ -3158,6 +3397,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3180,11 +3420,13 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3195,6 +3437,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3208,6 +3451,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3230,11 +3474,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3245,6 +3491,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">scope</span></td>
@@ -3345,6 +3592,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3367,11 +3615,13 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3382,6 +3632,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3395,6 +3646,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3417,11 +3669,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(string scope, string query, IEnumerable&lt;string&gt; assetTypes, string pageToken = null, int? pageSize = default(int? ), CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3432,6 +3686,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">scope</span></td>
@@ -3532,6 +3787,7 @@ page.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3554,10 +3810,12 @@ page.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static Task ShutdownDefaultChannelsAsync()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Shuts down any channels automatically created by <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_Create">Create()</a> and
 <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_CreateAsync_System_Threading_CancellationToken_">CreateAsync(CancellationToken)</a>. Channels which weren&apos;t automatically created are not
 affected.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3584,8 +3842,10 @@ by another call to this method.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3596,6 +3856,7 @@ by another call to this method.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a></td>
         <td><span class="parametername">feed</span></td>
@@ -3613,6 +3874,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3635,8 +3897,10 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3647,6 +3911,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3660,6 +3925,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3682,8 +3948,10 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3694,6 +3962,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a></td>
         <td><span class="parametername">feed</span></td>
@@ -3711,6 +3980,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3733,8 +4003,10 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(Feed feed, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3745,6 +4017,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a></td>
         <td><span class="parametername">feed</span></td>
@@ -3762,6 +4035,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3784,8 +4058,10 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3796,6 +4072,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3809,6 +4086,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3831,8 +4109,10 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public virtual Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CancellationToken cancellationToken)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3843,6 +4123,7 @@ organizations/organization_number/feeds/feed_id.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -3856,6 +4137,7 @@ organizations/organization_number/feeds/feed_id.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
@@ -122,8 +122,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override GrpcAdapter DefaultGrpcAdapter { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default <span class="xref">Google.Api.Gax.Grpc.GrpcAdapter</span>to use if not otherwise specified.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,8 +148,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Settings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The settings to use for RPCs, or <code>null</code> for the default settings.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,8 +174,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetServiceClient Build()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Builds the resulting client.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,8 +200,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AssetServiceClient&gt; BuildAsync(CancellationToken cancellationToken = default(CancellationToken))</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Builds the resulting client asynchronously.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.Threading.CancellationToken</span></td>
         <td><span class="parametername">cancellationToken</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -235,8 +245,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override ChannelPool GetChannelPool()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the channel pool to use when no other options are specified.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -259,8 +271,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override string GetDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the endpoint for this builder type, used if no endpoint is otherwise specified.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,8 +297,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected override IReadOnlyList&lt;string&gt; GetDefaultScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default scopes for this builder type, used if no scopes are otherwise specified.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
@@ -194,8 +194,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceClientImpl(AssetService.AssetServiceClient grpcClient, AssetServiceSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs a client wrapper for the AssetService service, with the specified gRPC client and settings.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,6 +208,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html">AssetService.AssetServiceClient</a></td>
         <td><span class="parametername">grpcClient</span></td>
@@ -219,6 +222,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -227,8 +231,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient AnalyzeIamPolicyLongrunningOperationsClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The long-running operations client for <code>AnalyzeIamPolicyLongrunning</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -251,8 +257,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override OperationsClient ExportAssetsOperationsClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The long-running operations client for <code>ExportAssets</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,8 +283,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AssetService.AssetServiceClient GrpcClient { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The underlying gRPC AssetService client</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,9 +311,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public override AnalyzeIamPolicyResponse AnalyzeIamPolicy(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -314,6 +326,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -327,6 +340,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -351,9 +365,11 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;AnalyzeIamPolicyResponse&gt; AnalyzeIamPolicyAsync(AnalyzeIamPolicyRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies to answer which identities have what accesses on
 which resources.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,6 +380,7 @@ which resources.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html">AnalyzeIamPolicyRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -377,6 +394,7 @@ which resources.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -401,6 +419,7 @@ which resources.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt; AnalyzeIamPolicyLongrunning(AnalyzeIamPolicyLongrunningRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -411,6 +430,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,6 +441,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -434,6 +455,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -458,6 +480,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;AnalyzeIamPolicyLongrunningResponse, AnalyzeIamPolicyLongrunningRequest&gt;&gt; AnalyzeIamPolicyLongrunningAsync(AnalyzeIamPolicyLongrunningRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Analyzes IAM policies asynchronously to answer which identities have what
 accesses on which resources, and writes the analysis results to a Google
 Cloud Storage or a BigQuery destination. For Cloud Storage destination, the
@@ -468,6 +491,7 @@ status. We recommend intervals of at least 2 seconds with exponential
 backoff retry to poll the operation result. The metadata contains the
 request to help callers to map responses to requests.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,6 +502,7 @@ request to help callers to map responses to requests.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html">AnalyzeIamPolicyLongrunningRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -491,6 +516,7 @@ request to help callers to map responses to requests.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -515,6 +541,7 @@ request to help callers to map responses to requests.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override BatchGetAssetsHistoryResponse BatchGetAssetsHistory(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -523,6 +550,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,6 +561,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -546,6 +575,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -570,6 +600,7 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;BatchGetAssetsHistoryResponse&gt; BatchGetAssetsHistoryAsync(BatchGetAssetsHistoryRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Batch gets the update history of assets that overlap a time window.
 For IAM_POLICY content, this API outputs history when the asset and its
 attached IAM POLICY both exist. This can create gaps in the output history.
@@ -578,6 +609,7 @@ deleted status.
 If a specified asset does not exist, this API returns an INVALID_ARGUMENT
 error.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,6 +620,7 @@ error.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -601,6 +634,7 @@ error.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -625,9 +659,11 @@ error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed CreateFeed(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -638,6 +674,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -651,6 +688,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -675,9 +713,11 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; CreateFeedAsync(CreateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a feed in a parent project/folder/organization to listen to its
 asset updates.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,6 +728,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -701,6 +742,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -725,8 +767,10 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override void DeleteFeed(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,6 +781,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -750,6 +795,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="Google.Cloud.Asset.V1.AssetServiceClient.html#Google_Cloud_Asset_V1_AssetServiceClient_DeleteFeed_Google_Cloud_Asset_V1_DeleteFeedRequest_Google_Api_Gax_Grpc_CallSettings_">AssetServiceClient.DeleteFeed(DeleteFeedRequest, CallSettings)</a></div>
@@ -758,8 +804,10 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task DeleteFeedAsync(DeleteFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Deletes an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -770,6 +818,7 @@ asset updates.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -783,6 +832,7 @@ asset updates.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -807,6 +857,7 @@ asset updates.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt; ExportAssets(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -818,6 +869,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,6 +880,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -841,6 +894,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,6 +919,7 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Operation&lt;ExportAssetsResponse, ExportAssetsRequest&gt;&gt; ExportAssetsAsync(ExportAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Exports assets with time and resource types to a given Cloud Storage
 location/BigQuery table. For Cloud Storage location destinations, the
 output format is newline-delimited JSON. Each line represents a
@@ -876,6 +931,7 @@ at least 2 seconds with exponential retry to poll the export operation
 result. For regular-size resource parent, the export operation usually
 finishes within 5 minutes.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,6 +942,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -899,6 +956,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -923,8 +981,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed GetFeed(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,6 +995,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -948,6 +1009,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -972,8 +1034,10 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; GetFeedAsync(GetFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Gets details about an asset feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -984,6 +1048,7 @@ finishes within 5 minutes.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -997,6 +1062,7 @@ finishes within 5 minutes.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1021,9 +1087,11 @@ finishes within 5 minutes.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssets(ListAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,6 +1102,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1047,6 +1116,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,9 +1141,11 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;ListAssetsResponse, Asset&gt; ListAssetsAsync(ListAssetsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists assets with time and resource types and returns paged results in
 response.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1084,6 +1156,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1097,6 +1170,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,8 +1195,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override ListFeedsResponse ListFeeds(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1133,6 +1209,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1146,6 +1223,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1170,8 +1248,10 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;ListFeedsResponse&gt; ListFeedsAsync(ListFeedsRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Lists all asset feeds in a parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1182,6 +1262,7 @@ response.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1195,6 +1276,7 @@ response.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1219,11 +1301,13 @@ response.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPolicies(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,6 +1318,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1247,6 +1332,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1271,11 +1357,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllIamPoliciesResponse, IamPolicySearchResult&gt; SearchAllIamPoliciesAsync(SearchAllIamPoliciesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all IAM policies within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllIamPolicies</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1286,6 +1374,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1299,6 +1388,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1323,11 +1413,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResources(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,6 +1430,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1351,6 +1444,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,11 +1469,13 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override PagedAsyncEnumerable&lt;SearchAllResourcesResponse, ResourceSearchResult&gt; SearchAllResourcesAsync(SearchAllResourcesRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Searches all Cloud resources within the specified scope, such as a project,
 folder, or organization. The caller must be granted the
 <code>cloudasset.assets.searchAllResources</code> permission on the desired scope,
 otherwise the request will be rejected.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1390,6 +1486,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1403,6 +1500,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1427,8 +1525,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Feed UpdateFeed(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1439,6 +1539,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1452,6 +1553,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1476,8 +1578,10 @@ otherwise the request will be rejected.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override Task&lt;Feed&gt; UpdateFeedAsync(UpdateFeedRequest request, CallSettings callSettings = null)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Updates an asset feed configuration.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1488,6 +1592,7 @@ otherwise the request will be rejected.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1501,6 +1606,7 @@ otherwise the request will be rejected.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AssetServiceSettings.html
@@ -65,8 +65,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs a new <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a> object with default settings.</p>
 </div>
+  {% endverbatim %}
   <h2 id="properties">Properties
   </h2>
   <a id="Google_Cloud_Asset_V1_AssetServiceSettings_AnalyzeIamPolicyLongrunningOperationsSettings_" data-uid="Google.Cloud.Asset.V1.AssetServiceSettings.AnalyzeIamPolicyLongrunningOperationsSettings*"></a>
@@ -74,9 +76,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings AnalyzeIamPolicyLongrunningOperationsSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.AnalyzeIamPolicyLongrunning</code> and
 <code>AssetServiceClient.AnalyzeIamPolicyLongrunningAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -101,10 +105,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicyLongrunningSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.AnalyzeIamPolicyLongrunning</code> and
 <code>AssetServiceClient.AnalyzeIamPolicyLongrunningAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,9 +134,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings AnalyzeIamPolicySettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.AnalyzeIamPolicy</code> and <code>AssetServiceClient.AnalyzeIamPolicyAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,9 +162,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings BatchGetAssetsHistorySettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.BatchGetAssetsHistory</code> and <code>AssetServiceClient.BatchGetAssetsHistoryAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,9 +190,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings CreateFeedSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.CreateFeed</code> and <code>AssetServiceClient.CreateFeedAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,9 +218,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings DeleteFeedSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.DeleteFeed</code> and <code>AssetServiceClient.DeleteFeedAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,9 +246,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationsSettings ExportAssetsOperationsSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Long Running Operation settings for calls to <code>AssetServiceClient.ExportAssets</code> and
 <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -259,9 +275,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ExportAssetsSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ExportAssets</code> and <code>AssetServiceClient.ExportAssetsAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,9 +303,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings GetFeedSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to <code>AssetServiceClient.GetFeed</code>
  and <code>AssetServiceClient.GetFeedAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,9 +331,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ListAssetsSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ListAssets</code> and <code>AssetServiceClient.ListAssetsAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -337,9 +359,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings ListFeedsSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.ListFeeds</code> and <code>AssetServiceClient.ListFeedsAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,9 +387,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllIamPoliciesSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllIamPolicies</code> and <code>AssetServiceClient.SearchAllIamPoliciesAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,9 +415,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings SearchAllResourcesSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.SearchAllResources</code> and <code>AssetServiceClient.SearchAllResourcesAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,9 +443,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CallSettings UpdateFeedSettings { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.Grpc.CallSettings</span> for synchronous and asynchronous calls to
 <code>AssetServiceClient.UpdateFeed</code> and <code>AssetServiceClient.UpdateFeedAsync</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -443,8 +473,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AssetServiceSettings Clone()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a deep clone of this object, with all the same property values.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,8 +498,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AssetServiceSettings GetDefault()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a new instance of the default <a class="xref" href="Google.Cloud.Asset.V1.AssetServiceSettings.html">AssetServiceSettings</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html">BatchGetAssetsHistoryRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of the full names of the assets.
 See: <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">https://cloud.google.com/asset-inventory/docs/resource-name-format</a>
 Example:</p>
@@ -93,6 +96,7 @@ Example:</p>
 <p>The request becomes a no-op if the asset name list is empty, and the max
 size of the asset name list is 100 in one request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,8 +117,10 @@ size of the asset name list is 100 in one request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The content type.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,10 +141,12 @@ size of the asset name list is 100 in one request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The relative name of the root asset. It can only be an
 organization number (such as &quot;organizations/123&quot;), a project ID (such as
 &quot;projects/my-project-id&quot;)&quot;, or a project number (such as &quot;projects/12345&quot;).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -159,8 +167,10 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html#Google_Cloud_Asset_V1_BatchGetAssetsHistoryRequest_Parent">Parent</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -181,6 +191,7 @@ organization number (such as &quot;organizations/123&quot;), a project ID (such 
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow ReadTimeWindow { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The time window for the asset history. Both start_time and
 end_time are optional and if set, it must be after the current time minus
 35 days. If end_time is not set, it is default to current timestamp.
@@ -188,6 +199,7 @@ If start_time is not set, the snapshot of the assets at end_time will be
 returned. The returned results contain all temporal assets whose time
 window overlap with read_time_window.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html">BatchGetAssetsHistoryResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;TemporalAsset&gt; Assets { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of assets with valid time windows.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.BigQueryDestination.html">BigQueryDestination</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,11 +88,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The BigQuery dataset in format
 &quot;projects/projectId/datasets/datasetId&quot;, to which the snapshot result
 should be exported. If this dataset does not exist, the export call returns
 an INVALID_ARGUMENT error.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,11 +115,13 @@ an INVALID_ARGUMENT error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Force { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>If the destination table already exists and this flag is <code>TRUE</code>, the
 table will be overwritten by the contents of assets snapshot. If the flag
 is <code>FALSE</code> or unset and the destination table already exists, the export
 call returns an INVALID_ARGUMEMT error.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,6 +142,7 @@ call returns an INVALID_ARGUMEMT error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public PartitionSpec PartitionSpec { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>[partition_spec] determines whether to export to partitioned table(s) and
 how to partition the data.</p>
 <p>If [partition_spec] is unset or [partition_spec.partition_key] is unset or
@@ -152,6 +159,7 @@ overwritten by the snapshot results (data in different partitions will
 remain intact); if [force] is unset or <code>FALSE</code>, it will append the data. An
 error will be returned if the schema update or data appension fails.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,6 +180,7 @@ error will be returned if the schema update or data appension fails.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool SeparateTablesPerAssetType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>If this flag is <code>TRUE</code>, the snapshot results will be written to one or
 multiple tables, each of which contains results of one asset type. The
 [force] and [partition_spec] fields will apply to each of them.</p>
@@ -197,6 +206,7 @@ Example: if exporting to table_type_A succeeds when exporting to
 table_type_B fails during one export call, the results in table_type_A will
 persist and there will not be partial results persisting in a table.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,10 +227,12 @@ persist and there will not be partial results persisting in a table.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Table { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The BigQuery table to which the snapshot result should be
 written. If this table does not exist, a new table with the given name
 will be created.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ConditionEvaluation.html">ConditionEvaluation</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ConditionEvaluation.Types.EvaluationValue EvaluationValue { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The evaluation result.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.CreateFeedRequest.html">CreateFeedRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,12 +88,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The feed details. The field <code>name</code> must be empty and it will be generated
 in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,9 +116,11 @@ organizations/organization_number/feeds/feed_id</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. This is the client-assigned asset feed identifier and it needs to
 be unique under a specific parent project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,12 +141,14 @@ be unique under a specific parent project/folder/organization.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The name of the project/folder/organization where this feed
 should be created in. It can only be an organization number (such as
 &quot;organizations/123&quot;), a folder number (such as &quot;folders/123&quot;), a project ID
 (such as &quot;projects/my-project-id&quot;)&quot;, or a project number (such as
 &quot;projects/12345&quot;).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -70,12 +70,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html">DeleteFeedRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -84,8 +86,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.DeleteFeedRequest.html#Google_Cloud_Asset_V1_DeleteFeedRequest_Name">Name</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,11 +110,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The name of the feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html">ExportAssetsRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of asset types to take a snapshot for. For example:
 &quot;compute.googleapis.com/Disk&quot;.</p>
 <p>Regular expressions are also supported. For example:</p>
@@ -103,6 +106,7 @@ snapshot all asset types. See <a href="https://cloud.google.com/asset-inventory/
 Inventory</a>
 for all supported asset types.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +127,11 @@ for all supported asset types.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name will be
 returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,8 +152,10 @@ returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. Output configuration indicating where the results will be output to.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,11 +176,13 @@ returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The relative name of the root asset. This can only be an
 organization number (such as &quot;organizations/123&quot;), a project ID (such as
 &quot;projects/my-project-id&quot;), or a project number (such as &quot;projects/12345&quot;),
 or a folder number (such as &quot;folders/123&quot;).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -193,8 +203,10 @@ or a folder number (such as &quot;folders/123&quot;).</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsRequest.html#Google_Cloud_Asset_V1_ExportAssetsRequest_Parent">Parent</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -215,12 +227,14 @@ or a folder number (such as &quot;folders/123&quot;).</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Timestamp to take an asset snapshot. This can only be set to a timestamp
 between the current time and the current time minus 35 days (inclusive).
 If not specified, the current time will be used. Due to delays in resource
 data collection and indexing, there is a volatile window during which
 running the same query may get different results.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -74,12 +74,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ExportAssetsResponse.html">ExportAssetsResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -88,8 +90,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputConfig OutputConfig { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Output configuration indicating where the results were output to.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,12 +114,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OutputResult OutputResult { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Output result indicating where the assets were exported to. For example, a
 set of actual Google Cloud Storage object uris where the assets are
 exported to. The uris can be different from what [output_config] has
 specified, as the service will split the output object into multiple ones
 once it exceeds a single Google Cloud Storage object limit.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,8 +142,10 @@ once it exceeds a single Google Cloud Storage object limit.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Time the snapshot was taken.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -76,12 +76,14 @@ Pub/Sub topics.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Feed.html">Feed</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -90,6 +92,7 @@ Pub/Sub topics.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetNames { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of the full names of the assets to receive updates. You must specify
 either or both of asset_names and asset_types. Only asset updates matching
 specified asset_names or asset_types are exported to the feed.
@@ -99,6 +102,7 @@ See <a href="https://cloud.google.com/apis/design/resource_names#full_resource_n
 Names</a>
 for more info.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,6 +123,7 @@ for more info.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of types of the assets to receive updates. You must specify either
 or both of asset_names and asset_types. Only asset updates matching
 specified asset_names or asset_types are exported to the feed.
@@ -127,6 +132,7 @@ Example: <code>&amp;quot;compute.googleapis.com/Disk&amp;quot;</code></p>
 topic</a>
 for a list of all supported asset types.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,6 +153,7 @@ for a list of all supported asset types.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Expr Condition { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A condition which determines whether an asset update should be published.
 If specified, an asset will be returned only when the expression evaluates
 to true.
@@ -158,6 +165,7 @@ optional.</p>
 guide</a>
 for detailed instructions.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -178,9 +186,11 @@ for detailed instructions.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name and
 type will be returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -201,8 +211,10 @@ type will be returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.Feed.html#Google_Cloud_Asset_V1_Feed_Name">Name</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,9 +235,11 @@ type will be returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedOutputConfig FeedOutputConfig { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. Feed output configuration defining where the asset updates are
 published to.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,6 +260,7 @@ published to.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The format will be
 projects/{project_number}/feeds/{client-assigned_feed_identifier} or
 folders/{folder_number}/feeds/{client-assigned_feed_identifier} or
@@ -253,6 +268,7 @@ organizations/{organization_number}/feeds/{client-assigned_feed_identifier}</p>
 <p>The client-assigned feed identifier must be unique within the parent
 project/folder/organization.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -48,9 +48,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName(string projectId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs a new instance of a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> class from the component parts of pattern
 <code>projects/{project}/feeds/{feed}</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -61,6 +63,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">projectId</span></td>
@@ -74,6 +77,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -82,8 +86,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FeedId { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <code>Feed</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,8 +110,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FolderId { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <code>Folder</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -126,8 +134,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool IsKnownPattern { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Whether this instance contains a resource name with a known pattern.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,9 +158,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrganizationId { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <code>Organization</code> ID. May be <code>null</code>, depending on which resource name is contained by this
 instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,8 +183,10 @@ instance.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ProjectId { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <code>Project</code> ID. May be <code>null</code>, depending on which resource name is contained by this instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -193,8 +207,10 @@ instance.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName.ResourceNameType Type { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <a class="xref" href="Google.Cloud.Asset.V1.FeedName.ResourceNameType.html">FeedName.ResourceNameType</a> of the contained resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -215,9 +231,11 @@ instance.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnparsedResourceName UnparsedResource { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The contained <span class="xref">Google.Api.Gax.UnparsedResourceName</span>. Only non-<code>null</code> if this instance contains an
 unparsed resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,9 +258,11 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string Format(string projectId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -253,6 +273,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">projectId</span></td>
@@ -266,6 +287,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -289,9 +311,11 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatFolderFeed(string folderId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>folders/{folder}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,6 +326,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">folderId</span></td>
@@ -315,6 +340,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,9 +363,11 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -350,6 +378,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">organizationId</span></td>
@@ -363,6 +392,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -386,9 +416,11 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static string FormatProjectFeed(string projectId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Formats the IDs into the string representation of this <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with pattern
 <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -399,6 +431,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">projectId</span></td>
@@ -412,6 +445,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,8 +469,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromFolderFeed(string folderId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>folders/{folder}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,6 +483,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">folderId</span></td>
@@ -460,6 +497,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -482,8 +520,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromOrganizationFeed(string organizationId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>organizations/{organization}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -494,6 +534,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">organizationId</span></td>
@@ -507,6 +548,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -529,8 +571,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromProjectFeed(string projectId, string feedId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> with the pattern <code>projects/{project}/feeds/{feed}</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,6 +585,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">projectId</span></td>
@@ -554,6 +599,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -576,8 +622,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName FromUnparsed(UnparsedResourceName unparsedResourceName)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> containing an unparsed resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,6 +636,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">Google.Api.Gax.UnparsedResourceName</span></td>
         <td><span class="parametername">unparsedResourceName</span></td>
@@ -595,6 +644,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -617,8 +667,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public override int GetHashCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a hash code for this resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,8 +693,10 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,6 +707,7 @@ unparsed resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">feedName</span></td>
@@ -660,6 +715,7 @@ unparsed resource name.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -686,9 +742,11 @@ unparsed resource name.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public static FeedName Parse(string feedName, bool allowUnparsed)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Parses the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally allowing an
 unparseable resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,6 +757,7 @@ unparseable resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">feedName</span></td>
@@ -714,6 +773,7 @@ specified.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -741,8 +801,10 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="codewrapper">
     <pre><code class="prettyprint">public override string ToString()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The string representation of the resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,8 +828,10 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, out FeedName result)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -778,6 +842,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">feedName</span></td>
@@ -791,6 +856,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -817,9 +883,11 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
   <div class="codewrapper">
     <pre><code class="prettyprint">public static bool TryParse(string feedName, bool allowUnparsed, out FeedName result)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Tries to parse the given resource name string into a new <a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a> instance; optionally
 allowing an unparseable resource name.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -830,6 +898,7 @@ allowing an unparseable resource name.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">System.String</span></td>
         <td><span class="parametername">feedName</span></td>
@@ -851,6 +920,7 @@ specified.</p>
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -890,6 +960,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">a</span></td>
@@ -901,6 +972,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,6 +1004,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a></td>
         <td><span class="parametername">a</span></td>
@@ -943,6 +1016,7 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.FeedOutputConfig.html">FeedOutputConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -106,8 +108,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PubsubDestination PubsubDestination { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Destination on Pub/Sub.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GcsDestination.html">GcsDestination</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -106,6 +108,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The uri of the Cloud Storage object. It&apos;s the same uri that is used by
 gsutil. Example: &quot;gs://bucket_name/object_name&quot;. See <a href="https://cloud.google.com/storage/docs/viewing-editing-metadata">Viewing and
 Editing Object
@@ -115,6 +118,7 @@ for more information.</p>
 <a href="https://cloud.google.com/storage/docs/object-holds">hold</a>, it will be
 overwritten with the exported result.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,6 +139,7 @@ overwritten with the exported result.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string UriPrefix { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The uri prefix of all generated Cloud Storage objects. Example:
 &quot;gs://bucket_name/object_name_prefix&quot;. Each object uri is in format:
 &quot;gs://bucket_name/object_name_prefix/&lt;asset type&gt;/&lt;shard number&gt; and only
@@ -145,6 +150,7 @@ compute.googleapis.com/Disk assets. An INVALID_ARGUMENT error will be
 returned if file with the same name &quot;gs://bucket_name/object_name_prefix&quot;
 already exists.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GcsOutputResult.html">GcsOutputResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Uris { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List of uris of the Cloud Storage objects. Example:
 &quot;gs://bucket_name/object_name&quot;.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html">GetFeedRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FeedName FeedName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><a class="xref" href="Google.Cloud.Asset.V1.FeedName.html">FeedName</a>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.GetFeedRequest.html#Google_Cloud_Asset_V1_GetFeedRequest_Name">Name</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,11 +112,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The name of the Feed and it must be in the format of:
 projects/project_number/feeds/feed_id
 folders/folder_number/feeds/feed_id
 organizations/organization_number/feeds/feed_id</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html">IamPolicyAnalysisOutputConfig.Types.BigQueryDestination</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,10 +88,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Dataset { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The BigQuery dataset in format &quot;projects/projectId/datasets/datasetId&quot;,
 to which the analysis results should be exported. If this dataset does
 not exist, the export call will return an INVALID_ARGUMENT error.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,8 +114,10 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey PartitionKey { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The partition key for BigQuery partitioned table.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,6 +138,7 @@ not exist, the export call will return an INVALID_ARGUMENT error.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TablePrefix { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The prefix of the BigQuery tables to which the analysis results will be
 written. Tables will be created based on this table_prefix if not exist:</p>
 <ul>
@@ -142,6 +149,7 @@ When [partition_key] is specified, both tables will be partitioned based
 on the [partition_key].</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -162,6 +170,7 @@ on the [partition_key].</li>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string WriteDisposition { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. Specifies the action that occurs if the destination table or partition
 already exists. The following values are supported:</p>
 <ul>
@@ -176,6 +185,7 @@ returned.</li>
 if BigQuery is able to complete the job successfully. Details are at
 <a href="https://cloud.google.com/bigquery/docs/loading-data-local#appending_to_or_overwriting_a_table_using_a_local_file">https://cloud.google.com/bigquery/docs/loading-data-local#appending_to_or_overwriting_a_table_using_a_local_file</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html">IamPolicyAnalysisOutputConfig.Types.GcsDestination</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Uri { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The uri of the Cloud Storage object. It&apos;s the same uri that is used by
 gsutil. Example: &quot;gs://bucket_name/object_name&quot;. See <a href="https://cloud.google.com/storage/docs/viewing-editing-metadata">Viewing and
 Editing Object
@@ -95,6 +98,7 @@ for more information.</p>
 <a href="https://cloud.google.com/storage/docs/object-holds">hold</a>, it will be
 overwritten with the analysis result.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html">IamPolicyAnalysisOutputConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Destination on BigQuery.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,8 +132,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisOutputConfig.Types.GcsDestination GcsDestination { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -76,12 +76,14 @@ less than 10.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html">IamPolicyAnalysisQuery.Types.AccessSelector</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -90,8 +92,10 @@ less than 10.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The permissions to appear in result.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,8 +116,10 @@ less than 10.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Roles { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The roles to appear in result.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html">IamPolicyAnalysisQuery.Types.ConditionContext</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,10 +88,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp AccessTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The hypothetical access timestamp to evaluate IAM conditions. Note that
 this value must not be earlier than the current time; otherwise, an
 INVALID_ARGUMENT error will be returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -74,12 +74,14 @@ directly or indirectly.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html">IamPolicyAnalysisQuery.Types.IdentitySelector</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -88,6 +90,7 @@ directly or indirectly.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Identity { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The identity appear in the form of members in
 <a href="https://cloud.google.com/iam/reference/rest/v1/Binding">IAM policy
 binding</a>.</p>
@@ -99,6 +102,7 @@ binding</a>.</p>
 <p>Notice that wildcard characters (such as * and ?) are not supported.
 You must give a specific identity.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html">IamPolicyAnalysisQuery.Types.Options</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool AnalyzeServiceAccountImpersonation { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true, the response will include access analysis from identities to
 resources via service account impersonation. This is a very expensive
 operation, because many derived queries will be executed. We highly
@@ -107,6 +110,7 @@ F. And those advanced analysis results will be included in
 [AnalyzeIamPolicyResponse.service_account_impersonation_analysis][google.cloud.asset.v1.AnalyzeIamPolicyResponse.service_account_impersonation_analysis].</p>
 <p>Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +131,7 @@ F. And those advanced analysis results will be included in
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandGroups { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true, the identities section of the result will expand any
 Google groups appearing in an IAM policy binding.</p>
 <p>If [IamPolicyAnalysisQuery.identity_selector][google.cloud.asset.v1.IamPolicyAnalysisQuery.identity_selector] is specified, the
@@ -134,6 +139,7 @@ identity in the result will be determined by the selector, and this flag
 is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,6 +160,7 @@ is not allowed to set.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandResources { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true and [IamPolicyAnalysisQuery.resource_selector][google.cloud.asset.v1.IamPolicyAnalysisQuery.resource_selector] is not
 specified, the resource section of the result will expand any resource
 attached to an IAM policy to include resources lower in the resource
@@ -172,6 +179,7 @@ a GCP project with this option enabled, the results will include all
 users who have permission P on that project or any lower resource.</p>
 <p>Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -192,6 +200,7 @@ users who have permission P on that project or any lower resource.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool ExpandRoles { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true, the access section of result will expand any roles
 appearing in IAM policy bindings to include their permissions.</p>
 <p>If [IamPolicyAnalysisQuery.access_selector][google.cloud.asset.v1.IamPolicyAnalysisQuery.access_selector] is specified, the access
@@ -199,6 +208,7 @@ section of the result will be determined by the selector, and this flag
 is not allowed to set.</p>
 <p>Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,10 +229,12 @@ is not allowed to set.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputGroupEdges { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true, the result will output group identity edges, starting
 from the binding&apos;s group members, to any expanded identities.
 Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,10 +255,12 @@ Default is false.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool OutputResourceEdges { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If true, the result will output resource edges, starting
 from the policy attached resource, to any expanded resources.
 Default is false.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -74,12 +74,14 @@ projects.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html">IamPolicyAnalysisQuery.Types.ResourceSelector</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -88,10 +90,12 @@ projects.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource name</a>
 of a resource of <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#analyzable_asset_types">supported resource
 types</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html">IamPolicyAnalysisQuery</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.AccessSelector AccessSelector { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. Specifies roles or permissions for analysis. This is optional.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,8 +112,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.ConditionContext ConditionContext { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The hypothetical context for IAM conditions evaluation.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,8 +136,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.IdentitySelector IdentitySelector { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. Specifies an identity for analysis.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,8 +160,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.Options Options { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The query options.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,8 +184,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisQuery.Types.ResourceSelector ResourceSelector { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. Specifies a resource for analysis.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,6 +208,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The relative name of the root asset. Only resources and IAM policies within
 the scope will be analyzed.</p>
 <p>This can only be an organization number (such as &quot;organizations/123&quot;), a
@@ -206,6 +219,7 @@ folder number (such as &quot;folders/123&quot;), a project ID (such as
 <p>To know how to get folder or project id, visit <a href="https://cloud.google.com/resource-manager/docs/creating-managing-folders#viewing_or_listing_folders_and_projects">here
 </a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html">IamPolicyAnalysisResult.Types.Access</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The analysis state of this access.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,8 +132,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Permission { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The permission.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,8 +156,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Role { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The role.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -87,12 +87,14 @@ combinations.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html">IamPolicyAnalysisResult.Types.AccessControlList</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -101,12 +103,14 @@ combinations.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Access&gt; Accesses { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The accesses that match one of the following conditions:</p>
 <ul>
 <li>The access_selector, if it is specified in request;</li>
 <li>Otherwise, access specifiers reachable from the policy binding&apos;s role.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,9 +131,11 @@ combinations.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ConditionEvaluation ConditionEvaluation { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Condition evaluation for this AccessControlList, if there is a condition
 defined in the above IAM policy binding.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,12 +156,14 @@ defined in the above IAM policy binding.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; ResourceEdges { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Resource edges of the graph starting from the policy attached
 resource to any descendant resources. The [Edge.source_node][google.cloud.asset.v1.IamPolicyAnalysisResult.Edge.source_node] contains
 the full resource name of a parent resource and [Edge.target_node][google.cloud.asset.v1.IamPolicyAnalysisResult.Edge.target_node]
 contains the full resource name of a child resource. This field is
 present only if the output_resource_edges option is enabled in request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,12 +184,14 @@ present only if the output_resource_edges option is enabled in request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Resource&gt; Resources { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The resources that match one of the following conditions:</p>
 <ul>
 <li>The resource_selector, if it is specified in request;</li>
 <li>Otherwise, resources reachable from the policy attached resource.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html">IamPolicyAnalysisResult.Types.Edge</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string SourceNode { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The source node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,9 +113,11 @@ name for a resource node or an email of an identity.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string TargetNode { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The target node of the edge. For example, it could be a full resource
 name for a resource node or an email of an identity.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html">IamPolicyAnalysisResult.Types.Identity</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The analysis state of this identity.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,6 +112,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The identity name in any form of members appear in
 <a href="https://cloud.google.com/iam/reference/rest/v1/Binding">IAM policy
 binding</a>, such
@@ -122,6 +127,7 @@ as:</p>
 <li>etc.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html">IamPolicyAnalysisResult.Types.IdentityList</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Edge&gt; GroupEdges { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Group identity edges of the graph starting from the binding&apos;s
 group members to any node of the [identities][google.cloud.asset.v1.IamPolicyAnalysisResult.IdentityList.identities]. The [Edge.source_node][google.cloud.asset.v1.IamPolicyAnalysisResult.Edge.source_node]
 contains a group, such as <code>group:parent@google.com</code>. The
@@ -94,6 +97,7 @@ such as <code>group:child@google.com</code> or <code>user:foo@google.com</code>.
 This field is present only if the output_group_edges option is enabled in
 request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,6 +118,7 @@ request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.Identity&gt; Identities { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Only the identities that match one of the following conditions will be
 presented:</p>
 <ul>
@@ -121,6 +126,7 @@ presented:</p>
 <li>Otherwise, identities reachable from the policy binding&apos;s members.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html">IamPolicyAnalysisResult.Types.Resource</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisState AnalysisState { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The analysis state of this resource.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,9 +112,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string FullResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource
 name</a></p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -73,12 +73,14 @@ access control lists.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html">IamPolicyAnalysisResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,9 +89,11 @@ access control lists.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicyAnalysisResult.Types.AccessControlList&gt; AccessControlLists { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The access control lists derived from the [iam_binding][google.cloud.asset.v1.IamPolicyAnalysisResult.iam_binding] that match or
 potentially match resource and access selectors specified in the request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,10 +114,12 @@ potentially match resource and access selectors specified in the request.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AttachedResourceFullName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">full resource
 name</a>
 of the resource to which the [iam_binding][google.cloud.asset.v1.IamPolicyAnalysisResult.iam_binding] policy attaches.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,9 +140,11 @@ of the resource to which the [iam_binding][google.cloud.asset.v1.IamPolicyAnalys
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool FullyExplored { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Represents whether all analyses on the [iam_binding][google.cloud.asset.v1.IamPolicyAnalysisResult.iam_binding] have successfully
 finished.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,8 +165,10 @@ finished.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Binding IamBinding { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The Cloud IAM policy binding under analysis.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,9 +189,11 @@ finished.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicyAnalysisResult.Types.IdentityList IdentityList { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The identity list derived from members of the [iam_binding][google.cloud.asset.v1.IamPolicyAnalysisResult.iam_binding] that match or
 potentially match identity selector specified in the request.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -73,12 +73,14 @@ resource, an identity or an access.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicyAnalysisState.html">IamPolicyAnalysisState</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,8 +89,10 @@ resource, an identity or an access.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Cause { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The human-readable description of the cause of failure.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,6 +113,7 @@ resource, an identity or an access.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Code Code { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The Google standard error code that best describes the state.
 For example:</p>
 <ul>
@@ -118,6 +123,7 @@ For example:</p>
 in time;</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html">IamPolicySearchResult.Types.Explanation.Types.Permissions</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Permissions_ { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of permissions. A sample permission string: <code>compute.disk.get</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html">IamPolicySearchResult.Types.Explanation</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, IamPolicySearchResult.Types.Explanation.Types.Permissions&gt; MatchedPermissions { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The map from roles to their included permissions that match the
 permission query (i.e., a query containing <code>policy.role.permissions:</code>).
 Example: if query <code>policy.role.permissions:compute.disk.get</code>
@@ -94,6 +97,7 @@ matched_permissions will be <code>{&amp;quot;roles/owner&amp;quot;: [&amp;quot;c
 roles can also be found in the returned <code>policy</code> bindings. Note that the
 map is populated only for requests with permission queries.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.IamPolicySearchResult.html">IamPolicySearchResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public IamPolicySearchResult.Types.Explanation Explanation { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Explanation about the IAM policy search result. It contains additional
 information to explain why the search result matches the query.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,6 +113,7 @@ information to explain why the search result matches the query.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Policy Policy { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The IAM policy directly set on the given resource. Note that the original
 IAM policy can contain multiple bindings. This only contains the bindings
 that match the given query. For queries that don&apos;t contain a constrain on
@@ -124,6 +129,7 @@ policies (e.g., an empty query), this contains all the bindings.</p>
 <code>policy.role.permissions:compute.instances.create</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,6 +150,7 @@ policies (e.g., an empty query), this contains all the bindings.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The project that the associated GCP resource belongs to, in the form of
 projects/{PROJECT_NUMBER}. If an IAM policy is set on a resource (like VM
 instance, Cloud Storage bucket), the project field will indicate the
@@ -154,6 +161,7 @@ orgnization, this field will be empty.</p>
 <li>specify the <code>scope</code> field as this project in your search request.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,6 +182,7 @@ orgnization, this field will be empty.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Resource { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The full resource name of the resource associated with this IAM policy.
 Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code>.
@@ -185,6 +194,7 @@ for more information.</p>
 <li>use a field query. Example: <code>resource:organizations/123</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
@@ -73,12 +73,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html">ListAssetsRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,6 +89,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of asset types to take a snapshot for. For example:
 &quot;compute.googleapis.com/Disk&quot;.</p>
 <p>Regular expression is also supported. For example:</p>
@@ -104,6 +107,7 @@ snapshot all asset types. See <a href="https://cloud.google.com/asset-inventory/
 Inventory</a>
 for all supported asset types.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -124,9 +128,11 @@ for all supported asset types.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public ContentType ContentType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Asset content type. If not specified, no content but the asset name will
 be returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,9 +153,11 @@ be returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The maximum number of assets to be returned in a single response. Default
 is 100, minimum is 1, and maximum is 1000.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,10 +178,12 @@ is 100, minimum is 1, and maximum is 1000.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The <code>next_page_token</code> returned from the previous <code>ListAssetsResponse</code>, or
 unspecified for the first <code>ListAssetsRequest</code>. It is a continuation of a
 prior <code>ListAssets</code> call, and the API should return the next page of assets.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -194,11 +204,13 @@ prior <code>ListAssets</code> call, and the API should return the next page of a
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. Name of the organization or project the assets belong to. Format:
 &quot;organizations/[organization-number]&quot; (such as &quot;organizations/123&quot;),
 &quot;projects/[project-id]&quot; (such as &quot;projects/my-project-id&quot;), or
 &quot;projects/[project-number]&quot; (such as &quot;projects/12345&quot;).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -219,8 +231,10 @@ prior <code>ListAssets</code> call, and the API should return the next page of a
   <div class="codewrapper">
     <pre><code class="prettyprint">public IResourceName ParentAsResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p><span class="xref">Google.Api.Gax.IResourceName</span>-typed view over the <a class="xref" href="Google.Cloud.Asset.V1.ListAssetsRequest.html#Google_Cloud_Asset_V1_ListAssetsRequest_Parent">Parent</a> resource name property.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,12 +255,14 @@ prior <code>ListAssets</code> call, and the API should return the next page of a
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Timestamp to take an asset snapshot. This can only be set to a timestamp
 between the current time and the current time minus 35 days (inclusive).
 If not specified, the current time will be used. Due to delays in resource
 data collection and indexing, there is a volatile window during which
 running the same query may get different results.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
@@ -75,12 +75,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListAssetsResponse.html">ListAssetsResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -89,8 +91,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Asset&gt; Assets { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Assets.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -111,10 +115,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Token to retrieve the next page of results. It expires 72 hours after the
 page token for the first page is generated. Set to empty if there are no
 remaining results.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,8 +141,10 @@ remaining results.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp ReadTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Time the snapshot was taken.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -159,8 +167,10 @@ remaining results.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;Asset&gt; GetEnumerator()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsRequest.html">ListFeedsRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,10 +88,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The parent project/folder/organization whose feeds are to be
 listed. It can only be using project/folder/organization number (such as
 &quot;folders/12345&quot;)&quot;, or a project ID (such as &quot;projects/my-project-id&quot;).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -70,12 +70,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ListFeedsResponse.html">ListFeedsResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -84,8 +86,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;Feed&gt; Feeds { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of feeds.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.OutputConfig.html">OutputConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public BigQueryDestination BigqueryDestination { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Destination on BigQuery. The output table stores the fields in asset
 proto as columns in BigQuery.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,8 +133,10 @@ proto as columns in BigQuery.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsDestination GcsDestination { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Destination on Cloud Storage.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.OutputResult.html">OutputResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GcsOutputResult GcsResult { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Export result on Cloud Storage.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.PartitionSpec.html">PartitionSpec</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,8 +88,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PartitionSpec.Types.PartitionKey PartitionKey { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The partition key for BigQuery partitioned table.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.PubsubDestination.html">PubsubDestination</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Topic { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The name of the Pub/Sub topic to publish to.
 Example: <code>projects/PROJECT_ID/topics/TOPIC_ID</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.Resource.html">Resource</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct Data { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The content of the resource, in which some sensitive fields are removed
 and may not be present.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,12 +113,14 @@ and may not be present.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryDocumentUri { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The URL of the discovery document containing the resource&apos;s JSON schema.
 Example:
 <code>https://www.googleapis.com/discovery/v1/apis/compute/v1/rest</code></p>
 <p>This value is unspecified for resources that do not have an API based on a
 discovery document, such as Cloud Bigtable.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,11 +141,13 @@ discovery document, such as Cloud Bigtable.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DiscoveryName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The JSON schema name listed in the discovery document. Example:
 <code>Project</code></p>
 <p>This value is unspecified for resources that do not have an API based on a
 discovery document, such as Cloud Bigtable.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,9 +168,11 @@ discovery document, such as Cloud Bigtable.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The location of the resource in Google Cloud, such as its zone and region.
 For more information, see <a href="https://cloud.google.com/about/locations/">https://cloud.google.com/about/locations/</a>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,6 +193,7 @@ For more information, see <a href="https://cloud.google.com/about/locations/">ht
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Parent { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The full name of the immediate parent of this resource. See
 <a href="https://cloud.google.com/apis/design/resource_names#full_resource_name">Resource
 Names</a>
@@ -194,6 +205,7 @@ Example:
 <code>//cloudresourcemanager.googleapis.com/projects/my_project_123</code></p>
 <p>For third-party assets, this field may be set differently.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -214,11 +226,13 @@ Example:
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ResourceUrl { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The REST URL for accessing the resource. An HTTP <code>GET</code> request using this
 URL returns the resource itself. Example:
 <code>https://cloudresourcemanager.googleapis.com/v1/projects/my-project-123</code></p>
 <p>This value is unspecified for resources without a REST API.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -239,8 +253,10 @@ URL returns the resource itself. Example:
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Version { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The API version. Example: <code>v1</code></p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.ResourceSearchResult.html">ResourceSearchResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Struct AdditionalAttributes { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The additional searchable attributes of this resource. The attributes may
 vary from one resource type to another. Examples: <code>projectId</code> for Project,
 <code>dnsName</code> for DNS ManagedZone. This field contains a subset of the resource
@@ -105,6 +108,7 @@ version.</p>
 <code>foobar</code>.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -125,12 +129,14 @@ version.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string AssetType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The type of this resource. Example: <code>compute.googleapis.com/Disk</code>.</p>
 <p>To search against the <code>asset_type</code>:</p>
 <ul>
 <li>specify the <code>asset_type</code> field in your search request.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -151,6 +157,7 @@ version.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp CreateTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The create timestamp of this resource, at which the resource was created.
 The granularity is in seconds. Timestamp.nanos will always be 0. This field
 is available only when the resource&apos;s proto contains it.</p>
@@ -163,6 +170,7 @@ is available only when the resource&apos;s proto contains it.</p>
 &amp;quot;2021-01-01T00:00:00&amp;quot;</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -183,6 +191,7 @@ is available only when the resource&apos;s proto contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Description { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>One or more paragraphs of text description of this resource. Maximum length
 could be up to 1M bytes. This field is available only when the resource&apos;s
 proto contains it.</p>
@@ -192,6 +201,7 @@ proto contains it.</p>
 <li>use a free text query. Example: <code>&amp;quot;important instance&amp;quot;</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,6 +222,7 @@ proto contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string DisplayName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The display name of this resource. This field is available only when the
 resource&apos;s proto contains it.</p>
 <p>To search against the <code>display_name</code>:</p>
@@ -220,6 +231,7 @@ resource&apos;s proto contains it.</p>
 <li>use a free text query. Example: <code>&amp;quot;My Instance&amp;quot;</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,6 +252,7 @@ resource&apos;s proto contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; Folders { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The folder(s) that this resource belongs to, in the form of
 folders/{FOLDER_NUMBER}. This field is available when the resource
 belongs to one or more folders.</p>
@@ -250,6 +263,7 @@ belongs to one or more folders.</p>
 <li>specify the <code>scope</code> field as this folder in your search request.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -270,6 +284,7 @@ belongs to one or more folders.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string KmsKey { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The Cloud KMS
 <a href="https://cloud.google.com/kms/docs/reference/rest/v1/projects.locations.keyRings.cryptoKeys?hl=en">CryptoKey</a>
 name or
@@ -281,6 +296,7 @@ name. This field is available only when the resource&apos;s proto contains it.</
 <li>use a free text query. Example: <code>key</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,6 +317,7 @@ name. This field is available only when the resource&apos;s proto contains it.</
   <div class="codewrapper">
     <pre><code class="prettyprint">public MapField&lt;string, string&gt; Labels { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Labels associated with this resource. See <a href="https://cloud.google.com/blog/products/gcp/labelling-and-grouping-your-google-cloud-platform-resources">Labelling and grouping GCP
 resources</a>
 for more information. This field is available only when the resource&apos;s
@@ -314,6 +331,7 @@ proto contains it.</p>
 <li>use a free text query. Example: <code>prod</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -334,6 +352,7 @@ proto contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Location { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Location can be <code>global</code>, regional like <code>us-east1</code>, or zonal like
 <code>us-west1-b</code>. This field is available only when the resource&apos;s proto
 contains it.</p>
@@ -343,6 +362,7 @@ contains it.</p>
 <li>use a free text query. Example: <code>us-west*</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,6 +383,7 @@ contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Name { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The full resource name of this resource. Example:
 <code>//compute.googleapis.com/projects/my_project_123/zones/zone1/instances/instance1</code>.
 See <a href="https://cloud.google.com/asset-inventory/docs/resource-name-format">Cloud Asset Inventory Resource Name
@@ -374,6 +395,7 @@ for more information.</p>
 <li>use a free text query. Example: <code>instance1</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,6 +416,7 @@ for more information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; NetworkTags { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Network tags associated with this resource. Like labels, network tags are a
 type of annotations used to group GCP resources. See <a href="https://cloud.google.com/blog/products/gcp/labelling-and-grouping-your-google-cloud-platform-resources">Labelling GCP
 resources</a>
@@ -405,6 +428,7 @@ proto contains it.</p>
 <li>use a free text query. Example: <code>internal</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -425,6 +449,7 @@ proto contains it.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Organization { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The organization that this resource belongs to, in the form of
 organizations/{ORGANIZATION_NUMBER}. This field is available when the
 resource belongs to an organization.</p>
@@ -435,6 +460,7 @@ resource belongs to an organization.</p>
 <li>specify the <code>scope</code> field as this organization in your search request.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -455,6 +481,7 @@ resource belongs to an organization.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ParentAssetType { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The type of this resource&apos;s immediate parent, if there is one.</p>
 <p>To search against the <code>parent_asset_type</code>:</p>
 <ul>
@@ -464,6 +491,7 @@ resource belongs to an organization.</p>
 <code>cloudresourcemanager.googleapis.com/Project</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,6 +512,7 @@ resource belongs to an organization.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string ParentFullResourceName { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The full resource name of this resource&apos;s parent, if it has one.
 To search against the <code>parent_full_resource_name</code>:</p>
 <ul>
@@ -493,6 +522,7 @@ To search against the <code>parent_full_resource_name</code>:</p>
 <code>project-name</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -513,6 +543,7 @@ To search against the <code>parent_full_resource_name</code>:</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Project { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The project that this resource belongs to, in the form of
 projects/{PROJECT_NUMBER}. This field is available when the resource
 belongs to a project.</p>
@@ -523,6 +554,7 @@ belongs to a project.</p>
 <li>specify the <code>scope</code> field as this project in your search request.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -543,6 +575,7 @@ belongs to a project.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string State { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The state of this resource. Different resources types have different state
 definitions that are mapped from various fields of different resource
 types. This field is available only when the resource&apos;s proto contains it.</p>
@@ -562,6 +595,7 @@ Reference</a>.</p>
 <li>use a free text query. Example: <code>RUNNING</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -582,6 +616,7 @@ Reference</a>.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp UpdateTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The last update timestamp of this resource, at which the resource was last
 modified or deleted. The granularity is in seconds. Timestamp.nanos will
 always be 0. This field is available only when the resource&apos;s proto
@@ -595,6 +630,7 @@ contains it.</p>
 &amp;quot;2021-01-01T00:00:00&amp;quot;</code></li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -73,12 +73,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html">SearchAllIamPoliciesRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,11 +89,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The page size for search result pagination. Page size is capped at 500 even
 if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,11 +116,13 @@ there could be more results as long as <code>next_page_token</code> is returned.
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If present, retrieve the next batch of results from the preceding call to
 this method. <code>page_token</code> must be the value of <code>next_page_token</code> from the
 previous response. The values of all other method parameters must be
 identical to those in the previous call.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -137,6 +143,7 @@ identical to those in the previous call.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-iam-policies#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
@@ -176,6 +183,7 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
 &quot;instance2&quot; and also specify user &quot;amy&quot;.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,6 +204,7 @@ IAM policy bindings that are set on resources &quot;instance1&quot; or
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the IAM policies within the <code>scope</code>. The caller must be granted
 the
@@ -209,6 +218,7 @@ permission on the desired scope.</p>
 <li>organizations/{ORGANIZATION_NUMBER} (e.g., &quot;organizations/123456&quot;)</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -75,12 +75,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html">SearchAllIamPoliciesResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -89,10 +91,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Set if there are more results than those appearing in this response; to get
 the next set of results, call this method again, using this value as the
 <code>page_token</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,9 +117,11 @@ the next set of results, call this method again, using this value as the
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;IamPolicySearchResult&gt; Results { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of IamPolicy that match the search query. Related information such
 as the associated resource is returned along with the policy.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,8 +144,10 @@ as the associated resource is returned along with the policy.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;IamPolicySearchResult&gt; GetEnumerator()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -73,12 +73,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesRequest.html">SearchAllResourcesRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,6 +89,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;string&gt; AssetTypes { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. A list of asset types that this request searches for. If empty, it will
 search all the <a href="https://cloud.google.com/asset-inventory/docs/supported-asset-types#searchable_asset_types">searchable asset
 types</a>.</p>
@@ -101,6 +104,7 @@ with &quot;compute.googleapis.com&quot;.</li>
 regular expression syntax. If the regular expression does not match any
 supported asset type, an INVALID_ARGUMENT error will be returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,6 +125,7 @@ supported asset type, an INVALID_ARGUMENT error will be returned.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string OrderBy { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. A comma-separated list of fields specifying the sorting order of the
 results. The default order is ascending. Add &quot; DESC&quot; after the field name
 to indicate descending order. Redundant space characters are ignored.
@@ -144,6 +149,7 @@ fields (e.g., <code>labels</code>) and struct fields (e.g., <code>additionalAttr
 are not supported.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -164,11 +170,13 @@ are not supported.</li>
   <div class="codewrapper">
     <pre><code class="prettyprint">public int PageSize { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The page size for search result pagination. Page size is capped at 500 even
 if a larger value is given. If set to zero, server will pick an appropriate
 default. Returned results may be fewer than requested. When this happens,
 there could be more results as long as <code>next_page_token</code> is returned.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -189,11 +197,13 @@ there could be more results as long as <code>next_page_token</code> is returned.
   <div class="codewrapper">
     <pre><code class="prettyprint">public string PageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. If present, then retrieve the next batch of results from the preceding call
 to this method. <code>page_token</code> must be the value of <code>next_page_token</code> from
 the previous response. The values of all other method parameters, must be
 identical to those in the previous call.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -214,6 +224,7 @@ identical to those in the previous call.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Query { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Optional. The query statement. See <a href="https://cloud.google.com/asset-inventory/docs/searching-resources#how_to_construct_a_query">how to construct a
 query</a>
 for more information. If not specified or empty, it will search all the
@@ -255,6 +266,7 @@ fields and are also located in the &quot;us-west1&quot; region or the &quot;glob
 location.</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,6 +287,7 @@ location.</li>
   <div class="codewrapper">
     <pre><code class="prettyprint">public string Scope { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. A scope can be a project, a folder, or an organization. The search is
 limited to the resources within the <code>scope</code>. The caller must be granted the
 <a href="https://cloud.google.com/asset-inventory/docs/access-control#required_permissions"><code>cloudasset.assets.searchAllResources</code></a>
@@ -287,6 +300,7 @@ permission on the desired scope.</p>
 <li>organizations/{ORGANIZATION_NUMBER} (e.g., &quot;organizations/123456&quot;)</li>
 </ul>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -75,12 +75,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.SearchAllResourcesResponse.html">SearchAllResourcesResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -89,10 +91,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public string NextPageToken { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>If there are more results than those appearing in this response, then
 <code>next_page_token</code> is included. To get the next set of results, call this
 method again using the value of <code>next_page_token</code> as <code>page_token</code>.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,9 +117,11 @@ method again using the value of <code>next_page_token</code> as <code>page_token
   <div class="codewrapper">
     <pre><code class="prettyprint">public RepeatedField&lt;ResourceSearchResult&gt; Results { get; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>A list of Resources that match the search query. It contains the resource
 standard metadata information.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,8 +144,10 @@ standard metadata information.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public IEnumerator&lt;ResourceSearchResult&gt; GetEnumerator()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns an enumerator that iterates through the resources in this response.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -73,12 +73,14 @@ when it was observed and its status during that window.</p>
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.TemporalAsset.html">TemporalAsset</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -87,8 +89,10 @@ when it was observed and its status during that window.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset Asset { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>An asset in Google Cloud.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,8 +113,10 @@ when it was observed and its status during that window.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public bool Deleted { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Whether the asset has been deleted or not.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -131,9 +137,11 @@ when it was observed and its status during that window.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Asset PriorAsset { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Prior copy of the asset. Populated if prior_asset_state is PRESENT.
 Currently this is only set for responses in Real-Time Feed.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,8 +162,10 @@ Currently this is only set for responses in Real-Time Feed.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TemporalAsset.Types.PriorAssetState PriorAssetState { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>State of prior_asset.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,8 +186,10 @@ Currently this is only set for responses in Real-Time Feed.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimeWindow Window { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>The time window when the asset data and state was observed.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.TimeWindow.html">TimeWindow</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp EndTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>End time of the time window (inclusive). If not specified, the current
 timestamp is used instead.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,8 +113,10 @@ timestamp is used instead.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp StartTime { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Start time of the time window (exclusive).</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -72,12 +72,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="Google.Cloud.Asset.V1.UpdateFeedRequest.html">UpdateFeedRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="properties">Properties
   </h2>
@@ -86,12 +88,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Feed Feed { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. The new values of feed details. It must match an existing feed and the
 field <code>name</code> must be in the format of:
 projects/project_number/feeds/feed_id or
 folders/folder_number/feeds/feed_id or
 organizations/organization_number/feeds/feed_id.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,10 +116,12 @@ organizations/organization_number/feeds/feed_id.</p>
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask UpdateMask { get; set; }</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Required. Only updates the <code>feed</code> fields indicated by this mask.
 The field mask must not be empty, and it must not contain fields that
 are immutable or only set by the server.</p>
 </div>
+  {% endverbatim %}
   <strong>Property Value</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
@@ -242,6 +242,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -253,6 +254,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -348,12 +350,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,9 +381,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,12 +416,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -439,10 +447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,9 +474,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -571,9 +583,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -595,9 +609,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getLastUpdateTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -618,9 +634,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,10 +659,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,9 +686,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -690,9 +712,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getStartTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,9 +737,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -736,9 +762,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -760,9 +788,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,12 +868,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html">LongRunningRecognizeMetadata</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -875,6 +907,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -886,6 +919,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -934,12 +968,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -963,9 +999,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,12 +1014,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1003,9 +1043,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1016,12 +1058,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1053,12 +1097,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1092,6 +1138,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1103,6 +1150,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1126,9 +1174,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1139,12 +1189,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1166,9 +1218,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setLastUpdateTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1179,12 +1233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,10 +1262,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setProgressPercent(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1220,6 +1278,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1227,6 +1286,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1259,6 +1319,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1275,6 +1336,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1298,9 +1360,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1311,12 +1375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1338,9 +1404,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setStartTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1351,12 +1419,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1388,12 +1458,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
@@ -346,12 +346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,9 +437,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,9 +463,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,10 +510,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -551,9 +559,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -575,9 +585,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -620,9 +632,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,9 +658,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,12 +780,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html">LongRunningRecognizeMetadata</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -821,12 +839,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -860,12 +880,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -899,12 +921,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -951,6 +975,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -962,6 +987,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,12 +1034,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1060,6 +1088,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1071,6 +1100,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1117,12 +1147,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1169,6 +1201,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1180,6 +1213,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1226,12 +1260,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1278,6 +1314,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1289,6 +1326,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1335,12 +1373,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1387,6 +1427,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1398,6 +1439,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1444,12 +1486,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1496,6 +1540,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1507,6 +1552,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1593,12 +1639,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,9 +105,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,9 +156,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,9 +182,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,9 +339,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,10 +364,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,12 +400,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,12 +441,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -484,9 +494,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,9 +520,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,9 +545,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,10 +570,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,10 +597,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,10 +623,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,9 +711,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,10 +737,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,9 +808,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,12 +823,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -822,10 +852,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,12 +868,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -873,12 +907,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -910,6 +946,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -921,6 +958,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -969,12 +1007,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,12 +1048,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1037,9 +1079,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,12 +1094,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1077,9 +1123,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1090,12 +1138,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1117,10 +1167,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1131,12 +1183,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1158,10 +1212,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,12 +1228,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1209,6 +1267,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1220,6 +1279,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1253,6 +1313,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1269,6 +1330,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1302,12 +1364,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
@@ -326,12 +326,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -355,9 +357,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,9 +383,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,10 +408,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,10 +435,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,9 +587,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,10 +613,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,12 +736,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -779,12 +795,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -818,12 +836,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -857,12 +877,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,6 +931,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -920,6 +943,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -966,12 +990,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1018,6 +1044,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1029,6 +1056,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1075,12 +1103,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1127,6 +1157,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1138,6 +1169,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1184,12 +1216,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1236,6 +1270,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1247,6 +1282,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1293,12 +1329,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1345,6 +1383,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1356,6 +1395,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1402,12 +1442,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1454,6 +1496,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1465,6 +1508,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1551,12 +1595,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,10 +105,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,10 +157,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
@@ -234,10 +234,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,12 +250,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -296,6 +301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -319,10 +325,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -333,12 +341,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -360,10 +370,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,12 +386,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -401,10 +415,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -426,6 +443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -447,10 +465,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,6 +481,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -472,6 +493,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -493,10 +515,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -517,10 +541,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,12 +557,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -630,12 +658,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -669,12 +699,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -698,10 +730,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -806,10 +840,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -820,12 +856,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -847,10 +885,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,12 +901,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -888,10 +930,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -912,10 +956,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -936,10 +982,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,10 +1008,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,12 +1024,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1001,10 +1053,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,12 +1133,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponse.html">LongRunningRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1116,6 +1172,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1127,6 +1184,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1175,12 +1233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1214,12 +1274,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1243,10 +1305,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1257,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,6 +1360,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1305,6 +1372,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1338,6 +1406,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1354,6 +1423,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1377,10 +1447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,6 +1463,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1402,6 +1475,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1423,10 +1497,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,6 +1513,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1448,6 +1525,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1479,12 +1557,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
@@ -310,12 +310,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -421,10 +423,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,12 +439,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -462,10 +468,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,10 +494,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,10 +520,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,12 +536,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -551,10 +565,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,12 +731,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponse.html">LongRunningRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -772,12 +790,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -811,12 +831,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -850,12 +872,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -902,6 +926,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -913,6 +938,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -959,12 +985,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,6 +1039,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1022,6 +1051,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1068,12 +1098,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1120,6 +1152,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1131,6 +1164,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1177,12 +1211,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1229,6 +1265,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1240,6 +1277,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1286,12 +1324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1338,6 +1378,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1349,6 +1390,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1395,12 +1437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1447,6 +1491,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1458,6 +1503,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1544,12 +1590,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
@@ -243,6 +243,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -254,6 +255,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,11 +361,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -434,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -463,6 +471,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -472,6 +481,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -535,11 +545,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,6 +635,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -632,6 +645,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,6 +667,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -662,6 +677,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,11 +699,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,6 +727,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -718,6 +737,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,12 +813,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -830,6 +852,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -841,6 +864,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -889,12 +913,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -928,12 +954,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -957,11 +985,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,6 +1002,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -979,6 +1010,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,6 +1043,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1022,6 +1055,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1055,6 +1089,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1071,6 +1106,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1104,12 +1140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1133,6 +1171,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUri(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -1142,6 +1181,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1152,6 +1192,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1159,6 +1200,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1181,6 +1223,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUriBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -1190,6 +1233,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1200,6 +1244,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1207,6 +1252,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
@@ -328,12 +328,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,6 +533,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -538,6 +543,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,6 +565,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -568,6 +575,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -589,11 +597,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -615,6 +625,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -624,6 +635,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -741,12 +753,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -798,12 +812,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -837,12 +853,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -876,12 +894,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -928,6 +948,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -939,6 +960,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -985,12 +1007,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1037,6 +1061,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1048,6 +1073,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1094,12 +1120,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1146,6 +1174,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1157,6 +1186,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1203,12 +1233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1255,6 +1287,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1266,6 +1299,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1312,12 +1346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1364,6 +1400,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1375,6 +1412,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1421,12 +1459,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1473,6 +1513,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1484,6 +1525,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1570,12 +1612,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
@@ -47,11 +47,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,6 +75,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -82,6 +85,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,6 +107,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -112,6 +117,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,11 +139,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -159,6 +167,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -168,6 +177,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
@@ -231,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addAllSpeechContexts(Iterable&lt;? extends SpeechContext&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -238,6 +239,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,12 +250,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.SpeechContext</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -296,6 +301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -319,6 +325,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -326,6 +333,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -336,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -363,6 +373,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -370,6 +381,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,12 +392,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechContext.Builder.html">SpeechContext.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -407,6 +421,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(int index, SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -414,6 +429,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,6 +440,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -435,6 +452,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -456,6 +474,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(int index, SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -463,6 +482,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -473,6 +493,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -484,6 +505,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -505,6 +527,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addSpeechContextsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -512,6 +535,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,6 +556,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addSpeechContextsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -539,6 +564,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,12 +575,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -638,6 +666,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -649,6 +678,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -670,6 +700,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -680,6 +711,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,6 +732,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
@@ -709,6 +742,7 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,6 +764,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -738,6 +773,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,12 +795,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,11 +824,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,12 +862,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -851,6 +893,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -859,6 +902,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,6 +924,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -888,6 +933,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -909,9 +955,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,6 +980,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -966,6 +1015,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -997,12 +1047,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1026,12 +1078,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,6 +1107,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1062,6 +1117,7 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,6 +1139,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSpeechContexts()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1090,6 +1147,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1110,6 +1168,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -1119,6 +1178,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1162,6 +1222,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -1173,6 +1234,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,6 +1318,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1266,6 +1329,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1287,6 +1351,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder getDiarizationConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1297,6 +1362,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1317,6 +1383,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1327,6 +1394,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1347,6 +1415,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
@@ -1356,6 +1425,7 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1377,6 +1447,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -1385,6 +1456,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1406,12 +1478,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1433,11 +1507,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1459,11 +1535,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1485,6 +1563,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -1493,6 +1572,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1514,6 +1594,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -1522,6 +1603,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1543,6 +1625,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -1551,6 +1634,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1572,9 +1656,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1596,9 +1682,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder getMetadataBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1619,9 +1707,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1642,6 +1732,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1676,6 +1767,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1697,6 +1789,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1731,6 +1824,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1752,12 +1846,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1779,6 +1875,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1788,6 +1885,7 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1809,6 +1907,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1816,6 +1915,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1826,12 +1926,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1853,6 +1955,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder getSpeechContextsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1860,6 +1963,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1870,12 +1974,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1897,6 +2003,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext.Builder&gt; getSpeechContextsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1904,6 +2011,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1924,6 +2032,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1931,6 +2040,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1951,6 +2061,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1958,6 +2069,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1978,6 +2090,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1985,6 +2098,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1995,12 +2109,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2022,6 +2138,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2029,6 +2146,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2049,6 +2167,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -2058,6 +2177,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2079,6 +2199,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2089,6 +2210,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2110,9 +2232,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2178,6 +2302,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeDiarizationConfig(SpeakerDiarizationConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2188,6 +2313,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2198,12 +2324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2235,12 +2363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2272,6 +2402,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2283,6 +2414,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2331,12 +2463,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2360,9 +2494,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeMetadata(RecognitionMetadata value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2373,12 +2509,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2410,12 +2548,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2439,6 +2579,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder removeSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2446,6 +2587,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2456,12 +2598,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2483,6 +2627,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setAudioChannelCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -2494,6 +2639,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2504,6 +2650,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -2511,6 +2658,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2533,6 +2681,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setDiarizationConfig(SpeakerDiarizationConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2543,6 +2692,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2553,12 +2703,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2580,6 +2732,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setDiarizationConfig(SpeakerDiarizationConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2590,6 +2743,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2600,12 +2754,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html">SpeakerDiarizationConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2627,6 +2783,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableAutomaticPunctuation(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
@@ -2636,6 +2793,7 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2646,6 +2804,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -2653,6 +2812,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2675,6 +2835,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableSeparateRecognitionPerChannel(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -2683,6 +2844,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2693,6 +2855,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -2700,6 +2863,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2722,12 +2886,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableWordTimeOffsets(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2738,6 +2904,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -2745,6 +2912,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2767,11 +2935,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncoding(RecognitionConfig.AudioEncoding value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2782,6 +2952,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html">RecognitionConfig.AudioEncoding</a></td>
         <td><span class="parametername">value</span></td>
@@ -2789,6 +2960,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2811,11 +2983,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncodingValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2826,6 +3000,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -2833,6 +3008,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2865,6 +3041,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2876,6 +3053,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2899,6 +3077,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -2907,6 +3086,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2917,6 +3097,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -2924,6 +3105,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2946,6 +3128,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -2954,6 +3137,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2964,6 +3148,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -2971,6 +3156,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2993,6 +3179,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMaxAlternatives(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -3001,6 +3188,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3011,6 +3199,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -3018,6 +3207,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3040,9 +3230,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMetadata(RecognitionMetadata value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3053,12 +3245,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3080,9 +3274,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMetadata(RecognitionMetadata.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3093,12 +3289,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.Builder.html">RecognitionMetadata.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3120,6 +3318,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setModel(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -3154,6 +3353,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3164,6 +3364,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -3171,6 +3372,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3193,6 +3395,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setModelBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -3227,6 +3430,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3237,6 +3441,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -3244,6 +3449,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3266,12 +3472,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setProfanityFilter(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3282,6 +3490,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3289,6 +3498,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3321,6 +3531,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -3337,6 +3548,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3360,6 +3572,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSampleRateHertz(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -3369,6 +3582,7 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3379,6 +3593,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -3386,6 +3601,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3408,6 +3624,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContexts(int index, SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -3415,6 +3632,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3425,6 +3643,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -3436,6 +3655,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3457,6 +3677,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContexts(int index, SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -3464,6 +3685,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3474,6 +3696,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -3485,6 +3708,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3516,12 +3740,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3545,6 +3771,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setUseEnhanced(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -3554,6 +3781,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3564,6 +3792,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3571,6 +3800,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
@@ -554,12 +554,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -583,6 +585,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -594,6 +597,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -675,6 +679,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -685,6 +690,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,6 +712,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -716,6 +723,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -736,6 +744,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
@@ -745,6 +754,7 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,6 +776,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -774,6 +785,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,12 +807,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -822,11 +836,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -848,11 +864,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,6 +892,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -882,6 +901,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,6 +923,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -911,6 +932,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,6 +954,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -940,6 +963,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -961,9 +985,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -985,9 +1011,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1008,6 +1036,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1042,6 +1071,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1063,6 +1093,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1097,6 +1128,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1140,12 +1172,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,6 +1201,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1176,6 +1211,7 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1219,6 +1255,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1226,6 +1263,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1236,12 +1274,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1263,6 +1303,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1270,6 +1311,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1290,6 +1332,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1297,6 +1340,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1317,6 +1361,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1324,6 +1369,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1334,12 +1380,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1361,6 +1409,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1368,6 +1417,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1410,6 +1460,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -1419,6 +1470,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1440,6 +1492,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1450,6 +1503,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1471,9 +1525,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1591,12 +1647,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1648,12 +1706,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1687,12 +1747,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1726,12 +1788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1778,6 +1842,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1789,6 +1854,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1835,12 +1901,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1887,6 +1955,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1898,6 +1967,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1944,12 +2014,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1996,6 +2068,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -2007,6 +2080,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2053,12 +2127,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2105,6 +2181,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2116,6 +2193,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2162,12 +2240,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2214,6 +2294,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2225,6 +2306,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2271,12 +2353,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2323,6 +2407,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -2334,6 +2419,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2420,12 +2506,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -38,6 +39,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -59,6 +61,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -69,6 +72,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,6 +94,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -100,6 +105,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,6 +126,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
@@ -129,6 +136,7 @@
  premium feature.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -150,6 +158,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -158,6 +167,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,12 +189,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,11 +218,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,11 +246,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,6 +274,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -266,6 +283,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,6 +305,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -295,6 +314,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -316,6 +336,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -324,6 +345,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -345,9 +367,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,9 +393,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,6 +418,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -426,6 +453,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,6 +475,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -481,6 +510,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,12 +532,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,6 +561,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -538,6 +571,7 @@
  required for all other audio formats. For details, see [AudioEncoding][google.cloud.speech.v1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,6 +593,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -566,6 +601,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,12 +612,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -603,6 +641,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -610,6 +649,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,6 +670,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -637,6 +678,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,6 +699,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -664,6 +707,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,12 +718,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -701,6 +747,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -708,6 +755,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,6 +776,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -737,6 +786,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -758,6 +808,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -768,6 +819,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,9 +841,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,10 +338,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,12 +375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +406,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,9 +435,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,9 +461,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,12 +497,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -514,9 +528,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,12 +554,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,11 +583,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -591,9 +611,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -637,10 +659,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,10 +686,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,12 +775,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,9 +804,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -800,9 +830,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,9 +856,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -848,9 +882,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -872,9 +908,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -896,9 +934,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,12 +960,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -947,12 +989,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,11 +1018,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1000,11 +1046,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1026,9 +1074,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,9 +1100,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1128,12 +1180,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1165,6 +1219,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1176,6 +1231,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1224,12 +1280,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1263,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,10 +1352,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setAudioTopic(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1306,6 +1368,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1313,6 +1376,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1335,10 +1399,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setAudioTopicBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1349,6 +1415,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1356,6 +1423,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1388,6 +1456,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1399,6 +1468,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1422,12 +1492,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setIndustryNaicsCodeOfAudio(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1438,6 +1510,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1445,6 +1518,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1467,9 +1541,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setInteractionType(RecognitionMetadata.InteractionType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1480,6 +1556,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html">RecognitionMetadata.InteractionType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1487,6 +1564,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1509,9 +1587,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setInteractionTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1522,6 +1602,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1529,6 +1610,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1551,9 +1633,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setMicrophoneDistance(RecognitionMetadata.MicrophoneDistance value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1564,6 +1648,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html">RecognitionMetadata.MicrophoneDistance</a></td>
         <td><span class="parametername">value</span></td>
@@ -1571,6 +1656,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1593,9 +1679,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setMicrophoneDistanceValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1606,6 +1694,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1613,6 +1702,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1635,9 +1725,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMediaType(RecognitionMetadata.OriginalMediaType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1648,6 +1740,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html">RecognitionMetadata.OriginalMediaType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1655,6 +1748,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1677,9 +1771,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMediaTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1690,6 +1786,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1697,6 +1794,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1719,12 +1817,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMimeType(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1735,6 +1835,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1742,6 +1843,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1764,12 +1866,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMimeTypeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1780,6 +1884,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1787,6 +1892,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1809,11 +1915,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1824,6 +1932,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1831,6 +1940,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1853,11 +1963,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1868,6 +1980,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1875,6 +1988,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1897,9 +2011,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceType(RecognitionMetadata.RecordingDeviceType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1910,6 +2026,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html">RecognitionMetadata.RecordingDeviceType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1917,6 +2034,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1939,9 +2057,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1952,6 +2072,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1959,6 +2080,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1991,6 +2113,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2007,6 +2130,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2040,12 +2164,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
@@ -439,12 +439,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -468,10 +470,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,10 +497,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,12 +584,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,9 +613,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,9 +639,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,9 +665,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -677,9 +691,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -701,9 +717,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,9 +743,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,12 +769,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,12 +798,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,11 +849,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -851,11 +877,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -877,9 +905,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,9 +931,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1065,12 +1097,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1122,12 +1156,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1161,12 +1197,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,12 +1238,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1252,6 +1292,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1263,6 +1304,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1309,12 +1351,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1361,6 +1405,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1372,6 +1417,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1418,12 +1464,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1470,6 +1518,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1481,6 +1530,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1527,12 +1577,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1579,6 +1631,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1590,6 +1643,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1636,12 +1690,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1688,6 +1744,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1699,6 +1756,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1745,12 +1803,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1797,6 +1857,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1808,6 +1869,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1894,12 +1956,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,12 +81,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,9 +110,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,9 +136,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,9 +162,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,9 +188,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,9 +214,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -224,9 +240,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,12 +266,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,12 +295,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -302,11 +324,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -328,11 +352,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -354,9 +380,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -378,9 +406,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,9 +338,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,10 +363,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -432,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -483,9 +493,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,9 +519,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,9 +544,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,10 +569,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,10 +596,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,10 +622,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,9 +710,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,10 +736,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,9 +807,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,12 +822,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -821,10 +851,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,12 +867,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -872,12 +906,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,6 +945,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -920,6 +957,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -968,12 +1006,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1007,12 +1047,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1036,9 +1078,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,12 +1093,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,9 +1122,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1089,12 +1137,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1116,10 +1166,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,12 +1182,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1157,10 +1211,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,12 +1227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1208,6 +1266,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1219,6 +1278,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1252,6 +1312,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1268,6 +1329,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,12 +1363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,9 +356,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -378,9 +382,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -401,10 +407,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,10 +434,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,9 +586,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,10 +612,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,12 +735,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -778,12 +794,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -817,12 +835,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -856,12 +876,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -908,6 +930,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -919,6 +942,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -965,12 +989,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,6 +1043,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1028,6 +1055,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1074,12 +1102,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1126,6 +1156,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1137,6 +1168,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1183,12 +1215,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1235,6 +1269,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1246,6 +1281,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,12 +1328,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,6 +1382,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1355,6 +1394,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1401,12 +1441,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1453,6 +1495,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1464,6 +1507,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1550,12 +1594,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,10 +105,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,10 +157,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
@@ -232,10 +232,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,6 +287,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -294,6 +299,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,10 +323,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,12 +339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,10 +368,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +384,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -399,10 +413,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,6 +429,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -424,6 +441,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -445,10 +463,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +479,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -470,6 +491,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -491,10 +513,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,10 +539,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,12 +555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -628,12 +656,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,12 +697,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -696,10 +728,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,10 +838,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -845,10 +883,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,12 +899,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -886,10 +928,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,10 +954,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -934,10 +980,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,10 +1006,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,12 +1022,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -999,10 +1051,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,12 +1131,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeResponse.html">RecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1114,6 +1170,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1125,6 +1182,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1173,12 +1231,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,12 +1272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,10 +1303,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,12 +1319,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,6 +1358,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1303,6 +1370,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,6 +1404,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1352,6 +1421,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,10 +1445,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,6 +1461,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1400,6 +1473,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1421,10 +1495,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1435,6 +1511,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1446,6 +1523,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1477,12 +1555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
@@ -308,12 +308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -419,10 +421,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,12 +437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -460,10 +466,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,10 +492,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,10 +518,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,12 +534,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -549,10 +563,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,12 +729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeResponse.html">RecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -770,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -809,12 +829,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -848,12 +870,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -900,6 +924,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -911,6 +936,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -957,12 +983,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1009,6 +1037,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1020,6 +1049,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1066,12 +1096,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1118,6 +1150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1129,6 +1162,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1175,12 +1209,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1227,6 +1263,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1238,6 +1275,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1284,12 +1322,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,6 +1376,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1347,6 +1388,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1393,12 +1435,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1445,6 +1489,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1456,6 +1501,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1542,12 +1588,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,11 +338,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -401,11 +407,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,11 +435,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,12 +473,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -492,9 +504,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,11 +614,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,11 +642,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,11 +670,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,9 +698,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,12 +778,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -793,6 +817,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -804,6 +829,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -852,12 +878,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -891,12 +919,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -920,11 +950,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setEnableSpeakerDiarization(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,6 +967,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -942,6 +975,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,6 +1008,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -985,6 +1020,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,11 +1044,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setMaxSpeakerCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,6 +1061,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1030,6 +1069,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1052,11 +1092,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setMinSpeakerCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,6 +1109,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1074,6 +1117,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1106,6 +1150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1122,6 +1167,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1145,9 +1191,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setSpeakerTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,6 +1206,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1165,6 +1214,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1197,12 +1247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
@@ -363,12 +363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -452,11 +454,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,11 +482,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,11 +510,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,9 +582,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,12 +726,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -773,12 +785,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -812,12 +826,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -851,12 +867,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -903,6 +921,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -914,6 +933,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -960,12 +980,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1012,6 +1034,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1023,6 +1046,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1069,12 +1093,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,6 +1147,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1132,6 +1159,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1178,12 +1206,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1230,6 +1260,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1241,6 +1272,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1287,12 +1319,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1339,6 +1373,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1350,6 +1385,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1396,12 +1432,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1448,6 +1486,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1459,6 +1498,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1545,12 +1585,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -79,11 +83,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,9 +111,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
@@ -96,8 +96,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechClient(SpeechSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,12 +110,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechClient_SpeechClient_" data-uid="com.google.cloud.speech.v1.SpeechClient.SpeechClient*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechClient_SpeechClient_com_google_cloud_speech_v1_stub_SpeechStub_" data-uid="com.google.cloud.speech.v1.SpeechClient.SpeechClient(com.google.cloud.speech.v1.stub.SpeechStub)" class="notranslate">SpeechClient(SpeechStub stub)</h3>
@@ -130,12 +134,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStub.html">SpeechStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -154,6 +160,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -165,6 +172,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -206,8 +214,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient with default settings.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,8 +253,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create(SpeechSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,12 +267,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -297,8 +311,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create(SpeechStub stub)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given stub for making calls. This is for advanced usage - prefer using create(SpeechSettings).</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStub.html">SpeechStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,8 +354,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationsClient getOperationsClient()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the OperationsClient that can be used to query the status of a long-running operation returned by another API method call.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,6 +458,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationFuture&lt;LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeAsync(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -449,6 +470,7 @@
    LongRunningRecognizeResponse response = speechClient.longRunningRecognizeAsync(request).get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +481,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -466,6 +489,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -487,6 +511,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationFuture&lt;LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -496,6 +521,7 @@
        speechClient.longRunningRecognizeAsync(config, audio).get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,6 +532,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">config</span></td>
@@ -520,6 +547,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -541,6 +569,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -554,6 +583,7 @@
    Operation response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,6 +604,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -588,6 +619,7 @@
    LongRunningRecognizeResponse response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,6 +640,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse recognize(RecognitionConfig config, RecognitionAudio audio)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -616,6 +649,7 @@
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,6 +660,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">config</span></td>
@@ -640,6 +675,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -661,6 +697,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -672,6 +709,7 @@
    RecognizeResponse response = speechClient.recognize(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -682,6 +720,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -689,6 +728,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -710,6 +750,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -723,6 +764,7 @@
    RecognizeResponse response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,6 +795,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs bidirectional streaming speech recognition: receive results while sending audio. This method is only available via the gRPC API (not REST).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -765,6 +808,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
@@ -231,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addAllPhrases(Iterable&lt;String&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -244,6 +245,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,6 +256,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">values</span></td>
@@ -261,6 +264,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,6 +287,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrases(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -296,6 +301,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,6 +312,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -313,6 +320,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -335,6 +343,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrasesBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -348,6 +357,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,6 +368,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -365,6 +376,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -397,6 +409,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -408,6 +421,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -503,12 +517,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -542,12 +558,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -571,6 +589,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearPhrases()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -584,6 +603,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,6 +709,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -702,6 +723,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,6 +734,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -719,6 +742,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -741,6 +765,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -754,6 +779,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -764,6 +790,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -771,6 +798,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -793,6 +821,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -806,6 +835,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -827,6 +857,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -840,6 +871,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -915,12 +947,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -952,6 +986,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -963,6 +998,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,12 +1047,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1050,12 +1088,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1089,6 +1129,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1100,6 +1141,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1123,6 +1165,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setPhrases(int index, String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -1136,6 +1179,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1146,6 +1190,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1159,6 +1204,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1191,6 +1237,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1207,6 +1254,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1240,12 +1288,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
@@ -307,12 +307,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -418,6 +420,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -431,6 +434,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,6 +445,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -448,6 +453,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -470,6 +476,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -483,6 +490,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,6 +501,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -500,6 +509,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -522,6 +532,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -535,6 +546,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,6 +568,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -569,6 +582,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,12 +744,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -787,12 +803,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -826,12 +844,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,12 +885,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -917,6 +939,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -928,6 +951,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,12 +998,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1026,6 +1052,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1037,6 +1064,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1083,12 +1111,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1135,6 +1165,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1146,6 +1177,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1192,12 +1224,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1244,6 +1278,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1255,6 +1290,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,12 +1337,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1353,6 +1391,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1364,6 +1403,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1410,12 +1450,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1462,6 +1504,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1473,6 +1516,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1559,12 +1603,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -40,6 +41,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,6 +52,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -57,6 +60,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -79,6 +83,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -92,6 +97,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -102,6 +108,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -109,6 +116,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -131,6 +139,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -144,6 +153,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -165,6 +175,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;String&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -178,6 +189,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Operation longRunningRecognize(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -204,9 +210,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,12 +225,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;Operation&gt; longRunningRecognize(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -204,9 +210,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;RecognizeResponse&gt; recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,12 +225,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
@@ -97,6 +97,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void longRunningRecognize(LongRunningRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -104,6 +105,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,6 +116,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -125,15 +128,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_recognize_" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.recognize*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_recognize_com_google_cloud_speech_v1_RecognizeRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1_RecognizeResponse__" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.recognize(com.google.cloud.speech.v1.RecognizeRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1.RecognizeResponse&gt;)" class="notranslate">recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,6 +150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -155,15 +162,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_streamingRecognize_" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.streamingRecognize*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechImplBase_streamingRecognize_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1_StreamingRecognizeResponse__" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.streamingRecognize(io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1.StreamingRecognizeResponse&gt;)" class="notranslate">streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,12 +184,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void longRunningRecognize(LongRunningRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,6 +181,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -188,15 +193,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechGrpc_SpeechStub_recognize_" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.recognize*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechStub_recognize_com_google_cloud_speech_v1_RecognizeRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1_RecognizeResponse__" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.recognize(com.google.cloud.speech.v1.RecognizeRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1.RecognizeResponse&gt;)" class="notranslate">recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,6 +215,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -218,15 +227,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechGrpc_SpeechStub_streamingRecognize_" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.streamingRecognize*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechGrpc_SpeechStub_streamingRecognize_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1_StreamingRecognizeResponse__" data-uid="com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.streamingRecognize(io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1.StreamingRecognizeResponse&gt;)" class="notranslate">streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -237,12 +249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.html
@@ -167,8 +167,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechBlockingStub newBlockingStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -206,8 +210,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechFutureStub newFutureStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,12 +224,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -245,8 +253,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechStub newStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,12 +267,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechProto.html
@@ -94,12 +94,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistry</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechProto_registerAllExtensions_" data-uid="com.google.cloud.speech.v1.SpeechProto.registerAllExtensions*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechProto_registerAllExtensions_com_google_protobuf_ExtensionRegistryLite_" data-uid="com.google.cloud.speech.v1.SpeechProto.registerAllExtensions(com.google.protobuf.ExtensionRegistryLite)" class="notranslate">registerAllExtensions(ExtensionRegistryLite registry)</h3>
@@ -116,12 +118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistryLite</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
@@ -230,11 +230,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAllWords(Iterable&lt;? extends WordInfo&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,12 +247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.WordInfo</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -282,6 +286,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -293,6 +298,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -316,11 +322,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,12 +339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,11 +368,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,12 +385,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.WordInfo.Builder.html">WordInfo.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,11 +414,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(int index, WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -426,6 +443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -447,11 +465,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(int index, WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,6 +482,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -473,6 +494,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -494,11 +516,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addWordsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,11 +543,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addWordsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,12 +560,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -623,6 +651,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -632,6 +661,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,12 +693,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -702,12 +734,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -731,9 +765,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,11 +791,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearWords()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -802,6 +840,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -811,6 +850,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,9 +934,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,9 +960,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,11 +986,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -957,12 +1003,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -984,11 +1032,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder getWordsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1026,11 +1078,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo.Builder&gt; getWordsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1051,11 +1105,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,11 +1132,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,11 +1159,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1116,12 +1176,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1143,11 +1205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1222,12 +1286,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1259,6 +1325,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1270,6 +1337,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1318,12 +1386,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1357,12 +1427,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1386,11 +1458,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder removeWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1401,12 +1475,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1428,6 +1504,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setConfidence(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -1437,6 +1514,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1447,6 +1525,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -1454,6 +1533,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1486,6 +1566,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1497,6 +1578,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1530,6 +1612,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1546,6 +1629,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1569,9 +1653,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscript(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1582,6 +1668,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1589,6 +1676,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1611,9 +1699,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscriptBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1624,6 +1714,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1631,6 +1722,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1663,12 +1755,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1692,11 +1786,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setWords(int index, WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1707,6 +1803,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1718,6 +1815,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1739,11 +1837,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setWords(int index, WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1754,6 +1854,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1765,6 +1866,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -373,6 +375,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -382,6 +385,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,9 +511,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,9 +537,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,11 +585,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,12 +602,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -619,11 +631,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,11 +658,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,11 +685,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,12 +702,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -711,11 +731,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -832,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -889,12 +913,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -928,12 +954,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -967,12 +995,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,6 +1049,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1030,6 +1061,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,12 +1108,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,6 +1162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1139,6 +1174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1185,12 +1221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,6 +1275,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1248,6 +1287,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,12 +1334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,6 +1388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1357,6 +1400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1403,12 +1447,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1455,6 +1501,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1466,6 +1513,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1512,12 +1560,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1564,6 +1614,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1575,6 +1626,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1661,12 +1713,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -36,6 +37,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -57,9 +59,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,9 +85,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,11 +111,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,12 +128,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -147,11 +157,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,11 +184,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -197,11 +211,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,12 +228,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -239,11 +257,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
@@ -230,12 +230,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -273,12 +277,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -289,12 +295,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -316,12 +324,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -332,12 +342,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,12 +371,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,6 +389,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -386,6 +401,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -407,12 +423,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -423,6 +441,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -434,6 +453,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -455,12 +475,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,12 +503,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,12 +521,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -534,6 +560,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -545,6 +572,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -630,12 +658,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,11 +686,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,12 +724,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -731,12 +765,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -782,12 +818,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -798,12 +836,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -825,12 +865,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -841,12 +883,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +912,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,12 +940,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,12 +968,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,12 +996,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -962,12 +1014,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -989,12 +1043,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1015,11 +1071,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,12 +1215,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1194,6 +1254,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1205,6 +1266,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1253,12 +1315,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,12 +1356,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,12 +1387,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1337,12 +1405,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1364,12 +1434,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1380,6 +1452,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1391,6 +1464,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1412,12 +1486,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1428,6 +1504,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1439,6 +1516,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1460,11 +1538,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setChannelTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1475,6 +1555,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1482,6 +1563,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1514,6 +1596,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1525,6 +1608,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1558,6 +1642,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1574,6 +1659,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1607,12 +1693,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,12 +356,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,12 +374,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -397,12 +403,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -423,12 +431,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -449,12 +459,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -465,12 +477,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -492,12 +506,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,11 +534,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,12 +784,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -823,12 +843,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,12 +884,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -901,12 +925,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -953,6 +979,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -964,6 +991,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1010,12 +1038,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1062,6 +1092,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1073,6 +1104,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1119,12 +1151,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1171,6 +1205,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1182,6 +1217,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1228,12 +1264,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1280,6 +1318,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1291,6 +1330,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1337,12 +1377,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1389,6 +1431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1400,6 +1443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1446,12 +1490,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1498,6 +1544,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1509,6 +1556,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1595,12 +1643,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -43,12 +45,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -70,12 +74,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,12 +102,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,12 +130,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,12 +148,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -165,12 +177,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,11 +205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.Builder.html
@@ -154,12 +154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_com_google_cloud_speech_v1_SpeechSettings_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder(com.google.cloud.speech.v1.SpeechSettings)" class="notranslate">Builder(SpeechSettings settings)</h3>
@@ -176,12 +178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1_SpeechSettings_Builder_Builder_com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_" data-uid="com.google.cloud.speech.v1.SpeechSettings.Builder.Builder(com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder)" class="notranslate">Builder(SpeechStubSettings.Builder stubSettings)</h3>
@@ -198,12 +202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html">SpeechStubSettings.Builder</a></td>
         <td><span class="parametername">stubSettings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -212,9 +218,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,12 +233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -324,8 +334,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings.Builder&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,8 +358,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,8 +382,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,8 +406,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings.Builder&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechSettings.Builder.html">SpeechSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -156,12 +158,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -218,8 +222,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,8 +246,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,8 +270,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -304,8 +314,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,8 +338,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,8 +362,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +386,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,8 +410,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,8 +434,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,12 +448,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -453,8 +477,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +501,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,8 +525,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,10 +339,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,12 +375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +406,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,12 +445,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -466,6 +476,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -478,6 +489,7 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -521,10 +533,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,10 +560,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,10 +586,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,12 +674,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,6 +703,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -695,6 +716,7 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,10 +738,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -785,10 +809,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -799,12 +825,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -836,12 +864,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -873,6 +903,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -884,6 +915,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,12 +964,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,12 +1005,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1000,10 +1036,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,12 +1052,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1041,10 +1081,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1055,12 +1097,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1092,6 +1136,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1103,6 +1148,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1126,12 +1172,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setInterimResults(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,6 +1190,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1149,6 +1198,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1181,6 +1231,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1197,6 +1248,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1220,6 +1272,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setSingleUtterance(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -1232,6 +1285,7 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1242,6 +1296,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1249,6 +1304,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1281,12 +1337,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
@@ -345,12 +345,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -374,10 +376,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -399,10 +403,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,12 +489,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,6 +562,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -566,6 +575,7 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,10 +619,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,12 +742,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -787,12 +801,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -826,12 +842,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,12 +883,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -917,6 +937,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -928,6 +949,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,12 +996,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1026,6 +1050,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1037,6 +1062,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1083,12 +1109,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1135,6 +1163,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1146,6 +1175,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1192,12 +1222,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1244,6 +1276,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1255,6 +1288,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,12 +1335,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1353,6 +1389,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1364,6 +1401,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1410,12 +1448,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1462,6 +1502,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1473,6 +1514,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1559,12 +1601,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -76,12 +80,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,6 +109,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -115,6 +122,7 @@
  `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -136,10 +144,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
@@ -231,12 +231,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -247,12 +249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -274,12 +278,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -290,12 +296,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,12 +325,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -333,12 +343,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -360,12 +372,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,6 +390,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -387,6 +402,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -408,12 +424,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,6 +442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -435,6 +454,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -456,12 +476,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,12 +504,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,12 +522,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -535,6 +561,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -546,6 +573,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -631,12 +659,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,11 +687,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,12 +725,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -722,6 +756,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -729,6 +764,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -750,11 +786,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,12 +824,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -815,10 +855,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,6 +881,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -846,6 +889,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,12 +933,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -905,12 +951,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,12 +980,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,12 +998,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -975,12 +1027,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,12 +1055,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1027,12 +1083,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,12 +1111,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1069,12 +1129,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1096,12 +1158,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,11 +1186,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,6 +1276,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1217,6 +1284,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1238,11 +1306,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1264,11 +1334,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1290,10 +1362,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1315,10 +1389,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getResultEndTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,10 +1415,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1363,6 +1441,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -1370,6 +1449,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,10 +1471,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,12 +1552,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,6 +1591,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1518,6 +1603,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1566,12 +1652,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1595,10 +1683,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeResultEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,12 +1699,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1646,12 +1738,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1675,12 +1769,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1691,12 +1787,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1718,12 +1816,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1734,6 +1834,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1745,6 +1846,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1766,12 +1868,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1782,6 +1886,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1793,6 +1898,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1814,11 +1920,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setChannelTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1829,6 +1937,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1836,6 +1945,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1868,6 +1978,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1879,6 +1990,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1902,6 +2014,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setIsFinal(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1909,6 +2022,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1919,6 +2033,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1926,6 +2041,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1948,11 +2064,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1963,6 +2081,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1970,6 +2089,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1992,11 +2112,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2007,6 +2129,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -2014,6 +2137,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2046,6 +2170,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2062,6 +2187,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2085,10 +2211,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setResultEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2099,12 +2227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2126,10 +2256,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setResultEndTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2140,12 +2272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2167,6 +2301,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setStability(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -2174,6 +2309,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2184,6 +2320,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -2191,6 +2328,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2223,12 +2361,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
@@ -402,12 +402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -431,12 +433,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,12 +451,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -474,12 +480,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,12 +508,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,12 +536,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,12 +554,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -569,12 +583,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -595,11 +611,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,6 +699,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -688,6 +707,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,11 +729,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -735,11 +757,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,10 +807,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,10 +834,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -854,6 +882,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -861,6 +890,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -904,10 +934,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1025,12 +1057,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1082,12 +1116,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,12 +1157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,12 +1198,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,6 +1252,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1223,6 +1264,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1269,12 +1311,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,6 +1365,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1332,6 +1377,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1378,12 +1424,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1430,6 +1478,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1441,6 +1490,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1487,12 +1537,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,6 +1591,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1550,6 +1603,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,12 +1650,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1648,6 +1704,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1659,6 +1716,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1705,12 +1763,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1757,6 +1817,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1768,6 +1829,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1854,12 +1916,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -43,12 +45,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -70,12 +74,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,12 +102,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,12 +130,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,12 +148,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -165,12 +177,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,11 +205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,6 +233,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -224,6 +241,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,11 +263,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,11 +291,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag of
  the language in this result. This language code was detected to have the
  most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,10 +319,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,10 +346,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,6 +372,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -353,6 +380,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,10 +402,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
@@ -244,6 +244,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -255,6 +256,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -340,6 +342,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -350,6 +353,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,12 +385,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -420,12 +426,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -449,11 +457,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,6 +526,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -526,6 +537,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,11 +621,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,11 +649,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder getStreamingConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,11 +676,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,6 +723,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -715,6 +734,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -736,11 +756,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,12 +838,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -864,6 +889,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -912,12 +938,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -941,11 +969,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -956,12 +986,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -993,12 +1025,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1022,6 +1056,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setAudioContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -1032,6 +1067,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,6 +1078,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1049,6 +1086,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1081,6 +1119,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1092,6 +1131,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1125,6 +1165,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1141,6 +1182,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1164,11 +1206,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1179,12 +1223,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,11 +1252,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,12 +1269,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html">StreamingRecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1258,12 +1308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
@@ -329,12 +329,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,6 +360,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -368,6 +371,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,11 +497,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,11 +525,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,6 +594,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -596,6 +605,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,11 +627,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,12 +751,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,12 +810,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -835,12 +851,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -874,12 +892,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -926,6 +946,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -937,6 +958,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -983,12 +1005,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1035,6 +1059,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1046,6 +1071,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1092,12 +1118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1144,6 +1172,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1155,6 +1184,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1201,12 +1231,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1253,6 +1285,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1264,6 +1297,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1310,12 +1344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1362,6 +1398,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1373,6 +1410,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1419,12 +1457,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1471,6 +1511,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1482,6 +1523,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1568,12 +1610,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -37,6 +38,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,11 +60,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,11 +88,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,6 +135,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -139,6 +146,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,11 +168,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
@@ -265,12 +265,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addAllResults(Iterable&lt;? extends StreamingRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,12 +283,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1.StreamingRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -318,6 +322,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -329,6 +334,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -352,12 +358,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,12 +376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,12 +405,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +423,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html">StreamingRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -438,12 +452,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,6 +470,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -465,6 +482,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -486,12 +504,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,6 +522,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -513,6 +534,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -534,12 +556,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,12 +584,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,12 +602,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -665,10 +693,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,12 +729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -738,12 +770,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -767,12 +801,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,9 +829,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,10 +939,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -926,10 +966,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status.Builder getErrorBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -950,10 +992,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,12 +1018,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,12 +1036,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,12 +1065,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1033,12 +1083,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1060,12 +1112,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1086,12 +1140,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,12 +1168,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1138,12 +1196,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1154,12 +1214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1181,12 +1243,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,9 +1271,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,9 +1297,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,10 +1323,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1324,10 +1394,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,12 +1410,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,12 +1449,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1412,6 +1488,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1423,6 +1500,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1471,12 +1549,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1510,12 +1590,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,12 +1621,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1555,12 +1639,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1582,10 +1668,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1596,12 +1684,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1623,10 +1713,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1637,12 +1729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1674,6 +1768,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1685,6 +1780,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1718,6 +1814,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1734,6 +1831,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1757,12 +1855,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1773,6 +1873,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1784,6 +1885,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1805,12 +1907,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1821,6 +1925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1832,6 +1937,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1853,9 +1959,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setSpeechEventType(StreamingRecognizeResponse.SpeechEventType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1866,6 +1974,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html">StreamingRecognizeResponse.SpeechEventType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1873,6 +1982,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1895,9 +2005,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setSpeechEventTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1908,6 +2020,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1915,6 +2028,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1947,12 +2061,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
@@ -379,12 +379,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -468,10 +470,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,10 +497,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -539,12 +545,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,12 +563,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -582,12 +592,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,12 +620,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,12 +648,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,12 +666,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -677,12 +695,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,9 +745,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,9 +771,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,10 +819,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -916,12 +942,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -973,12 +1001,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1012,12 +1042,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1051,12 +1083,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1103,6 +1137,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1114,6 +1149,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,12 +1196,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,6 +1250,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1223,6 +1262,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1269,12 +1309,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,6 +1363,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1332,6 +1375,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1378,12 +1422,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1430,6 +1476,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1441,6 +1488,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1487,12 +1535,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,6 +1589,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1550,6 +1601,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,12 +1648,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1648,6 +1702,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1659,6 +1714,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1745,12 +1801,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -76,12 +80,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,12 +98,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -119,12 +127,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,12 +155,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,12 +183,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -187,12 +201,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -214,12 +230,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,9 +258,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,9 +284,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -288,10 +310,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,6 +338,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -344,6 +347,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,12 +378,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -413,12 +419,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -442,6 +450,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -449,6 +458,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -470,6 +480,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -478,6 +489,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,9 +510,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,6 +620,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -614,6 +629,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,6 +651,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getEndTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -643,6 +660,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,6 +681,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -671,6 +690,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,6 +711,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -698,6 +719,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -719,6 +741,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -727,6 +750,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -748,6 +772,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getStartTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -756,6 +781,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -776,6 +802,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -784,6 +811,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,9 +832,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,9 +858,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -852,6 +884,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -860,6 +893,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -881,6 +915,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -889,6 +924,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -954,6 +990,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -962,6 +999,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,12 +1010,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1009,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1046,6 +1088,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1057,6 +1100,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1105,12 +1149,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1134,6 +1180,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeStartTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1142,6 +1189,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1152,12 +1200,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1189,12 +1239,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1218,6 +1270,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1226,6 +1279,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1236,12 +1290,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1263,6 +1319,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setEndTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1271,6 +1328,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1281,12 +1339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1318,6 +1378,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1329,6 +1390,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1362,6 +1424,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1378,6 +1441,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1401,6 +1465,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setSpeakerTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -1408,6 +1473,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1418,6 +1484,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1425,6 +1492,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1447,6 +1515,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setStartTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1455,6 +1524,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1465,12 +1535,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1492,6 +1564,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setStartTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1500,6 +1573,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1510,12 +1584,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1547,12 +1623,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1576,9 +1654,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setWord(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1589,6 +1669,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1596,6 +1677,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1618,9 +1700,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setWordBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1631,6 +1715,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1638,6 +1723,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
@@ -363,12 +363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -452,6 +454,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -460,6 +463,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,6 +485,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -489,6 +494,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,6 +559,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -560,6 +567,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,6 +589,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -589,6 +598,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -610,6 +620,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -618,6 +629,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,9 +672,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,9 +698,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,6 +724,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -716,6 +733,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -737,6 +755,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -745,6 +764,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,12 +882,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -919,12 +941,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -958,12 +982,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -997,12 +1023,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1049,6 +1077,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1060,6 +1089,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1106,12 +1136,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1158,6 +1190,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1169,6 +1202,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1215,12 +1249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1267,6 +1303,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1278,6 +1315,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1324,12 +1362,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1376,6 +1416,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1387,6 +1428,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1433,12 +1475,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1485,6 +1529,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1496,6 +1541,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1542,12 +1588,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1594,6 +1642,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1605,6 +1654,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1691,12 +1741,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -35,6 +36,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,6 +58,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -64,6 +67,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,6 +88,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -91,6 +96,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -112,6 +118,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -120,6 +127,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -141,6 +149,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -149,6 +158,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,9 +179,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -193,9 +205,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -225,6 +240,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,6 +262,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -254,6 +271,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
@@ -88,6 +88,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">com.google.longrunning.Operation</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -109,6 +110,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -140,6 +142,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -156,6 +159,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -187,6 +191,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -203,6 +208,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -234,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -250,6 +257,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -281,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -297,6 +306,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -328,6 +338,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -344,6 +355,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,6 +387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -391,6 +404,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
@@ -86,8 +86,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -98,6 +100,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -109,14 +112,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_GrpcSpeechStub_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.GrpcSpeechStub*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_GrpcSpeechStub_GrpcSpeechStub_com_google_cloud_speech_v1_stub_SpeechStubSettings_com_google_api_gax_rpc_ClientContext_com_google_api_gax_grpc_GrpcStubCallableFactory_" data-uid="com.google.cloud.speech.v1.stub.GrpcSpeechStub.GrpcSpeechStub(com.google.cloud.speech.v1.stub.SpeechStubSettings,com.google.api.gax.rpc.ClientContext,com.google.api.gax.grpc.GrpcStubCallableFactory)" class="notranslate">GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +133,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -143,6 +150,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -161,6 +169,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -172,6 +181,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -225,12 +235,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -277,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
@@ -288,6 +301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -334,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
@@ -157,12 +157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1_stub_SpeechStubSettings_Builder_Builder_com_google_cloud_speech_v1_stub_SpeechStubSettings_" data-uid="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.Builder(com.google.cloud.speech.v1.stub.SpeechStubSettings)" class="notranslate">Builder(SpeechStubSettings settings)</h3>
@@ -179,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -193,9 +197,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +212,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,8 +293,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings.Builder&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,8 +317,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -329,8 +341,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,8 +365,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings.Builder&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html">SpeechStubSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -201,8 +203,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,8 +227,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,8 +251,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,8 +295,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,8 +319,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,8 +343,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,8 +367,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,8 +391,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechStubSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,8 +415,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechStubSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,12 +429,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -436,8 +458,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +482,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +506,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
@@ -242,6 +242,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -253,6 +254,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -348,12 +350,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,9 +381,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clearLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,12 +416,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -439,10 +447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clearProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,9 +473,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder clearStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,9 +582,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -593,9 +607,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getLastUpdateTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,9 +632,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,10 +657,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,9 +683,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,9 +708,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getStartTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,9 +733,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,9 +758,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,9 +783,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -832,12 +862,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html">AsyncRecognizeMetadata</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -869,6 +901,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -880,6 +913,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -928,12 +962,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -957,9 +993,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder mergeLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,12 +1008,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -997,9 +1037,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder mergeStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1010,12 +1052,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1047,12 +1091,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1086,6 +1132,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1097,6 +1144,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1120,9 +1168,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1133,12 +1183,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,9 +1212,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setLastUpdateTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1173,12 +1227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,10 +1256,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setProgressPercent(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,12 +1272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1251,6 +1311,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1267,6 +1328,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1290,9 +1352,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1303,12 +1367,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1330,9 +1396,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeMetadata.Builder setStartTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1343,12 +1411,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1380,12 +1450,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
@@ -346,12 +346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,9 +437,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,9 +462,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,10 +509,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,9 +557,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,9 +582,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,9 +629,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -640,9 +654,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -759,12 +775,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html">AsyncRecognizeMetadata</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -816,12 +834,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -855,12 +875,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -907,6 +929,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -918,6 +941,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -964,12 +988,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1016,6 +1042,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1027,6 +1054,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1073,12 +1101,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1125,6 +1155,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1136,6 +1167,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1182,12 +1214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1234,6 +1268,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1245,6 +1280,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1291,12 +1327,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1343,6 +1381,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1354,6 +1393,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1400,12 +1440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1452,6 +1494,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1463,6 +1506,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1549,12 +1593,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,9 +52,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,10 +77,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,9 +103,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,9 +128,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -143,9 +153,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -166,9 +178,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,9 +338,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,10 +363,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -432,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -483,9 +493,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,9 +518,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,9 +543,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,10 +568,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,10 +594,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,10 +620,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,9 +708,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,10 +733,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,9 +803,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,12 +818,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -817,10 +847,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -831,12 +863,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +902,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +941,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -916,6 +953,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -964,12 +1002,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1003,12 +1043,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1032,9 +1074,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,12 +1089,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1072,9 +1118,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1085,12 +1133,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,10 +1162,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1126,12 +1178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1153,10 +1207,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,12 +1223,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1204,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1215,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1248,6 +1308,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1264,6 +1325,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1297,12 +1359,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,9 +356,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -377,9 +381,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,10 +406,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,10 +432,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,9 +584,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,10 +609,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,12 +731,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -774,12 +790,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -813,12 +831,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,6 +885,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -876,6 +897,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -922,12 +944,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,6 +998,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -985,6 +1010,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1031,12 +1057,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1083,6 +1111,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1094,6 +1123,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1140,12 +1170,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1192,6 +1224,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1203,6 +1236,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1249,12 +1283,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,6 +1337,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1312,6 +1349,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1358,12 +1396,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1410,6 +1450,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1421,6 +1462,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,12 +1549,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,9 +52,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,10 +77,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,10 +103,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,9 +129,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,10 +154,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
@@ -233,10 +233,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -247,12 +249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1beta1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -284,6 +288,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -295,6 +300,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -318,10 +324,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -332,12 +340,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,10 +369,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,12 +385,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,10 +414,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,6 +430,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -425,6 +442,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -446,10 +464,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,6 +480,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -471,6 +492,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -492,10 +514,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,10 +540,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,12 +556,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -629,12 +657,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -668,12 +698,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -697,10 +729,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -805,10 +839,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -819,12 +855,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -846,10 +884,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,12 +900,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -887,10 +929,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -911,10 +955,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,10 +981,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -959,10 +1007,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -973,12 +1023,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1000,10 +1052,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1078,12 +1132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html">AsyncRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1115,6 +1171,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1126,6 +1183,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1174,12 +1232,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1213,12 +1273,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1242,10 +1304,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,12 +1320,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1293,6 +1359,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1304,6 +1371,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1337,6 +1405,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1353,6 +1422,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1376,10 +1446,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1390,6 +1462,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1401,6 +1474,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1422,10 +1496,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AsyncRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1436,6 +1512,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1447,6 +1524,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1478,12 +1556,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
@@ -309,12 +309,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -420,10 +422,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -434,12 +438,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -461,10 +467,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,10 +493,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -509,10 +519,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,12 +535,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -550,10 +564,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -714,12 +730,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html">AsyncRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -771,12 +789,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -810,12 +830,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,6 +884,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -873,6 +896,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -919,12 +943,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,6 +997,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -982,6 +1009,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1028,12 +1056,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1080,6 +1110,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1091,6 +1122,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1137,12 +1169,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1189,6 +1223,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1200,6 +1235,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1246,12 +1282,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1298,6 +1336,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1309,6 +1348,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1355,12 +1395,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1407,6 +1449,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1418,6 +1461,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1504,12 +1548,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
@@ -243,6 +243,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -254,6 +255,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,11 +361,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,12 +398,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,12 +439,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -462,6 +470,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -470,6 +479,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -532,11 +542,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,6 +631,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -627,6 +640,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -647,6 +661,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -655,6 +670,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -729,12 +745,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -766,6 +784,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -777,6 +796,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -825,12 +845,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -864,12 +886,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -893,11 +917,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -908,12 +934,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -945,6 +973,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -956,6 +985,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -989,6 +1019,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1005,6 +1036,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1038,12 +1070,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1067,6 +1101,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUri(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -1075,6 +1110,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1085,12 +1121,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,6 +1150,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUriBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -1120,6 +1159,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,12 +1170,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
@@ -328,12 +328,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,6 +532,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -536,6 +541,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -556,6 +562,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -564,6 +571,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,12 +688,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -737,12 +747,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -776,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -828,6 +842,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -839,6 +854,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -885,12 +901,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -937,6 +955,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -948,6 +967,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -994,12 +1014,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1046,6 +1068,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1057,6 +1080,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1103,12 +1127,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1155,6 +1181,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1166,6 +1193,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,12 +1240,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1264,6 +1294,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1275,6 +1306,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,12 +1353,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1373,6 +1407,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1384,6 +1419,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1470,12 +1506,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
@@ -47,11 +47,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, protobuffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -72,6 +74,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -80,6 +83,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -100,6 +104,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. Currently, only Google Cloud Storage URIs are
  supported, which must be specified in the following format:
@@ -108,6 +113,7 @@
  [Request URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,9 +339,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,12 +374,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -399,6 +405,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -406,6 +413,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,6 +434,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -434,6 +443,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,12 +474,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -493,12 +505,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,6 +533,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSampleRate()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -526,6 +541,7 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,9 +562,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -653,9 +671,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -676,9 +696,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,6 +721,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -706,6 +729,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -726,6 +750,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -733,6 +758,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,6 +779,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -761,6 +788,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,12 +809,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -807,6 +837,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRate()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -814,6 +845,7 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -834,9 +866,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -857,9 +891,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder getSpeechContextBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -880,9 +916,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,9 +941,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -980,12 +1020,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,6 +1059,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1028,6 +1071,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,12 +1120,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1105,9 +1151,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeSpeechContext(SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1118,12 +1166,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1155,12 +1205,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1184,9 +1236,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncoding(RecognitionConfig.AudioEncoding value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1197,12 +1251,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html">RecognitionConfig.AudioEncoding</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1224,9 +1280,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncodingValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1237,12 +1295,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1274,6 +1334,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1285,6 +1346,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1308,6 +1370,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -1315,6 +1378,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1325,12 +1389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1352,6 +1418,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -1359,6 +1426,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1369,12 +1437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1396,6 +1466,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMaxAlternatives(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -1404,6 +1475,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1414,12 +1486,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1441,12 +1515,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setProfanityFilter(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,12 +1533,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1494,6 +1572,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1510,6 +1589,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1533,6 +1613,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSampleRate(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1540,6 +1621,7 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,12 +1632,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1577,9 +1661,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContext(SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1590,12 +1676,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1617,9 +1705,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContext(SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1630,12 +1720,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContext.Builder.html">SpeechContext.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1667,12 +1759,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
@@ -402,12 +402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -491,9 +493,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,9 +518,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -537,6 +543,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -544,6 +551,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -564,6 +572,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -571,6 +580,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -591,6 +601,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -599,6 +610,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -641,12 +653,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -667,6 +681,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRate()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -674,6 +689,7 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,9 +732,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,9 +757,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -784,9 +804,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -903,12 +925,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -960,12 +984,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -999,12 +1025,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1051,6 +1079,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1062,6 +1091,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1108,12 +1138,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,6 +1192,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1171,6 +1204,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1217,12 +1251,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1269,6 +1305,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1280,6 +1317,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1326,12 +1364,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1378,6 +1418,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1389,6 +1430,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1435,12 +1477,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1487,6 +1531,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1498,6 +1543,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1544,12 +1590,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,6 +1644,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1607,6 +1656,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1693,12 +1743,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,9 +52,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Encoding of audio data sent in all `RecognitionAudio` messages.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,6 +77,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -80,6 +85,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -100,6 +106,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* The language of the supplied audio as a BCP-47 language tag.
  Example: &quot;en-GB&quot;  https://www.rfc-editor.org/rfc/bcp/bcp47.txt
  If omitted, defaults to &quot;en-US&quot;. See
@@ -107,6 +114,7 @@
  for a list of the currently supported language codes.
 </code></pre><p><code>string language_code = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +135,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -135,6 +144,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -155,12 +165,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -181,6 +193,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSampleRate()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -188,6 +201,7 @@
  the audio source (instead of re-sampling).
 </code></pre><p><code>int32 sample_rate = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -208,9 +222,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContext getSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -231,9 +247,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContextOrBuilder getSpeechContextOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,9 +272,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasSpeechContext()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A means to provide context to assist the speech recognition.
 </code></pre><p><code>.google.cloud.speech.v1beta1.SpeechContext speech_context = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
@@ -231,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addAllPhrases(Iterable&lt;String&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -239,6 +240,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,12 +251,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -276,6 +280,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrases(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -284,6 +289,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -294,12 +300,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -321,6 +329,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrasesBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -329,6 +338,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -339,12 +349,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -376,6 +388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -387,6 +400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -482,12 +496,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -521,12 +537,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -550,6 +568,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearPhrases()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -558,6 +577,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,6 +682,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -670,6 +691,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -680,12 +702,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -707,6 +731,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -715,6 +740,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,12 +751,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -752,6 +780,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -760,6 +789,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -780,6 +810,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -788,6 +819,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,12 +894,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -899,6 +933,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -910,6 +945,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -958,12 +994,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -997,12 +1035,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1036,6 +1076,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1047,6 +1088,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1070,6 +1112,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setPhrases(int index, String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -1078,6 +1121,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1088,6 +1132,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1099,6 +1144,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1130,6 +1176,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1146,6 +1193,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1179,12 +1227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
@@ -307,12 +307,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -418,6 +420,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -426,6 +429,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -463,6 +469,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -471,6 +478,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,12 +489,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -508,6 +518,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -516,6 +527,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,6 +548,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -544,6 +557,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -704,12 +718,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -761,12 +777,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -800,12 +818,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -852,6 +872,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -863,6 +884,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,12 +931,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -961,6 +985,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -972,6 +997,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1018,12 +1044,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1070,6 +1098,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1081,6 +1110,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1127,12 +1157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1179,6 +1211,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1190,6 +1223,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1236,12 +1270,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1288,6 +1324,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1299,6 +1336,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1345,12 +1383,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1397,6 +1437,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1408,6 +1449,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1494,12 +1536,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -35,6 +36,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -45,12 +47,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -72,6 +76,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -80,6 +85,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,12 +96,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -117,6 +125,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -125,6 +134,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,6 +155,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;String&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -153,6 +164,7 @@
  [usage limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -115,6 +115,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Operation asyncRecognize(AsyncRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  [google.longrunning.Operations]
  (/speech/reference/rest/v1beta1/operations#Operation)
@@ -122,6 +123,7 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,12 +134,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -169,6 +173,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -180,6 +185,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -203,9 +209,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse syncRecognize(SyncRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -216,12 +224,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -115,6 +115,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;Operation&gt; asyncRecognize(AsyncRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  [google.longrunning.Operations]
  (/speech/reference/rest/v1beta1/operations#Operation)
@@ -122,6 +123,7 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,12 +134,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -169,6 +173,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -180,6 +185,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -203,9 +209,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;SyncRecognizeResponse&gt; syncRecognize(SyncRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -216,12 +224,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
@@ -77,6 +77,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void asyncRecognize(AsyncRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  [google.longrunning.Operations]
  (/speech/reference/rest/v1beta1/operations#Operation)
@@ -84,6 +85,7 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -94,6 +96,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -105,6 +108,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechImplBase_bindService_" data-uid="com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.bindService*"></a>
   <h3 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechImplBase_bindService__" data-uid="com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.bindService()" class="notranslate">bindService()</h3>
@@ -131,9 +135,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,12 +150,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -171,9 +179,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void syncRecognize(SyncRecognizeRequest request, StreamObserver&lt;SyncRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -184,6 +194,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -195,6 +206,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="implements">Implements</h2>
   <div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
@@ -115,6 +115,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void asyncRecognize(AsyncRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  [google.longrunning.Operations]
  (/speech/reference/rest/v1beta1/operations#Operation)
@@ -122,6 +123,7 @@
  `Operation.error` or an `Operation.response` which contains
  an `AsyncRecognizeResponse` message.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,6 +134,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html">AsyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -143,6 +146,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechStub_build_" data-uid="com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.build*"></a>
   <h3 id="com_google_cloud_speech_v1beta1_SpeechGrpc_SpeechStub_build_io_grpc_Channel_io_grpc_CallOptions_" data-uid="com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.build(io.grpc.Channel,io.grpc.CallOptions)" class="notranslate">build(Channel channel, CallOptions callOptions)</h3>
@@ -159,6 +163,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -170,6 +175,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -193,9 +199,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -233,9 +243,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void syncRecognize(SyncRecognizeRequest request, StreamObserver&lt;SyncRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,6 +258,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -257,6 +270,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.html
@@ -224,8 +224,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechBlockingStub newBlockingStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -236,12 +238,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -263,8 +267,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechFutureStub newFutureStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -275,12 +281,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -302,8 +310,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechStub newStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -314,12 +324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechProto.html
@@ -94,12 +94,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistry</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1beta1_SpeechProto_registerAllExtensions_" data-uid="com.google.cloud.speech.v1beta1.SpeechProto.registerAllExtensions*"></a>
   <h3 id="com_google_cloud_speech_v1beta1_SpeechProto_registerAllExtensions_com_google_protobuf_ExtensionRegistryLite_" data-uid="com.google.cloud.speech.v1beta1.SpeechProto.registerAllExtensions(com.google.protobuf.ExtensionRegistryLite)" class="notranslate">registerAllExtensions(ExtensionRegistryLite registry)</h3>
@@ -116,12 +118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistryLite</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,6 +338,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is typically provided only for the top hypothesis, and
@@ -345,6 +348,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,12 +379,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +420,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -443,9 +451,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -488,6 +498,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is typically provided only for the top hypothesis, and
@@ -497,6 +508,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,9 +591,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,9 +616,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -679,12 +695,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -716,6 +734,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -727,6 +746,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -775,12 +795,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -814,12 +836,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -843,6 +867,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setConfidence(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is typically provided only for the top hypothesis, and
@@ -852,6 +877,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -862,12 +888,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -899,6 +927,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -910,6 +939,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -943,6 +973,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -959,6 +990,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -982,9 +1014,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscript(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,12 +1029,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1022,9 +1058,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscriptBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1035,12 +1073,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1072,12 +1112,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,6 +356,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is typically provided only for the top hypothesis, and
@@ -363,6 +366,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,9 +491,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,9 +516,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -651,12 +659,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -708,12 +718,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -747,12 +759,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -799,6 +813,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -810,6 +825,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -856,12 +872,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -908,6 +926,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -919,6 +938,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -965,12 +985,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,6 +1039,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1028,6 +1051,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1074,12 +1098,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1126,6 +1152,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1137,6 +1164,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1183,12 +1211,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1235,6 +1265,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1246,6 +1277,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,12 +1324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,6 +1378,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1355,6 +1390,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1441,12 +1477,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is typically provided only for the top hypothesis, and
@@ -36,6 +37,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -56,9 +58,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -79,9 +83,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
@@ -230,10 +230,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -244,12 +246,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -271,10 +275,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,12 +291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -312,10 +320,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,12 +336,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -353,10 +365,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -367,6 +381,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -378,6 +393,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -399,10 +415,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -424,6 +443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -445,10 +465,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -469,10 +491,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,12 +507,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -520,6 +546,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -531,6 +558,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -616,10 +644,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,12 +680,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -689,12 +721,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -740,10 +774,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -754,12 +790,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -781,10 +819,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,12 +835,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -822,10 +864,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -846,10 +890,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -870,10 +916,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,10 +942,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -908,12 +958,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -935,10 +987,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1075,12 +1129,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,6 +1168,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1123,6 +1180,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1171,12 +1229,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1210,12 +1270,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1239,10 +1301,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1253,12 +1317,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1280,10 +1346,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1294,6 +1362,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1305,6 +1374,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1326,10 +1396,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1340,6 +1412,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1351,6 +1424,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1382,6 +1456,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1393,6 +1468,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1426,6 +1502,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1442,6 +1519,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1475,12 +1553,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -335,10 +337,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -349,12 +353,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -376,10 +382,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,10 +408,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,10 +434,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,12 +450,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -465,10 +479,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -711,12 +727,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -768,12 +786,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -807,12 +827,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -859,6 +881,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -870,6 +893,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -916,12 +940,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -968,6 +994,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -979,6 +1006,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1025,12 +1053,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1077,6 +1107,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1088,6 +1119,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1134,12 +1166,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1186,6 +1220,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1197,6 +1232,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1243,12 +1279,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1295,6 +1333,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1306,6 +1345,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1352,12 +1392,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1404,6 +1446,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1415,6 +1458,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1501,12 +1545,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,10 +339,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,12 +375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +406,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,12 +444,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -465,6 +475,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -476,6 +487,7 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,10 +530,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,10 +556,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -566,10 +582,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,12 +670,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,6 +698,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -689,6 +710,7 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,10 +731,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,10 +801,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,12 +817,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -828,12 +856,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,6 +895,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -876,6 +907,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -924,12 +956,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -963,12 +997,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -992,10 +1028,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1006,12 +1044,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1033,10 +1073,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1047,12 +1089,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1084,6 +1128,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1095,6 +1140,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1118,12 +1164,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setInterimResults(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1134,12 +1182,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1171,6 +1221,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1187,6 +1238,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1210,6 +1262,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setSingleUtterance(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -1221,6 +1274,7 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,12 +1285,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1268,12 +1324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
@@ -345,12 +345,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -374,10 +376,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -398,10 +402,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,12 +488,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,6 +560,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -563,6 +572,7 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,10 +615,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,12 +737,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -782,12 +796,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -821,12 +837,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -873,6 +891,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -884,6 +903,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -930,12 +950,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -982,6 +1004,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -993,6 +1016,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1039,12 +1063,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1091,6 +1117,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1102,6 +1129,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1148,12 +1176,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,6 +1230,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1211,6 +1242,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1257,12 +1289,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1309,6 +1343,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1320,6 +1355,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1366,12 +1402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1418,6 +1456,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1429,6 +1468,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1515,12 +1555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,10 +53,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -75,12 +79,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -101,6 +107,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Optional* If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -112,6 +119,7 @@
  one `StreamingRecognitionResult` with the `is_final` flag set to `true`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -132,10 +140,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
@@ -231,10 +231,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,12 +247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -272,10 +276,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,12 +292,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -313,10 +321,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -327,12 +337,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,10 +366,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,6 +382,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -379,6 +394,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,10 +416,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,6 +432,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -425,6 +444,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -446,10 +466,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -470,10 +492,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,12 +508,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -521,6 +547,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -532,6 +559,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -617,10 +645,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -651,12 +681,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -680,6 +712,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -687,6 +720,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,12 +751,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -746,6 +782,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -753,6 +790,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,10 +833,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -809,12 +849,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -836,10 +878,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -850,12 +894,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -877,10 +923,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,10 +949,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -925,10 +975,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -949,10 +1001,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,12 +1017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -990,10 +1046,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,6 +1134,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1083,6 +1142,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1103,6 +1163,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -1110,6 +1171,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1184,12 +1246,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1221,6 +1285,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1232,6 +1297,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1280,12 +1346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1319,12 +1387,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1348,10 +1418,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1362,12 +1434,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1389,10 +1463,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1403,6 +1479,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1414,6 +1491,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1435,10 +1513,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1449,6 +1529,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1460,6 +1541,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1491,6 +1573,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1502,6 +1585,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1525,6 +1609,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setIsFinal(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1532,6 +1617,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1542,12 +1628,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1579,6 +1667,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1595,6 +1684,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1618,6 +1708,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setStability(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -1625,6 +1716,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1635,12 +1727,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1672,12 +1766,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
@@ -345,12 +345,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -374,10 +376,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -388,12 +392,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -415,10 +421,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,10 +447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,10 +473,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,12 +489,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -504,10 +518,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,6 +604,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -595,6 +612,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,6 +677,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -666,6 +685,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,12 +824,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -861,12 +883,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -900,12 +924,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -952,6 +978,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -963,6 +990,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1009,12 +1037,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1061,6 +1091,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1072,6 +1103,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1118,12 +1150,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1170,6 +1204,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1181,6 +1216,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1227,12 +1263,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1279,6 +1317,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1290,6 +1329,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,12 +1376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1388,6 +1430,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1399,6 +1442,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1445,12 +1489,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1497,6 +1543,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1508,6 +1555,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1594,12 +1642,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -181,6 +195,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -188,6 +203,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -208,6 +224,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -215,6 +232,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
@@ -244,6 +244,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -255,6 +256,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -340,6 +342,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -350,6 +353,7 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -380,12 +384,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -419,12 +425,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -448,11 +456,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,6 +525,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -525,6 +536,7 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,11 +619,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,11 +646,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder getStreamingConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,11 +673,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -702,11 +720,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,12 +801,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -818,6 +840,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -829,6 +852,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -877,12 +901,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -906,11 +932,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -921,12 +949,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -958,12 +988,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -987,6 +1019,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setAudioContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -997,6 +1030,7 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1007,12 +1041,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1044,6 +1080,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1055,6 +1092,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1088,6 +1126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1104,6 +1143,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1127,11 +1167,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1142,12 +1184,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1169,11 +1213,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1184,12 +1230,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html">StreamingRecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1221,12 +1269,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
@@ -329,12 +329,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,6 +360,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -368,6 +371,7 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -492,11 +496,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -517,11 +523,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,11 +592,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -762,12 +774,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -801,12 +815,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,6 +869,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -864,6 +881,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -910,12 +928,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,6 +982,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -973,6 +994,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,12 +1041,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,6 +1095,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1082,6 +1107,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,12 +1154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,6 +1208,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1191,6 +1220,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,12 +1267,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,6 +1321,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1300,6 +1333,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,12 +1380,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1398,6 +1434,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1409,6 +1446,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1495,12 +1533,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -37,6 +38,7 @@
  [audio limits](https://cloud.google.com/speech/limits#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -57,11 +59,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -82,11 +86,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,11 +133,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
@@ -273,12 +273,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addAllResults(Iterable&lt;? extends StreamingRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -289,12 +291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1beta1.StreamingRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -326,6 +330,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -337,6 +342,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -360,12 +366,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,12 +384,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -403,12 +413,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -419,12 +431,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html">StreamingRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -446,12 +460,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,6 +478,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -473,6 +490,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -494,12 +512,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,6 +530,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -521,6 +542,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -542,12 +564,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -568,12 +592,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,12 +610,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -673,9 +701,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearEndpointerType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,10 +726,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -730,12 +762,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -769,12 +803,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -798,11 +834,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearResultIndex()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the lowest index in the `results` array that has
  changed. The repeated `StreamingRecognitionResult` results overwrite past
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -823,12 +861,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,9 +973,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.EndpointerType getEndpointerType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -956,9 +998,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEndpointerTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -979,10 +1023,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1003,10 +1049,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status.Builder getErrorBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1027,10 +1075,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1051,11 +1101,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultIndex()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the lowest index in the `results` array that has
  changed. The repeated `StreamingRecognitionResult` results overwrite past
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,12 +1128,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1092,12 +1146,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1119,12 +1175,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,12 +1193,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1162,12 +1222,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1188,12 +1250,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,12 +1278,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1240,12 +1306,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1256,12 +1324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1283,12 +1353,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1309,10 +1381,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1377,10 +1451,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,12 +1467,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1428,12 +1506,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1465,6 +1545,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1476,6 +1557,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1524,12 +1606,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1563,12 +1647,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1592,12 +1678,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1608,12 +1696,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1635,9 +1725,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setEndpointerType(StreamingRecognizeResponse.EndpointerType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1648,12 +1740,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html">StreamingRecognizeResponse.EndpointerType</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1675,9 +1769,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setEndpointerTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1688,12 +1784,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1715,10 +1813,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1729,12 +1829,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1756,10 +1858,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1770,12 +1874,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1807,6 +1913,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1818,6 +1925,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1851,6 +1959,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1867,6 +1976,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1890,11 +2000,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResultIndex(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the lowest index in the `results` array that has
  changed. The repeated `StreamingRecognitionResult` results overwrite past
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1905,12 +2017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1932,12 +2046,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1948,6 +2064,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1959,6 +2076,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1980,12 +2098,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1996,6 +2116,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2007,6 +2128,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2038,12 +2160,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
@@ -406,12 +406,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -495,9 +497,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.EndpointerType getEndpointerType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -518,9 +522,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEndpointerTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,10 +547,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,10 +573,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -611,11 +621,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultIndex()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the lowest index in the `results` array that has
  changed. The repeated `StreamingRecognitionResult` results overwrite past
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -636,12 +648,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,12 +666,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -679,12 +695,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,12 +723,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -731,12 +751,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -747,12 +769,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -774,12 +798,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -844,10 +870,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -964,12 +992,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1021,12 +1051,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1060,12 +1092,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,6 +1146,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1123,6 +1158,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1169,12 +1205,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1221,6 +1259,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1232,6 +1271,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1278,12 +1318,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1330,6 +1372,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1341,6 +1384,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1387,12 +1431,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1439,6 +1485,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1450,6 +1497,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1496,12 +1544,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1548,6 +1598,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1559,6 +1610,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1605,12 +1657,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1657,6 +1711,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1668,6 +1723,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1754,12 +1810,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeResponse.EndpointerType getEndpointerType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,9 +52,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getEndpointerTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the type of endpointer event.
 </code></pre><p><code>.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType endpointer_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,10 +77,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,10 +103,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,11 +129,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultIndex()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Indicates the lowest index in the `results` array that has
  changed. The repeated `StreamingRecognitionResult` results overwrite past
  results at this index and higher.
 </code></pre><p><code>int32 result_index = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,12 +156,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -162,12 +174,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -189,12 +203,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -215,12 +231,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -241,12 +259,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,12 +277,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -284,12 +306,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -310,10 +334,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,9 +338,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,10 +363,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -432,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -483,9 +493,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,9 +518,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,9 +543,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -552,10 +568,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,10 +594,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,10 +620,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,9 +708,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,10 +733,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -777,9 +803,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -790,12 +818,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -817,10 +847,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -831,12 +863,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +902,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +941,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -916,6 +953,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -964,12 +1002,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1003,12 +1043,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1032,9 +1074,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,12 +1089,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1072,9 +1118,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1085,12 +1133,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,10 +1162,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1126,12 +1178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1153,10 +1207,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,12 +1223,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1204,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1215,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1248,6 +1308,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1264,6 +1325,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1297,12 +1359,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,9 +356,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -377,9 +381,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,10 +406,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,10 +432,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,9 +584,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,10 +609,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -717,12 +731,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html">SyncRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -774,12 +790,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -813,12 +831,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,6 +885,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -876,6 +897,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -922,12 +944,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,6 +998,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -985,6 +1010,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1031,12 +1057,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1083,6 +1111,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1094,6 +1123,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1140,12 +1170,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1192,6 +1224,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1203,6 +1236,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1249,12 +1283,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,6 +1337,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1312,6 +1349,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1358,12 +1396,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1410,6 +1450,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1421,6 +1462,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,12 +1549,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -50,9 +52,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,10 +77,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -97,10 +103,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -121,9 +129,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionAudio audio = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,10 +154,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Required* Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1beta1.RecognitionConfig config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
@@ -232,10 +232,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1beta1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,6 +287,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -294,6 +299,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,10 +323,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,12 +339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,10 +368,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +384,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -399,10 +413,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,6 +429,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -424,6 +441,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -445,10 +463,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +479,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -470,6 +491,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -491,10 +513,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,10 +539,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,12 +555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -628,12 +656,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,12 +697,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -696,10 +728,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,10 +838,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -845,10 +883,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,12 +899,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -886,10 +928,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,10 +954,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -934,10 +980,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,10 +1006,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,12 +1022,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -999,10 +1051,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,12 +1131,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html">SyncRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1114,6 +1170,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1125,6 +1182,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1173,12 +1231,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,12 +1272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,10 +1303,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,12 +1319,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,6 +1358,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1303,6 +1370,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,6 +1404,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1352,6 +1421,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,10 +1445,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,6 +1461,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1400,6 +1473,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1421,10 +1495,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SyncRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1435,6 +1511,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1446,6 +1523,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1477,12 +1555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
@@ -308,12 +308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -419,10 +421,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,12 +437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -460,10 +466,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,10 +492,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,10 +518,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,12 +534,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -549,10 +563,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,12 +729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html">SyncRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -770,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -809,12 +829,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -861,6 +883,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -872,6 +895,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -918,12 +942,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -970,6 +996,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -981,6 +1008,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1027,12 +1055,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1079,6 +1109,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1090,6 +1121,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1136,12 +1168,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1188,6 +1222,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1199,6 +1234,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1245,12 +1281,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1297,6 +1335,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1308,6 +1347,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1354,12 +1394,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1406,6 +1448,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1417,6 +1460,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1503,12 +1547,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>*Output-only* Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
@@ -93,6 +93,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html">ListCustomClassesPage</a>&gt;</td>
         <td><span class="parametername">pages</span></td>
@@ -104,6 +105,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
@@ -111,6 +111,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html">ListCustomClassesResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -122,6 +123,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -155,6 +157,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html">ListCustomClassesResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -166,6 +169,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
@@ -93,6 +93,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html">ListCustomClassesResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -104,6 +105,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
@@ -93,6 +93,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html">ListPhraseSetPage</a>&gt;</td>
         <td><span class="parametername">pages</span></td>
@@ -104,6 +105,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
@@ -111,6 +111,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html">ListPhraseSetResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -122,6 +123,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -155,6 +157,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html">ListPhraseSetResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -166,6 +169,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
@@ -93,6 +93,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.PageContext</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html">ListPhraseSetResponse</a>,<a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a>&gt;</td>
         <td><span class="parametername">context</span></td>
@@ -104,6 +105,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
@@ -98,8 +98,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected AdaptationClient(AdaptationSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -110,12 +112,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationSettings.html">AdaptationSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_AdaptationClient_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.AdaptationClient*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_AdaptationClient_com_google_cloud_speech_v1p1beta1_stub_AdaptationStub_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.AdaptationClient(com.google.cloud.speech.v1p1beta1.stub.AdaptationStub)" class="notranslate">AdaptationClient(AdaptationStub stub)</h3>
@@ -132,12 +136,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html">AdaptationStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -156,6 +162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -167,6 +174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -208,8 +216,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final AdaptationClient create()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient with default settings.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,8 +255,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final AdaptationClient create(AdaptationSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,12 +269,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationSettings.html">AdaptationSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -299,8 +313,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final AdaptationClient create(AdaptationStub stub)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of AdaptationClient, using the given stub for making calls. This is for advanced usage - prefer using create(AdaptationSettings).</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -311,12 +327,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html">AdaptationStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -338,6 +356,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass createCustomClass(CreateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -350,6 +369,7 @@
    CustomClass response = adaptationClient.createCustomClass(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,6 +380,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -367,6 +388,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -388,6 +410,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass createCustomClass(LocationName parent, CustomClass customClass, String customClassId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -397,6 +420,7 @@
    CustomClass response = adaptationClient.createCustomClass(parent, customClass, customClassId);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -407,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LocationName.html">LocationName</a></td>
         <td><span class="parametername">parent</span></td>
@@ -429,6 +454,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -450,6 +476,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass createCustomClass(String parent, CustomClass customClass, String customClassId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -459,6 +486,7 @@
    CustomClass response = adaptationClient.createCustomClass(parent, customClass, customClassId);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -469,6 +497,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -491,6 +520,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -512,6 +542,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -527,6 +558,7 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,6 +579,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet createPhraseSet(CreatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a set of phrase hints. Each item in the set can be a single word or a multi-word phrase. The items in the PhraseSet are favored by the recognition model when you send a call that includes the PhraseSet.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -559,6 +592,7 @@
    PhraseSet response = adaptationClient.createPhraseSet(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -569,6 +603,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -576,6 +611,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -597,6 +633,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet createPhraseSet(LocationName parent, PhraseSet phraseSet, String phraseSetId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a set of phrase hints. Each item in the set can be a single word or a multi-word phrase. The items in the PhraseSet are favored by the recognition model when you send a call that includes the PhraseSet.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -606,6 +643,7 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,6 +654,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LocationName.html">LocationName</a></td>
         <td><span class="parametername">parent</span></td>
@@ -638,6 +677,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -659,6 +699,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet createPhraseSet(String parent, PhraseSet phraseSet, String phraseSetId)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a set of phrase hints. Each item in the set can be a single word or a multi-word phrase. The items in the PhraseSet are favored by the recognition model when you send a call that includes the PhraseSet.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -668,6 +709,7 @@
    PhraseSet response = adaptationClient.createPhraseSet(parent, phraseSet, phraseSetId);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,6 +720,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -700,6 +743,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -721,6 +765,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Create a set of phrase hints. Each item in the set can be a single word or a multi-word phrase. The items in the PhraseSet are favored by the recognition model when you send a call that includes the PhraseSet.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -735,6 +780,7 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,6 +801,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deleteCustomClass(CustomClassName name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -762,6 +809,7 @@
    adaptationClient.deleteCustomClass(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,6 +820,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassName.html">CustomClassName</a></td>
         <td><span class="parametername">name</span></td>
@@ -780,12 +829,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClass_com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequest_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClass(com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest)" class="notranslate">deleteCustomClass(DeleteCustomClassRequest request)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deleteCustomClass(DeleteCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -796,6 +847,7 @@
    adaptationClient.deleteCustomClass(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -806,6 +858,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -813,12 +866,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClass_java_lang_String_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClass(java.lang.String)" class="notranslate">deleteCustomClass(String name)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deleteCustomClass(String name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -826,6 +881,7 @@
    adaptationClient.deleteCustomClass(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,6 +892,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -844,12 +901,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClassCallable_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClassCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deleteCustomClassCallable__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deleteCustomClassCallable()" class="notranslate">deleteCustomClassCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -862,6 +921,7 @@
    future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -882,6 +942,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deletePhraseSet(DeletePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -892,6 +953,7 @@
    adaptationClient.deletePhraseSet(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -902,6 +964,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -909,12 +972,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSet_com_google_cloud_speech_v1p1beta1_PhraseSetName_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSet(com.google.cloud.speech.v1p1beta1.PhraseSetName)" class="notranslate">deletePhraseSet(PhraseSetName name)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deletePhraseSet(PhraseSetName name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -922,6 +987,7 @@
    adaptationClient.deletePhraseSet(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -932,6 +998,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetName.html">PhraseSetName</a></td>
         <td><span class="parametername">name</span></td>
@@ -940,12 +1007,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSet_java_lang_String_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSet(java.lang.String)" class="notranslate">deletePhraseSet(String name)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final void deletePhraseSet(String name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -953,6 +1022,7 @@
    adaptationClient.deletePhraseSet(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -963,6 +1033,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -971,12 +1042,14 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSetCallable_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSetCallable*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationClient_deletePhraseSetCallable__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationClient.deletePhraseSetCallable()" class="notranslate">deletePhraseSetCallable()</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Delete a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -989,6 +1062,7 @@
    future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1009,6 +1083,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass getCustomClass(CustomClassName name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1016,6 +1091,7 @@
    CustomClass response = adaptationClient.getCustomClass(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1026,6 +1102,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassName.html">CustomClassName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1034,6 +1111,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1055,6 +1133,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass getCustomClass(GetCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1065,6 +1144,7 @@
    CustomClass response = adaptationClient.getCustomClass(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1075,6 +1155,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1082,6 +1163,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1103,6 +1185,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass getCustomClass(String name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1110,6 +1193,7 @@
    CustomClass response = adaptationClient.getCustomClass(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,6 +1204,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1128,6 +1213,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1149,6 +1235,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1161,6 +1248,7 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1181,6 +1269,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet getPhraseSet(GetPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1191,6 +1280,7 @@
    PhraseSet response = adaptationClient.getPhraseSet(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1201,6 +1291,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1208,6 +1299,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1229,6 +1321,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet getPhraseSet(PhraseSetName name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1236,6 +1329,7 @@
    PhraseSet response = adaptationClient.getPhraseSet(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1246,6 +1340,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetName.html">PhraseSetName</a></td>
         <td><span class="parametername">name</span></td>
@@ -1254,6 +1349,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1275,6 +1371,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet getPhraseSet(String name)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1282,6 +1379,7 @@
    PhraseSet response = adaptationClient.getPhraseSet(name);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1292,6 +1390,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">name</span></td>
@@ -1300,6 +1399,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,6 +1421,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Get a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1333,6 +1434,7 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1433,6 +1535,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListCustomClassesPagedResponse listCustomClasses(ListCustomClassesRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List custom classes.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1447,6 +1550,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1457,6 +1561,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1464,6 +1569,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1485,6 +1591,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListCustomClassesPagedResponse listCustomClasses(LocationName parent)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List custom classes.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1494,6 +1601,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1504,6 +1612,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LocationName.html">LocationName</a></td>
         <td><span class="parametername">parent</span></td>
@@ -1512,6 +1621,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1533,6 +1643,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListCustomClassesPagedResponse listCustomClasses(String parent)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List custom classes.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1542,6 +1653,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1552,6 +1664,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -1560,6 +1673,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1581,6 +1695,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;ListCustomClassesRequest,ListCustomClassesResponse&gt; listCustomClassesCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List custom classes.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1599,6 +1714,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1619,6 +1735,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;ListCustomClassesRequest,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesPagedCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List custom classes.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1636,6 +1753,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1656,6 +1774,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListPhraseSetPagedResponse listPhraseSet(ListPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List phrase sets.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1670,6 +1789,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1680,6 +1800,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1687,6 +1808,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1708,6 +1830,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListPhraseSetPagedResponse listPhraseSet(LocationName parent)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List phrase sets.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1717,6 +1840,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1727,6 +1851,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LocationName.html">LocationName</a></td>
         <td><span class="parametername">parent</span></td>
@@ -1735,6 +1860,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1756,6 +1882,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final AdaptationClient.ListPhraseSetPagedResponse listPhraseSet(String parent)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List phrase sets.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1765,6 +1892,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1775,6 +1903,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">parent</span></td>
@@ -1783,6 +1912,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1804,6 +1934,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;ListPhraseSetRequest,ListPhraseSetResponse&gt; listPhraseSetCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List phrase sets.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1821,6 +1952,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1841,6 +1973,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;ListPhraseSetRequest,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetPagedCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>List phrase sets.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1858,6 +1991,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1888,6 +2022,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final CustomClass updateCustomClass(UpdateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Update a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1899,6 +2034,7 @@
    CustomClass response = adaptationClient.updateCustomClass(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1909,6 +2045,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1916,6 +2053,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1937,6 +2075,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Update a custom class.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1951,6 +2090,7 @@
    CustomClass response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1971,6 +2111,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final PhraseSet updatePhraseSet(UpdatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Update a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -1982,6 +2123,7 @@
    PhraseSet response = adaptationClient.updatePhraseSet(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1992,6 +2134,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -1999,6 +2142,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2020,6 +2164,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Update a phrase set.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (AdaptationClient adaptationClient = AdaptationClient.create()) {
@@ -2033,6 +2178,7 @@
    PhraseSet response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,8 +162,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass createCustomClass(CreateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,12 +176,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -199,10 +205,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet createPhraseSet(CreatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a set of phrase hints. Each item in the set can be a single word or
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -213,12 +221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -240,8 +250,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Empty deleteCustomClass(DeleteCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -252,12 +264,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -279,8 +293,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Empty deletePhraseSet(DeletePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -291,12 +307,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -318,8 +336,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClass(GetCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,12 +350,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -357,8 +379,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSet(GetPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,12 +393,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -396,8 +422,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse listCustomClasses(ListCustomClassesRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,12 +436,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,8 +465,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse listPhraseSet(ListPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,12 +479,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -474,8 +508,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass updateCustomClass(UpdateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,12 +522,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -513,8 +551,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet updatePhraseSet(UpdatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,12 +565,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,8 +162,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;CustomClass&gt; createCustomClass(CreateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,12 +176,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -199,10 +205,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;PhraseSet&gt; createPhraseSet(CreatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a set of phrase hints. Each item in the set can be a single word or
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -213,12 +221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -240,8 +250,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;Empty&gt; deleteCustomClass(DeleteCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -252,12 +264,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -279,8 +293,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;Empty&gt; deletePhraseSet(DeletePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -291,12 +307,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -318,8 +336,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;CustomClass&gt; getCustomClass(GetCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,12 +350,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -357,8 +379,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;PhraseSet&gt; getPhraseSet(GetPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -369,12 +393,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -396,8 +422,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;ListCustomClassesResponse&gt; listCustomClasses(ListCustomClassesRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,12 +436,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,8 +465,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;ListPhraseSetResponse&gt; listPhraseSet(ListPhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,12 +479,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -474,8 +508,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;CustomClass&gt; updateCustomClass(UpdateCustomClassRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,12 +522,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -513,8 +551,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;PhraseSet&gt; updatePhraseSet(UpdatePhraseSetRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -525,12 +565,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
@@ -97,8 +97,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void createCustomClass(CreateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -109,6 +111,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -120,16 +123,19 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_createPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.createPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_createPhraseSet_com_google_cloud_speech_v1p1beta1_CreatePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.createPhraseSet(com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">createPhraseSet(CreatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void createPhraseSet(CreatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a set of phrase hints. Each item in the set can be a single word or
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,6 +146,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -151,14 +158,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_deleteCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.deleteCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_deleteCustomClass_com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequest_io_grpc_stub_StreamObserver_com_google_protobuf_Empty__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.deleteCustomClass(com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.protobuf.Empty&gt;)" class="notranslate">deleteCustomClass(DeleteCustomClassRequest request, StreamObserver&lt;Empty&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void deleteCustomClass(DeleteCustomClassRequest request, StreamObserver&lt;Empty&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -169,6 +179,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -180,14 +191,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_deletePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.deletePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_deletePhraseSet_com_google_cloud_speech_v1p1beta1_DeletePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_protobuf_Empty__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.deletePhraseSet(com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.protobuf.Empty&gt;)" class="notranslate">deletePhraseSet(DeletePhraseSetRequest request, StreamObserver&lt;Empty&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void deletePhraseSet(DeletePhraseSetRequest request, StreamObserver&lt;Empty&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -198,6 +212,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -209,14 +224,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_getCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.getCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_getCustomClass_com_google_cloud_speech_v1p1beta1_GetCustomClassRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_CustomClass__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.getCustomClass(com.google.cloud.speech.v1p1beta1.GetCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.CustomClass&gt;)" class="notranslate">getCustomClass(GetCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void getCustomClass(GetCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -227,6 +245,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -238,14 +257,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_getPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.getPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_getPhraseSet_com_google_cloud_speech_v1p1beta1_GetPhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.getPhraseSet(com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">getPhraseSet(GetPhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void getPhraseSet(GetPhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -256,6 +278,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -267,14 +290,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_listCustomClasses_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.listCustomClasses*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_listCustomClasses_com_google_cloud_speech_v1p1beta1_ListCustomClassesRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_ListCustomClassesResponse__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.listCustomClasses(com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse&gt;)" class="notranslate">listCustomClasses(ListCustomClassesRequest request, StreamObserver&lt;ListCustomClassesResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void listCustomClasses(ListCustomClassesRequest request, StreamObserver&lt;ListCustomClassesResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,6 +311,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -296,14 +323,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_listPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.listPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_listPhraseSet_com_google_cloud_speech_v1p1beta1_ListPhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_ListPhraseSetResponse__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.listPhraseSet(com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse&gt;)" class="notranslate">listPhraseSet(ListPhraseSetRequest request, StreamObserver&lt;ListPhraseSetResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void listPhraseSet(ListPhraseSetRequest request, StreamObserver&lt;ListPhraseSetResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -314,6 +344,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -325,14 +356,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_updateCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.updateCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_updateCustomClass_com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_CustomClass__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.updateCustomClass(com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.CustomClass&gt;)" class="notranslate">updateCustomClass(UpdateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void updateCustomClass(UpdateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -343,6 +377,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -354,14 +389,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_updatePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.updatePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationImplBase_updatePhraseSet_com_google_cloud_speech_v1p1beta1_UpdatePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.updatePhraseSet(com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">updatePhraseSet(UpdatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void updatePhraseSet(UpdatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,6 +410,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -383,6 +422,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="implements">Implements</h2>
   <div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,8 +162,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void createCustomClass(CreateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,6 +176,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -183,16 +188,19 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_createPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.createPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_createPhraseSet_com_google_cloud_speech_v1p1beta1_CreatePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.createPhraseSet(com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">createPhraseSet(CreatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void createPhraseSet(CreatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Create a set of phrase hints. Each item in the set can be a single word or
  a multi-word phrase. The items in the PhraseSet are favored by the
  recognition model when you send a call that includes the PhraseSet.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -203,6 +211,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -214,14 +223,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_deleteCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.deleteCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_deleteCustomClass_com_google_cloud_speech_v1p1beta1_DeleteCustomClassRequest_io_grpc_stub_StreamObserver_com_google_protobuf_Empty__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.deleteCustomClass(com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.protobuf.Empty&gt;)" class="notranslate">deleteCustomClass(DeleteCustomClassRequest request, StreamObserver&lt;Empty&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void deleteCustomClass(DeleteCustomClassRequest request, StreamObserver&lt;Empty&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -232,6 +244,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -243,14 +256,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_deletePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.deletePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_deletePhraseSet_com_google_cloud_speech_v1p1beta1_DeletePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_protobuf_Empty__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.deletePhraseSet(com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.protobuf.Empty&gt;)" class="notranslate">deletePhraseSet(DeletePhraseSetRequest request, StreamObserver&lt;Empty&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void deletePhraseSet(DeletePhraseSetRequest request, StreamObserver&lt;Empty&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Delete a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -261,6 +277,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -272,14 +289,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_getCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.getCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_getCustomClass_com_google_cloud_speech_v1p1beta1_GetCustomClassRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_CustomClass__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.getCustomClass(com.google.cloud.speech.v1p1beta1.GetCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.CustomClass&gt;)" class="notranslate">getCustomClass(GetCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void getCustomClass(GetCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -290,6 +310,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -301,14 +322,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_getPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.getPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_getPhraseSet_com_google_cloud_speech_v1p1beta1_GetPhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.getPhraseSet(com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">getPhraseSet(GetPhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void getPhraseSet(GetPhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Get a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,6 +343,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -330,14 +355,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_listCustomClasses_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.listCustomClasses*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_listCustomClasses_com_google_cloud_speech_v1p1beta1_ListCustomClassesRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_ListCustomClassesResponse__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.listCustomClasses(com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse&gt;)" class="notranslate">listCustomClasses(ListCustomClassesRequest request, StreamObserver&lt;ListCustomClassesResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void listCustomClasses(ListCustomClassesRequest request, StreamObserver&lt;ListCustomClassesResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List custom classes.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,6 +376,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -359,14 +388,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_listPhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.listPhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_listPhraseSet_com_google_cloud_speech_v1p1beta1_ListPhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_ListPhraseSetResponse__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.listPhraseSet(com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse&gt;)" class="notranslate">listPhraseSet(ListPhraseSetRequest request, StreamObserver&lt;ListPhraseSetResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void listPhraseSet(ListPhraseSetRequest request, StreamObserver&lt;ListPhraseSetResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>List phrase sets.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -377,6 +409,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -388,14 +421,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_updateCustomClass_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.updateCustomClass*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_updateCustomClass_com_google_cloud_speech_v1p1beta1_UpdateCustomClassRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_CustomClass__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.updateCustomClass(com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.CustomClass&gt;)" class="notranslate">updateCustomClass(UpdateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void updateCustomClass(UpdateCustomClassRequest request, StreamObserver&lt;CustomClass&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a custom class.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -406,6 +442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -417,14 +454,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_updatePhraseSet_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.updatePhraseSet*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationGrpc_AdaptationStub_updatePhraseSet_com_google_cloud_speech_v1p1beta1_UpdatePhraseSetRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_PhraseSet__" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.updatePhraseSet(com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.PhraseSet&gt;)" class="notranslate">updatePhraseSet(UpdatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void updatePhraseSet(UpdatePhraseSetRequest request, StreamObserver&lt;PhraseSet&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Update a phrase set.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,6 +475,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -446,6 +487,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
@@ -307,8 +307,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationGrpc.AdaptationBlockingStub newBlockingStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -319,12 +321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,8 +350,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationGrpc.AdaptationFutureStub newFutureStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,12 +364,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,8 +393,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationGrpc.AdaptationStub newStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,12 +407,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
@@ -154,12 +154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_AdaptationSettings_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.AdaptationSettings)" class="notranslate">Builder(AdaptationSettings settings)</h3>
@@ -176,12 +178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationSettings.html">AdaptationSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_AdaptationSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder)" class="notranslate">Builder(AdaptationStubSettings.Builder stubSettings)</h3>
@@ -198,12 +202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html">AdaptationStubSettings.Builder</a></td>
         <td><span class="parametername">stubSettings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -212,9 +218,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,12 +233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -304,8 +314,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,8 +338,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,8 +362,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deleteCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +386,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deletePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,8 +410,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,8 +434,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -456,8 +478,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings.Builder&lt;ListCustomClassesRequest,ListCustomClassesResponse,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listCustomClasses.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,8 +502,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings.Builder&lt;ListPhraseSetRequest,ListPhraseSetResponse,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,8 +526,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updateCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,8 +550,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updatePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html">AdaptationSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -156,12 +158,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html">AdaptationStubSettings</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -198,8 +202,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -220,8 +226,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,8 +270,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -284,8 +294,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,8 +318,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,8 +362,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deleteCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +386,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deletePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,8 +410,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,8 +434,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -436,8 +458,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +482,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +506,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings&lt;ListCustomClassesRequest,ListCustomClassesResponse,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listCustomClasses.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,8 +530,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings&lt;ListPhraseSetRequest,ListPhraseSetResponse,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,8 +554,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,8 +578,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,12 +592,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -585,8 +621,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,8 +647,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updateCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -631,8 +671,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updatePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,9 +338,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clearCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,12 +363,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clearCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,12 +402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,12 +443,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -464,11 +474,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder clearParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,9 +524,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,9 +550,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder getCustomClassBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -559,12 +575,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,12 +604,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -613,9 +633,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,11 +720,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -724,11 +748,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -750,9 +776,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,9 +846,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder mergeCustomClass(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -831,12 +861,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +900,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +939,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -916,6 +951,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -964,12 +1000,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1003,12 +1041,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1032,9 +1072,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setCustomClass(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1045,12 +1087,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1072,9 +1116,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setCustomClass(CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1085,12 +1131,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html">CustomClass.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,12 +1160,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setCustomClassId(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1128,6 +1178,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1135,6 +1186,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1157,12 +1209,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setCustomClassIdBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1173,6 +1227,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1180,6 +1235,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,6 +1268,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1223,6 +1280,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1246,11 +1304,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setParent(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1261,6 +1321,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1268,6 +1329,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1290,11 +1352,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreateCustomClassRequest.Builder setParentBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1305,6 +1369,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1312,6 +1377,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,6 +1410,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1360,6 +1427,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1393,12 +1461,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -373,9 +375,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,12 +401,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,12 +430,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,9 +459,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,11 +544,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,11 +572,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,9 +666,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html">CreateCustomClassRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -829,12 +847,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +888,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -907,12 +929,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -959,6 +983,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -970,6 +995,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1016,12 +1042,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1068,6 +1096,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1079,6 +1108,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1125,12 +1155,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1177,6 +1209,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1188,6 +1221,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1234,12 +1268,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1286,6 +1322,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1297,6 +1334,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1343,12 +1381,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1395,6 +1435,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1406,6 +1447,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1452,12 +1494,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1504,6 +1548,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1515,6 +1560,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1601,12 +1647,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,12 +53,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -78,12 +82,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the custom class, which will become the final
  component of the custom class&#39; resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,9 +111,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,11 +136,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,11 +164,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this custom class will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,9 +192,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,11 +420,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clearParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,9 +448,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clearPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,12 +473,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder clearPhraseSetId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,11 +586,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,11 +614,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,9 +642,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,9 +668,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder getPhraseSetBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,12 +693,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSetId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -700,12 +722,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhraseSetIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,9 +751,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -750,9 +776,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -828,12 +856,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -865,6 +895,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -876,6 +907,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -924,12 +956,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -953,9 +987,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder mergePhraseSet(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -966,12 +1002,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1003,12 +1041,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1042,6 +1082,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1053,6 +1094,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,11 +1118,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setParent(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,6 +1135,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1098,6 +1143,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1120,11 +1166,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setParentBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,6 +1183,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1142,6 +1191,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1164,9 +1214,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setPhraseSet(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1177,12 +1229,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1204,9 +1258,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setPhraseSet(PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1217,12 +1273,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html">PhraseSet.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1244,12 +1302,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setPhraseSetId(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1260,6 +1320,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1267,6 +1328,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,12 +1351,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CreatePhraseSetRequest.Builder setPhraseSetIdBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1305,6 +1369,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1312,6 +1377,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,6 +1410,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1360,6 +1427,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1393,12 +1461,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,11 +435,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,11 +463,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,9 +513,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,12 +539,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSetId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -558,12 +568,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhraseSetIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,9 +597,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,9 +666,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -772,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html">CreatePhraseSetRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -829,12 +847,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -868,12 +888,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -907,12 +929,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -959,6 +983,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -970,6 +995,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1016,12 +1042,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1068,6 +1096,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1079,6 +1108,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1125,12 +1155,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1177,6 +1209,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1188,6 +1221,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1234,12 +1268,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1286,6 +1322,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1297,6 +1334,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1343,12 +1381,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1395,6 +1435,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1406,6 +1447,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1452,12 +1494,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1504,6 +1548,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1515,6 +1560,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1601,12 +1647,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent resource where this phrase set will be created.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -79,9 +83,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,12 +109,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPhraseSetId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +138,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPhraseSetIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The ID to use for the phrase set, which will become the final
  component of the phrase set&#39;s resource name.
  This value should be 4-63 characters, and valid characters
  are /[a-z][0-9]-/.
 </code></pre><p><code>string phrase_set_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -157,9 +167,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -180,9 +192,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to create.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
@@ -232,9 +232,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addAllItems(Iterable&lt;? extends CustomClass.ClassItem&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,12 +247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -272,9 +276,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addItems(CustomClass.ClassItem value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -285,12 +291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html">CustomClass.ClassItem</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -312,9 +320,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addItems(CustomClass.ClassItem.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -325,12 +335,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html">CustomClass.ClassItem.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -352,9 +364,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addItems(int index, CustomClass.ClassItem value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -365,6 +379,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -376,6 +391,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -397,9 +413,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addItems(int index, CustomClass.ClassItem.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,6 +428,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -421,6 +440,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -442,9 +462,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder addItemsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -465,9 +487,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder addItemsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,12 +502,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -515,6 +541,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -526,6 +553,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -611,10 +639,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clearCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -646,12 +676,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -675,9 +707,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clearItems()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -698,9 +732,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,12 +768,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -783,10 +821,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,10 +848,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -895,9 +937,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem getItems(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -908,12 +952,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -935,9 +981,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder getItemsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,12 +996,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -975,9 +1025,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass.ClassItem.Builder&gt; getItemsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -998,9 +1050,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getItemsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,9 +1075,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass.ClassItem&gt; getItemsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1044,9 +1100,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItemOrBuilder getItemsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,12 +1115,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1084,9 +1144,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClass.ClassItemOrBuilder&gt; getItemsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,9 +1169,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1131,9 +1195,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1209,12 +1275,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1246,6 +1314,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1257,6 +1326,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1305,12 +1375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,12 +1416,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1373,9 +1447,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder removeItems(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,12 +1462,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1413,10 +1491,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setCustomClassId(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1427,6 +1507,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1434,6 +1515,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1456,10 +1538,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setCustomClassIdBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,6 +1554,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1477,6 +1562,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1509,6 +1595,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1520,6 +1607,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1543,9 +1631,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setItems(int index, CustomClass.ClassItem value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1556,6 +1646,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1567,6 +1658,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1588,9 +1680,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setItems(int index, CustomClass.ClassItem.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1601,6 +1695,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1612,6 +1707,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1633,9 +1729,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1646,6 +1744,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1653,6 +1752,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1675,9 +1775,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1688,6 +1790,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1695,6 +1798,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1727,6 +1831,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1743,6 +1848,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1776,12 +1882,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,9 +420,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder clearValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,9 +530,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -546,9 +556,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,12 +636,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html">CustomClass.ClassItem</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -661,6 +675,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -672,6 +687,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -720,12 +736,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -759,12 +777,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -798,6 +818,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -809,6 +830,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -842,6 +864,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -858,6 +881,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -891,12 +915,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -920,9 +946,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder setValue(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -933,6 +961,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -940,6 +969,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,9 +992,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem.Builder setValueBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -975,6 +1007,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -982,6 +1015,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -461,9 +463,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,9 +489,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,12 +611,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html">CustomClass.ClassItem</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -662,12 +670,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -701,12 +711,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -740,12 +752,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -792,6 +806,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -803,6 +818,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -849,12 +865,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -901,6 +919,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -912,6 +931,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -958,12 +978,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1010,6 +1032,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1021,6 +1044,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1067,12 +1091,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1119,6 +1145,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1130,6 +1157,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1176,12 +1204,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1228,6 +1258,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1239,6 +1270,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1285,12 +1317,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1337,6 +1371,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1348,6 +1383,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1434,12 +1470,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The class item&#39;s value.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
@@ -346,12 +346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,10 +377,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -400,10 +404,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,9 +491,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItem getItems(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,12 +506,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -525,9 +535,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getItemsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -548,9 +560,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass.ClassItem&gt; getItemsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -571,9 +585,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.ClassItemOrBuilder getItemsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -584,12 +600,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -611,9 +629,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClass.ClassItemOrBuilder&gt; getItemsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,9 +654,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,9 +680,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -844,12 +868,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -901,12 +927,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -940,12 +968,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -979,12 +1009,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1031,6 +1063,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1042,6 +1075,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1088,12 +1122,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1140,6 +1176,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1151,6 +1188,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1197,12 +1235,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1249,6 +1289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1260,6 +1301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1306,12 +1348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1358,6 +1402,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1369,6 +1414,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1415,12 +1461,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1467,6 +1515,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1478,6 +1527,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1524,12 +1574,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1576,6 +1628,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1587,6 +1640,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1673,12 +1727,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
@@ -163,12 +163,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">customClass</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -200,12 +202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">location</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -237,12 +241,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
@@ -85,12 +85,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">o</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -124,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -140,6 +143,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -191,12 +195,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">fieldName</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -310,12 +316,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -367,6 +375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -383,6 +392,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +424,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -451,12 +463,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">formattedStrings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -530,12 +544,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassName.html">CustomClassName</a>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getCustomClassId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getCustomClassIdBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If this custom class is a resource, the custom_class_id is the resource id
  of the CustomClass. Case sensitive.
 </code></pre><p><code>string custom_class_id = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,9 +81,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass.ClassItem getItems(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,12 +96,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -117,9 +125,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getItemsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,9 +150,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;CustomClass.ClassItem&gt; getItemsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,9 +175,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass.ClassItemOrBuilder getItemsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,12 +190,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -203,9 +219,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends CustomClass.ClassItemOrBuilder&gt; getItemsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of class items.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass.ClassItem items = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -226,9 +244,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -250,9 +270,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the custom class.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +417,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -524,11 +532,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,11 +560,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,12 +642,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,6 +681,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -678,6 +693,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -726,12 +742,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -765,12 +783,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -804,6 +824,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -815,6 +836,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -838,11 +860,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -860,6 +885,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -882,11 +908,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeleteCustomClassRequest.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,6 +925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -904,6 +933,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -936,6 +966,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -952,6 +983,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -985,12 +1017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,11 +397,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,11 +425,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,12 +615,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html">DeleteCustomClassRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -666,12 +674,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -705,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,12 +756,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,6 +810,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -807,6 +822,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,12 +869,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +923,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -916,6 +935,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,12 +982,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1014,6 +1036,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1025,6 +1048,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,12 +1095,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1123,6 +1149,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1134,6 +1161,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,12 +1208,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1232,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1243,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1341,6 +1375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1352,6 +1387,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1438,12 +1474,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +417,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -524,11 +532,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,11 +560,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,12 +642,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,6 +681,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -678,6 +693,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -726,12 +742,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -765,12 +783,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -804,6 +824,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -815,6 +836,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -838,11 +860,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -860,6 +885,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -882,11 +908,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DeletePhraseSetRequest.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,6 +925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -904,6 +933,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -936,6 +966,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -952,6 +983,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -985,12 +1017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,11 +397,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,11 +425,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,12 +615,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html">DeletePhraseSetRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -666,12 +674,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -705,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,12 +756,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,6 +810,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -807,6 +822,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,12 +869,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +923,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -916,6 +935,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,12 +982,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1014,6 +1036,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1025,6 +1048,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,12 +1095,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1123,6 +1149,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1134,6 +1161,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,12 +1208,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1232,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1243,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1341,6 +1375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1352,6 +1387,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1438,12 +1474,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to delete.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +417,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -524,11 +532,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,11 +560,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,12 +642,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,6 +681,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -678,6 +693,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -726,12 +742,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -765,12 +783,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -804,6 +824,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -815,6 +836,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -838,11 +860,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -860,6 +885,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -882,11 +908,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetCustomClassRequest.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,6 +925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -904,6 +933,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -936,6 +966,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -952,6 +983,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -985,12 +1017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,11 +397,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,11 +425,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,12 +615,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html">GetCustomClassRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -666,12 +674,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -705,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,12 +756,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,6 +810,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -807,6 +822,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,12 +869,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +923,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -916,6 +935,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,12 +982,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1014,6 +1036,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1025,6 +1048,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,12 +1095,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1123,6 +1149,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1134,6 +1161,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,12 +1208,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1232,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1243,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1341,6 +1375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1352,6 +1387,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1438,12 +1474,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the custom class to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +417,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -524,11 +532,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -550,11 +560,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,12 +642,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,6 +681,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -678,6 +693,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -726,12 +742,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -765,12 +783,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -804,6 +824,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -815,6 +836,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -838,11 +860,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -860,6 +885,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -882,11 +908,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public GetPhraseSetRequest.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,6 +925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -904,6 +933,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -936,6 +966,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -952,6 +983,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -985,12 +1017,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
@@ -306,12 +306,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,11 +397,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -421,11 +425,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,12 +615,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html">GetPhraseSetRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -666,12 +674,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -705,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,12 +756,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,6 +810,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -807,6 +822,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,12 +869,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -905,6 +923,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -916,6 +935,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,12 +982,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1014,6 +1036,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1025,6 +1048,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,12 +1095,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1123,6 +1149,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1134,6 +1161,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,12 +1208,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1232,6 +1262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1243,6 +1274,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1341,6 +1375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1352,6 +1387,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1438,12 +1474,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The name of the phrase set to retrieve.
  Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>string name = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +420,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clearPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of custom classes to return. The service may return
  fewer than this value. If unspecified, at most 50 custom classes will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,12 +449,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clearPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,11 +478,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder clearParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,12 +590,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of custom classes to return. The service may return
  fewer than this value. If unspecified, at most 50 custom classes will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,12 +619,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,12 +648,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,11 +677,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,11 +705,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,12 +787,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -802,6 +826,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -813,6 +838,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -861,12 +887,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -900,12 +928,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -939,6 +969,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -950,6 +981,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -973,12 +1005,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setPageSize(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of custom classes to return. The service may return
  fewer than this value. If unspecified, at most 50 custom classes will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -989,6 +1023,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -996,6 +1031,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1018,12 +1054,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setPageToken(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,6 +1072,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1041,6 +1080,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1063,12 +1103,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setPageTokenBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,6 +1121,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1086,6 +1129,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1108,11 +1152,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setParent(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1123,6 +1169,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1130,6 +1177,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1152,11 +1200,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesRequest.Builder setParentBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,6 +1217,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1174,6 +1225,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,6 +1258,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1222,6 +1275,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1255,12 +1309,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,12 +435,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of custom classes to return. The service may return
  fewer than this value. If unspecified, at most 50 custom classes will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,12 +464,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,12 +493,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,11 +522,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,11 +550,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,12 +740,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html">ListCustomClassesRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -785,12 +799,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -824,12 +840,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -863,12 +881,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -915,6 +935,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -926,6 +947,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -972,12 +994,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1024,6 +1048,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1035,6 +1060,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1081,12 +1107,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1133,6 +1161,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1144,6 +1173,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1190,12 +1220,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1242,6 +1274,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1253,6 +1286,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1299,12 +1333,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1351,6 +1387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1362,6 +1399,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1408,12 +1446,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1460,6 +1500,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1471,6 +1512,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1557,12 +1599,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of custom classes to return. The service may return
  fewer than this value. If unspecified, at most 50 custom classes will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -54,12 +56,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,12 +85,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListCustomClass` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListCustomClass` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,11 +114,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,11 +142,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of custom classes.
  Format:
  {api_version}/projects/{project}/locations/{location}/customClasses
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
@@ -230,9 +230,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addAllCustomClasses(Iterable&lt;? extends CustomClass&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,12 +245,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.CustomClass</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -270,9 +274,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addCustomClasses(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,12 +289,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -310,9 +318,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addCustomClasses(CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,12 +333,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html">CustomClass.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -350,9 +362,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addCustomClasses(int index, CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,6 +377,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -374,6 +389,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,9 +411,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder addCustomClasses(int index, CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,6 +426,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -419,6 +438,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -440,9 +460,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addCustomClassesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,9 +485,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addCustomClassesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,12 +500,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -513,6 +539,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -524,6 +551,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -609,9 +637,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clearCustomClasses()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -642,12 +672,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -671,10 +703,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder clearNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,12 +740,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -757,9 +793,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -770,12 +808,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -797,9 +837,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder getCustomClassesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,12 +852,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -837,9 +881,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass.Builder&gt; getCustomClassesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -860,9 +906,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,9 +931,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -906,9 +956,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -919,12 +971,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -946,9 +1000,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1031,10 +1087,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,10 +1114,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,12 +1195,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html">ListCustomClassesResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1172,6 +1234,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1183,6 +1246,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1231,12 +1295,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1270,12 +1336,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1299,9 +1367,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder removeCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,12 +1382,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1339,9 +1411,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setCustomClasses(int index, CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1352,6 +1426,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1363,6 +1438,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1384,9 +1460,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setCustomClasses(int index, CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,6 +1475,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1408,6 +1487,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1439,6 +1519,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1450,6 +1531,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1473,10 +1555,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setNextPageToken(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1487,6 +1571,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1494,6 +1579,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1516,10 +1602,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListCustomClassesResponse.Builder setNextPageTokenBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1530,6 +1618,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1537,6 +1626,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1569,6 +1659,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1585,6 +1676,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1618,12 +1710,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,9 +356,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -367,12 +371,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -394,9 +400,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,9 +425,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,9 +450,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -453,12 +465,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -480,9 +494,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,10 +579,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -588,10 +606,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,12 +795,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html">ListCustomClassesResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -832,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -871,12 +895,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -910,12 +936,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,6 +990,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -973,6 +1002,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,6 +1103,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1082,6 +1115,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,12 +1162,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,6 +1216,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1191,6 +1228,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,12 +1275,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,6 +1329,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1300,6 +1341,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,12 +1388,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1398,6 +1442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1409,6 +1454,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1455,12 +1501,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,6 +1555,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1518,6 +1567,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1604,12 +1654,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -40,12 +42,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -67,9 +71,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,9 +96,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -113,9 +121,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -126,12 +136,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -153,9 +165,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The custom classes.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,10 +190,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -201,10 +217,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +420,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clearPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of phrase sets to return. The service may return
  fewer than this value. If unspecified, at most 50 phrase sets will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,12 +449,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clearPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,11 +478,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder clearParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,12 +590,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of phrase sets to return. The service may return
  fewer than this value. If unspecified, at most 50 phrase sets will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,12 +619,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,12 +648,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,11 +677,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -685,11 +705,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -765,12 +787,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -802,6 +826,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -813,6 +838,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -861,12 +887,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -900,12 +928,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -939,6 +969,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -950,6 +981,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -973,12 +1005,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setPageSize(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of phrase sets to return. The service may return
  fewer than this value. If unspecified, at most 50 phrase sets will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -989,6 +1023,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -996,6 +1031,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1018,12 +1054,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setPageToken(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,6 +1072,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1041,6 +1080,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1063,12 +1103,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setPageTokenBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,6 +1121,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1086,6 +1129,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1108,11 +1152,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setParent(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1123,6 +1169,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1130,6 +1177,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1152,11 +1200,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetRequest.Builder setParentBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1167,6 +1217,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1174,6 +1225,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,6 +1258,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1222,6 +1275,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1255,12 +1309,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,12 +435,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of phrase sets to return. The service may return
  fewer than this value. If unspecified, at most 50 phrase sets will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,12 +464,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,12 +493,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -514,11 +522,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,11 +550,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -728,12 +740,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html">ListPhraseSetRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -785,12 +799,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -824,12 +840,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -863,12 +881,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -915,6 +935,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -926,6 +947,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -972,12 +994,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1024,6 +1048,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1035,6 +1060,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1081,12 +1107,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1133,6 +1161,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1144,6 +1173,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1190,12 +1220,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1242,6 +1274,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1253,6 +1286,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1299,12 +1333,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1351,6 +1387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1362,6 +1399,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1408,12 +1446,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1460,6 +1500,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1471,6 +1512,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1557,12 +1599,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPageSize()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The maximum number of phrase sets to return. The service may return
  fewer than this value. If unspecified, at most 50 phrase sets will be
  returned. The maximum value is 1000; values above 1000 will be coerced to
  1000.
 </code></pre><p><code>int32 page_size = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -54,12 +56,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,12 +85,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A page token, received from a previous `ListPhraseSet` call.
  Provide this to retrieve the subsequent page.
  When paginating, all other parameters provided to `ListPhraseSet` must
  match the call that provided the page token.
 </code></pre><p><code>string page_token = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,11 +114,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getParent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -134,11 +142,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getParentBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The parent, which owns this collection of phrase set.
  Format:
  projects/{project}/locations/{location}
 </code></pre><p><code>string parent = 1 [(.google.api.field_behavior) = REQUIRED, (.google.api.resource_reference) = { ... }</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
@@ -230,9 +230,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addAllPhraseSets(Iterable&lt;? extends PhraseSet&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,12 +245,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.PhraseSet</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -270,9 +274,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addPhraseSets(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -283,12 +289,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -310,9 +318,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addPhraseSets(PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,12 +333,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html">PhraseSet.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -350,9 +362,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addPhraseSets(int index, PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -363,6 +377,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -374,6 +389,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,9 +411,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder addPhraseSets(int index, PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -408,6 +426,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -419,6 +438,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -440,9 +460,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhraseSetsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,9 +485,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhraseSetsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -476,12 +500,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -513,6 +539,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -524,6 +551,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -619,12 +647,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -648,10 +678,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clearNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -683,12 +715,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -712,9 +746,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder clearPhraseSets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -819,10 +855,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -844,10 +882,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,9 +909,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -882,12 +924,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,9 +953,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder getPhraseSetsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,12 +968,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -949,9 +997,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet.Builder&gt; getPhraseSetsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,9 +1022,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -995,9 +1047,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1018,9 +1072,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1031,12 +1087,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1058,9 +1116,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1135,12 +1195,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html">ListPhraseSetResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1172,6 +1234,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1183,6 +1246,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1231,12 +1295,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1270,12 +1336,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1299,9 +1367,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder removePhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1312,12 +1382,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1349,6 +1421,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1360,6 +1433,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1383,10 +1457,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setNextPageToken(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1397,6 +1473,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1404,6 +1481,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1426,10 +1504,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setNextPageTokenBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1440,6 +1520,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1447,6 +1528,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1469,9 +1551,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setPhraseSets(int index, PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1482,6 +1566,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1493,6 +1578,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1514,9 +1600,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListPhraseSetResponse.Builder setPhraseSets(int index, PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1527,6 +1615,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1538,6 +1627,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1569,6 +1659,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1585,6 +1676,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1618,12 +1710,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,10 +416,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,10 +443,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,9 +492,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -499,12 +507,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -526,9 +536,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,9 +561,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -572,9 +586,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -585,12 +601,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -612,9 +630,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -775,12 +795,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html">ListPhraseSetResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -832,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -871,12 +895,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -910,12 +936,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -962,6 +990,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -973,6 +1002,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1071,6 +1103,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1082,6 +1115,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,12 +1162,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1180,6 +1216,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1191,6 +1228,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,12 +1275,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1289,6 +1329,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1300,6 +1341,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,12 +1388,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1398,6 +1442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1409,6 +1454,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1455,12 +1501,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,6 +1555,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1518,6 +1567,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1604,12 +1654,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getNextPageToken()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNextPageTokenBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A token, which can be sent as `page_token` to retrieve the next page.
  If this field is omitted, there are no subsequent pages.
 </code></pre><p><code>string next_page_token = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,9 +81,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -90,12 +96,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -117,9 +125,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -140,9 +150,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -163,9 +175,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,12 +190,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -203,9 +219,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase set.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
@@ -143,12 +143,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">location</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -180,12 +182,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
@@ -85,12 +85,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">o</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -124,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -135,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -166,12 +170,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">fieldName</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,12 +291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -342,6 +350,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -353,6 +362,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -384,12 +394,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -421,12 +433,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">formattedStrings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -500,12 +514,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.LocationName.html">LocationName</a>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
@@ -242,6 +242,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -253,6 +254,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -348,12 +350,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,9 +381,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -410,12 +416,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -439,10 +447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,9 +474,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -487,10 +499,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder clearUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -596,9 +610,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -620,9 +636,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getLastUpdateTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -643,9 +661,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,10 +686,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,9 +713,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,9 +739,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp.Builder getStartTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -738,9 +764,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -761,10 +789,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,10 +816,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,9 +843,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,9 +869,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -913,12 +949,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html">LongRunningRecognizeMetadata</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -950,6 +988,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -961,6 +1000,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1009,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1038,9 +1080,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1051,12 +1095,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1078,9 +1124,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder mergeStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1091,12 +1139,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,12 +1178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1167,6 +1219,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1178,6 +1231,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1201,9 +1255,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setLastUpdateTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1214,12 +1270,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,9 +1299,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setLastUpdateTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1254,12 +1314,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1281,10 +1343,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setProgressPercent(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1295,6 +1359,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1302,6 +1367,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1334,6 +1400,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1350,6 +1417,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1373,9 +1441,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setStartTime(Timestamp value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1386,12 +1456,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1413,9 +1485,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setStartTime(Timestamp.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1426,12 +1500,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Timestamp.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1463,12 +1539,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1492,10 +1570,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setUri(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,6 +1586,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1513,6 +1594,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1535,10 +1617,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeMetadata.Builder setUriBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1549,6 +1633,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1556,6 +1641,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
@@ -365,12 +365,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -454,9 +456,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,9 +482,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -523,10 +529,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -570,9 +578,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -594,9 +604,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -639,10 +651,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,10 +678,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,9 +705,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,9 +731,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -833,12 +853,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html">LongRunningRecognizeMetadata</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -890,12 +912,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -929,12 +953,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -968,12 +994,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1020,6 +1048,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1031,6 +1060,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1077,12 +1107,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1129,6 +1161,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1140,6 +1173,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1186,12 +1220,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1238,6 +1274,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1249,6 +1286,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1295,12 +1333,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1347,6 +1387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1358,6 +1399,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1404,12 +1446,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1456,6 +1500,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1467,6 +1512,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1513,12 +1559,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1565,6 +1613,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1576,6 +1625,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1662,12 +1712,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getLastUpdateTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getProgressPercent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Approximate percentage of audio processed thus far. Guaranteed to be 100
  when the audio is fully processed and the results are available.
 </code></pre><p><code>int32 progress_percent = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,9 +105,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Timestamp getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract TimestampOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -146,10 +156,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,10 +183,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The URI of the audio file being transcribed. Empty if the
  audio was sent as byte content.
 </code></pre><p><code>string uri = 4 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,9 +210,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasLastUpdateTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time of the most recent processing update.
 </code></pre><p><code>.google.protobuf.Timestamp last_update_time = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -220,9 +236,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time when the request was received.
 </code></pre><p><code>.google.protobuf.Timestamp start_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,9 +339,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -360,10 +364,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -394,12 +400,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -433,12 +441,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -484,9 +494,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,9 +520,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,9 +545,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,10 +570,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -579,10 +597,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -603,10 +623,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -689,9 +711,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,10 +737,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -782,9 +808,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,12 +823,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -822,10 +852,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,12 +868,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -873,12 +907,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -910,6 +946,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -921,6 +958,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -969,12 +1007,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,12 +1048,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1037,9 +1079,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,12 +1094,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1077,9 +1123,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1090,12 +1138,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1117,10 +1167,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1131,12 +1183,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1158,10 +1212,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1172,12 +1228,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1209,6 +1267,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1220,6 +1279,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1253,6 +1313,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1269,6 +1330,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1302,12 +1364,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
@@ -326,12 +326,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -355,9 +357,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,9 +383,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -402,10 +408,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,10 +435,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,9 +587,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -601,10 +613,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -722,12 +736,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -779,12 +795,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -818,12 +836,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -857,12 +877,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,6 +931,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -920,6 +943,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -966,12 +990,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1018,6 +1044,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1029,6 +1056,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1075,12 +1103,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1127,6 +1157,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1138,6 +1169,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1184,12 +1216,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1236,6 +1270,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1247,6 +1282,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1293,12 +1329,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1345,6 +1383,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1356,6 +1395,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1402,12 +1442,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1454,6 +1496,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1465,6 +1508,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1551,12 +1595,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,10 +105,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,10 +157,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
@@ -234,10 +234,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -248,12 +250,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -296,6 +301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -319,10 +325,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -333,12 +341,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -360,10 +370,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,12 +386,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -401,10 +415,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -426,6 +443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -447,10 +465,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -461,6 +481,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -472,6 +493,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -493,10 +515,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -517,10 +541,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,12 +557,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -630,12 +658,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -669,12 +699,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -698,10 +730,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -806,10 +840,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -820,12 +856,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -847,10 +885,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -861,12 +901,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -888,10 +930,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -912,10 +956,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -936,10 +982,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -960,10 +1008,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,12 +1024,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1001,10 +1053,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,12 +1133,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html">LongRunningRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1116,6 +1172,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1127,6 +1184,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1175,12 +1233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1214,12 +1274,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1243,10 +1305,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1257,12 +1321,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,6 +1360,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1305,6 +1372,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1338,6 +1406,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1354,6 +1423,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1377,10 +1447,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,6 +1463,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1402,6 +1475,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1423,10 +1497,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public LongRunningRecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1437,6 +1513,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1448,6 +1525,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1479,12 +1557,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
@@ -310,12 +310,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -421,10 +423,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -435,12 +439,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -462,10 +468,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,10 +494,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,10 +520,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -524,12 +536,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -551,10 +565,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,12 +731,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html">LongRunningRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -772,12 +790,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -811,12 +831,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -850,12 +872,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -902,6 +926,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -913,6 +938,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -959,12 +985,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,6 +1039,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1022,6 +1051,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1068,12 +1098,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1120,6 +1152,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1131,6 +1164,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1177,12 +1211,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1229,6 +1265,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1240,6 +1277,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1286,12 +1324,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1338,6 +1378,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1349,6 +1390,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1395,12 +1437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1447,6 +1491,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1458,6 +1503,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1544,12 +1590,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
@@ -231,9 +231,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addAllPhrases(Iterable&lt;? extends PhraseSet.Phrase&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -244,12 +246,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -271,9 +275,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhrases(PhraseSet.Phrase value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -284,12 +290,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html">PhraseSet.Phrase</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -311,9 +319,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhrases(PhraseSet.Phrase.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -324,12 +334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html">PhraseSet.Phrase.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -351,9 +363,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhrases(int index, PhraseSet.Phrase value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -364,6 +378,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -375,6 +390,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -396,9 +412,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhrases(int index, PhraseSet.Phrase.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,6 +427,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -420,6 +439,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -441,9 +461,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder addPhrasesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -464,9 +486,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder addPhrasesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -477,12 +501,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -514,6 +540,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -525,6 +552,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -610,6 +638,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clearBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -621,6 +650,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,12 +682,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -681,9 +713,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clearName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -715,12 +749,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,9 +780,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder clearPhrases()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -789,6 +827,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -800,6 +839,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -883,9 +923,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -907,9 +949,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -931,9 +975,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -944,12 +990,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,9 +1019,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder getPhrasesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -984,12 +1034,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,9 +1063,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet.Phrase.Builder&gt; getPhrasesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1034,9 +1088,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1057,9 +1113,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet.Phrase&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1080,9 +1138,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.PhraseOrBuilder getPhrasesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1093,12 +1153,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1120,9 +1182,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSet.PhraseOrBuilder&gt; getPhrasesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1197,12 +1261,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1234,6 +1300,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1245,6 +1312,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1293,12 +1361,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1332,12 +1402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1361,9 +1433,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder removePhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1374,12 +1448,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1401,6 +1477,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setBoost(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -1412,6 +1489,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1422,6 +1500,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -1429,6 +1508,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1461,6 +1541,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1472,6 +1553,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1495,9 +1577,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1508,6 +1592,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1515,6 +1600,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1537,9 +1623,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1550,6 +1638,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1557,6 +1646,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1579,9 +1669,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setPhrases(int index, PhraseSet.Phrase value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1592,6 +1684,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1603,6 +1696,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1624,9 +1718,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder setPhrases(int index, PhraseSet.Phrase.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1637,6 +1733,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1648,6 +1745,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1679,6 +1777,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1695,6 +1794,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1728,12 +1828,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
@@ -257,6 +257,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -268,6 +269,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -353,6 +355,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clearBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Overrides the boost set at the phrase set level.
  Positive value will increase the probability that a specific phrase will
  be recognized over other similar sounding phrases. The higher the boost,
@@ -365,6 +368,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -396,12 +400,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -435,12 +441,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -464,9 +472,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder clearValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,6 +520,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Overrides the boost set at the phrase set level.
  Positive value will increase the probability that a specific phrase will
  be recognized over other similar sounding phrases. The higher the boost,
@@ -522,6 +533,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -605,9 +617,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -629,9 +643,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -707,12 +723,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html">PhraseSet.Phrase</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -744,6 +762,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -755,6 +774,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -803,12 +823,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -842,12 +864,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -871,6 +895,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder setBoost(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Overrides the boost set at the phrase set level.
  Positive value will increase the probability that a specific phrase will
  be recognized over other similar sounding phrases. The higher the boost,
@@ -883,6 +908,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -893,6 +919,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -900,6 +927,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,6 +960,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -943,6 +972,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -976,6 +1006,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -992,6 +1023,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1025,12 +1057,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1054,9 +1088,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder setValue(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,6 +1103,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1074,6 +1111,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1096,9 +1134,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase.Builder setValueBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,6 +1149,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1116,6 +1157,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
@@ -342,12 +342,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -371,6 +373,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Overrides the boost set at the phrase set level.
  Positive value will increase the probability that a specific phrase will
  be recognized over other similar sounding phrases. The higher the boost,
@@ -383,6 +386,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,9 +534,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,9 +560,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,12 +682,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html">PhraseSet.Phrase</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -731,12 +741,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -770,12 +782,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -809,12 +823,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -861,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -872,6 +889,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -918,12 +936,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -970,6 +990,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -981,6 +1002,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1027,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1079,6 +1103,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1090,6 +1115,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1136,12 +1162,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1188,6 +1216,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1199,6 +1228,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1245,12 +1275,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1297,6 +1329,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1308,6 +1341,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1354,12 +1388,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1406,6 +1442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1417,6 +1454,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1503,12 +1541,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Overrides the boost set at the phrase set level.
  Positive value will increase the probability that a specific phrase will
  be recognized over other similar sounding phrases. The higher the boost,
@@ -39,6 +40,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -60,9 +62,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,9 +88,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getValueBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The phrase itself.
 </code></pre><p><code>string value = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
@@ -345,12 +345,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -374,6 +376,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -385,6 +388,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -466,9 +470,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -490,9 +496,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,9 +544,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Phrase getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -549,12 +559,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -576,9 +588,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -599,9 +613,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet.Phrase&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -622,9 +638,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.PhraseOrBuilder getPhrasesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,12 +653,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -662,9 +682,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSet.PhraseOrBuilder&gt; getPhrasesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,12 +847,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -882,12 +906,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -921,12 +947,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -960,12 +988,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1012,6 +1042,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1023,6 +1054,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1069,12 +1101,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,6 +1155,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1132,6 +1167,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1178,12 +1214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1230,6 +1268,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1241,6 +1280,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1287,12 +1327,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1339,6 +1381,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1350,6 +1393,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1396,12 +1440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1448,6 +1494,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1459,6 +1506,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1505,12 +1553,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1557,6 +1607,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1568,6 +1619,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1654,12 +1706,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
@@ -163,12 +163,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">location</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -200,12 +202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">phraseSet</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -237,12 +241,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
@@ -85,12 +85,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">o</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -124,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -140,6 +143,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -171,12 +175,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">fieldName</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -310,12 +316,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -367,6 +375,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">project</span></td>
@@ -383,6 +392,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +424,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">formattedString</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -451,12 +463,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">formattedStrings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -530,12 +544,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.util.List</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetName.html">PhraseSetName</a>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -38,6 +39,7 @@
  will skip PhraseSets with a boost value of 0.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -59,9 +61,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -83,9 +87,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The resource name of the phrase set.
 </code></pre><p><code>string name = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -107,9 +113,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet.Phrase getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,12 +128,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -147,9 +157,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -170,9 +182,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;PhraseSet.Phrase&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -193,9 +207,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet.PhraseOrBuilder getPhrasesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +222,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -233,9 +251,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends PhraseSet.PhraseOrBuilder&gt; getPhrasesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word and phrases.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet.Phrase phrases = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
@@ -243,6 +243,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -254,6 +255,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,11 +361,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -434,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -463,6 +471,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder clearUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -473,6 +482,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -536,11 +546,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,6 +636,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -634,6 +647,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -655,6 +669,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -665,6 +680,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -686,11 +702,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,6 +730,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -722,6 +741,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -797,12 +817,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -834,6 +856,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -845,6 +868,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -893,12 +917,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,12 +958,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -961,11 +989,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -976,6 +1006,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -983,6 +1014,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1015,6 +1047,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1026,6 +1059,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1059,6 +1093,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1075,6 +1110,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1108,12 +1144,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1137,6 +1175,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUri(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -1147,6 +1186,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1157,6 +1197,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1164,6 +1205,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1186,6 +1228,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder setUriBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -1196,6 +1239,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1206,6 +1250,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1213,6 +1258,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
@@ -328,12 +328,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -377,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,6 +533,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -539,6 +544,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,6 +566,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -570,6 +577,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -591,11 +599,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,6 +627,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -627,6 +638,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -744,12 +756,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -801,12 +815,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -840,12 +856,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -879,12 +897,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -931,6 +951,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -942,6 +963,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -988,12 +1010,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1040,6 +1064,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1051,6 +1076,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1097,12 +1123,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1149,6 +1177,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1160,6 +1189,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,12 +1236,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1258,6 +1290,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1269,6 +1302,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1315,12 +1349,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1367,6 +1403,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1378,6 +1415,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1424,12 +1462,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1476,6 +1516,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1487,6 +1528,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1573,12 +1615,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
@@ -47,11 +47,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -73,6 +75,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -83,6 +86,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,6 +108,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getUriBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -114,6 +119,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -135,11 +141,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data bytes encoded as specified in
  `RecognitionConfig`. Note: as with all bytes fields, proto buffers use a
  pure binary representation, whereas JSON representations use base64.
 </code></pre><p><code>bytes content = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -161,6 +169,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasUri()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>URI that points to a file that contains audio data bytes as specified in
  `RecognitionConfig`. The file must not be compressed (for example, gzip).
  Currently, only Google Cloud Storage URIs are
@@ -171,6 +180,7 @@
  URIs](https://cloud.google.com/storage/docs/reference-uris).
 </code></pre><p><code>string uri = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
@@ -231,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addAllAlternativeLanguageCodes(Iterable&lt;String&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -245,6 +246,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,6 +257,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">values</span></td>
@@ -262,6 +265,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -284,6 +288,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addAllSpeechContexts(Iterable&lt;? extends SpeechContext&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -291,6 +296,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -301,12 +307,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.SpeechContext</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -328,6 +336,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addAlternativeLanguageCodes(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -342,6 +351,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -352,6 +362,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -359,6 +370,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -381,6 +393,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addAlternativeLanguageCodesBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -395,6 +408,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -405,6 +419,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -412,6 +427,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -444,6 +460,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -455,6 +472,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -478,6 +496,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -485,6 +504,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -495,12 +515,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -522,6 +544,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -529,6 +552,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -539,12 +563,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html">SpeechContext.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -566,6 +592,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(int index, SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -573,6 +600,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -583,6 +611,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -594,6 +623,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -615,6 +645,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder addSpeechContexts(int index, SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -622,6 +653,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,6 +664,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -643,6 +676,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -664,6 +698,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addSpeechContextsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -671,6 +706,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,6 +727,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addSpeechContextsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -698,6 +735,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -708,12 +746,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -797,6 +837,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -804,6 +845,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,6 +866,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearAlternativeLanguageCodes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -838,6 +881,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,6 +903,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -870,6 +915,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -891,6 +937,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -901,6 +948,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -921,11 +969,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearDiarizationSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, specifies the estimated number of speakers in the conversation.
  Defaults to &#39;2&#39;. Ignored unless enable_speaker_diarization is set to true.
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -947,12 +997,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,6 +1026,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -982,6 +1035,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1003,12 +1057,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1030,11 +1086,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableWordConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and the
  confidence for those words. If `false`, no word-level confidence
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1056,12 +1114,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1083,12 +1143,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1120,12 +1182,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1149,6 +1213,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -1157,6 +1222,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1178,6 +1244,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -1186,6 +1253,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,9 +1275,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1230,6 +1300,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1264,6 +1335,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1295,12 +1367,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1324,12 +1398,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1351,6 +1427,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1361,6 +1438,7 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1382,6 +1460,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearSpeechContexts()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1389,6 +1468,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1409,6 +1489,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder clearUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -1418,6 +1499,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1461,6 +1543,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation getAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -1468,6 +1551,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1489,6 +1573,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder getAdaptationBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -1496,6 +1581,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1516,6 +1602,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptationOrBuilder getAdaptationOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -1523,6 +1610,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1543,6 +1631,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAlternativeLanguageCodes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -1557,6 +1646,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1567,6 +1657,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1574,6 +1665,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,6 +1688,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAlternativeLanguageCodesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -1610,6 +1703,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1620,6 +1714,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1627,6 +1722,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1649,6 +1745,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativeLanguageCodesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -1663,6 +1760,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1684,6 +1782,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getAlternativeLanguageCodesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -1698,6 +1797,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1719,6 +1819,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -1730,6 +1831,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1813,6 +1915,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1823,6 +1926,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1844,6 +1948,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder getDiarizationConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1854,6 +1959,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1874,6 +1980,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1884,6 +1991,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1904,11 +2012,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getDiarizationSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, specifies the estimated number of speakers in the conversation.
  Defaults to &#39;2&#39;. Ignored unless enable_speaker_diarization is set to true.
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1930,12 +2040,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1957,6 +2069,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -1965,6 +2078,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1986,12 +2100,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2013,11 +2129,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and the
  confidence for those words. If `false`, no word-level confidence
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2039,12 +2157,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2066,12 +2186,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2093,12 +2215,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2120,6 +2244,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -2128,6 +2253,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2149,6 +2275,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -2157,6 +2284,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2178,6 +2306,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -2186,6 +2315,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2207,9 +2337,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2231,9 +2363,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder getMetadataBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2254,9 +2388,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2277,6 +2413,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -2311,6 +2448,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2332,6 +2470,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -2366,6 +2505,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2387,12 +2527,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2414,6 +2556,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -2424,6 +2567,7 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2445,6 +2589,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2452,6 +2597,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2462,12 +2608,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2489,6 +2637,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder getSpeechContextsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2496,6 +2645,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2506,12 +2656,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2533,6 +2685,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext.Builder&gt; getSpeechContextsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2540,6 +2693,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2560,6 +2714,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2567,6 +2722,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2587,6 +2743,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2594,6 +2751,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2614,6 +2772,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2621,6 +2780,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2631,12 +2791,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2658,6 +2820,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -2665,6 +2828,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2685,6 +2849,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -2694,6 +2859,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2715,6 +2881,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -2722,6 +2889,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2743,6 +2911,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2753,6 +2922,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2774,9 +2944,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2842,6 +3014,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeAdaptation(SpeechAdaptation value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -2849,6 +3022,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2859,12 +3033,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html">SpeechAdaptation</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2886,6 +3062,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeDiarizationConfig(SpeakerDiarizationConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -2896,6 +3073,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2906,12 +3084,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2943,12 +3123,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2980,6 +3162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2991,6 +3174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3039,12 +3223,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3068,9 +3254,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder mergeMetadata(RecognitionMetadata value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3081,12 +3269,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3118,12 +3308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3147,6 +3339,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder removeSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -3154,6 +3347,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3164,12 +3358,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3191,6 +3387,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setAdaptation(SpeechAdaptation value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -3198,6 +3395,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3208,12 +3406,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html">SpeechAdaptation</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3235,6 +3435,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setAdaptation(SpeechAdaptation.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -3242,6 +3443,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3252,12 +3454,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html">SpeechAdaptation.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3279,6 +3483,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setAlternativeLanguageCodes(int index, String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -3293,6 +3498,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3303,6 +3509,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -3316,6 +3523,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3338,6 +3546,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setAudioChannelCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -3349,6 +3558,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3359,6 +3569,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -3366,6 +3577,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3388,6 +3600,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setDiarizationConfig(SpeakerDiarizationConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -3398,6 +3611,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3408,12 +3622,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3435,6 +3651,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setDiarizationConfig(SpeakerDiarizationConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -3445,6 +3662,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3455,12 +3673,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html">SpeakerDiarizationConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3482,11 +3702,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setDiarizationSpeakerCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, specifies the estimated number of speakers in the conversation.
  Defaults to &#39;2&#39;. Ignored unless enable_speaker_diarization is set to true.
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3497,6 +3719,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -3504,6 +3727,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3526,12 +3750,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableAutomaticPunctuation(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3542,6 +3768,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3549,6 +3776,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3571,6 +3799,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableSeparateRecognitionPerChannel(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -3579,6 +3808,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3589,6 +3819,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3596,6 +3827,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3618,12 +3850,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableSpeakerDiarization(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3634,6 +3868,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3641,6 +3876,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3663,11 +3899,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableWordConfidence(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and the
  confidence for those words. If `false`, no word-level confidence
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3678,6 +3916,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3685,6 +3924,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3707,12 +3947,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEnableWordTimeOffsets(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3723,6 +3965,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -3730,6 +3973,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3752,12 +3996,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncoding(RecognitionConfig.AudioEncoding value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3768,6 +4014,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html">RecognitionConfig.AudioEncoding</a></td>
         <td><span class="parametername">value</span></td>
@@ -3775,6 +4022,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3797,12 +4045,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setEncodingValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3813,6 +4063,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -3820,6 +4071,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3852,6 +4104,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -3863,6 +4116,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3886,6 +4140,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -3894,6 +4149,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3904,6 +4160,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -3911,6 +4168,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3933,6 +4191,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -3941,6 +4200,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3951,6 +4211,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -3958,6 +4219,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -3980,6 +4242,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMaxAlternatives(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -3988,6 +4251,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -3998,6 +4262,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -4005,6 +4270,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4027,9 +4293,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMetadata(RecognitionMetadata value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4040,12 +4308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4067,9 +4337,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setMetadata(RecognitionMetadata.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4080,12 +4352,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html">RecognitionMetadata.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4107,6 +4381,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setModel(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -4141,6 +4416,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4151,6 +4427,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -4158,6 +4435,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4180,6 +4458,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setModelBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -4214,6 +4493,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4224,6 +4504,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -4231,6 +4512,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4253,12 +4535,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setProfanityFilter(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4269,6 +4553,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -4276,6 +4561,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4308,6 +4594,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -4324,6 +4611,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4347,6 +4635,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSampleRateHertz(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -4357,6 +4646,7 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4367,6 +4657,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -4374,6 +4665,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4396,6 +4688,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContexts(int index, SpeechContext value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -4403,6 +4696,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4413,6 +4707,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -4424,6 +4719,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4445,6 +4741,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setSpeechContexts(int index, SpeechContext.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -4452,6 +4749,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4462,6 +4760,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -4473,6 +4772,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4504,12 +4804,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -4533,6 +4835,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder setUseEnhanced(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -4542,6 +4845,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -4552,6 +4856,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -4559,6 +4864,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
@@ -649,12 +649,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -678,6 +680,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation getAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -685,6 +688,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -706,6 +710,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptationOrBuilder getAdaptationOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -713,6 +718,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -733,6 +739,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAlternativeLanguageCodes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -747,6 +754,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -757,6 +765,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -764,6 +773,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -786,6 +796,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAlternativeLanguageCodesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -800,6 +811,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -810,6 +822,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -817,6 +830,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -839,6 +853,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativeLanguageCodesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -853,6 +868,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -874,6 +890,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getAlternativeLanguageCodesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -888,6 +905,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -909,6 +927,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -920,6 +939,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,6 +1021,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1011,6 +1032,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1032,6 +1054,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1042,6 +1065,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1062,11 +1086,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getDiarizationSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, specifies the estimated number of speakers in the conversation.
  Defaults to &#39;2&#39;. Ignored unless enable_speaker_diarization is set to true.
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1088,12 +1114,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1115,6 +1143,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -1123,6 +1152,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1144,12 +1174,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,11 +1203,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and the
  confidence for those words. If `false`, no word-level confidence
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1197,12 +1231,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1224,12 +1260,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1251,12 +1289,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1278,6 +1318,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -1286,6 +1327,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1307,6 +1349,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -1315,6 +1358,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1336,6 +1380,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -1344,6 +1389,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1365,9 +1411,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,9 +1437,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1412,6 +1462,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1446,6 +1497,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1467,6 +1519,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -1501,6 +1554,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1544,12 +1598,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1571,6 +1627,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -1581,6 +1638,7 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1624,6 +1682,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1631,6 +1690,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1641,12 +1701,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1668,6 +1730,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1675,6 +1738,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1695,6 +1759,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1702,6 +1767,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1722,6 +1788,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1729,6 +1796,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1739,12 +1807,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1766,6 +1836,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1773,6 +1844,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1815,6 +1887,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -1824,6 +1897,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1845,6 +1919,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -1852,6 +1927,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1873,6 +1949,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1883,6 +1960,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1904,9 +1982,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2024,12 +2104,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2081,12 +2163,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2120,12 +2204,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2159,12 +2245,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2211,6 +2299,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2222,6 +2311,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2268,12 +2358,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2320,6 +2412,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -2331,6 +2424,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2377,12 +2471,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2429,6 +2525,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -2440,6 +2537,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2486,12 +2584,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2538,6 +2638,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2549,6 +2650,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2595,12 +2697,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2647,6 +2751,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -2658,6 +2763,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2704,12 +2810,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2756,6 +2864,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -2767,6 +2876,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2853,12 +2963,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechAdaptation getAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -34,6 +35,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -55,6 +57,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechAdaptationOrBuilder getAdaptationOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -62,6 +65,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -82,6 +86,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getAlternativeLanguageCodes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -96,6 +101,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -106,6 +112,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -113,6 +120,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -135,6 +143,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAlternativeLanguageCodesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -149,6 +158,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -159,6 +169,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -166,6 +177,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -188,6 +200,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativeLanguageCodesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -202,6 +215,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,6 +237,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;String&gt; getAlternativeLanguageCodesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of up to 3 additional
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tags,
  listing possible alternative languages of the supplied audio.
@@ -237,6 +252,7 @@
  transcription).
 </code></pre><p><code>repeated string alternative_language_codes = 18;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -258,6 +274,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAudioChannelCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The number of channels in the input audio data.
  ONLY set this for MULTI-CHANNEL recognition.
  Valid values for LINEAR16 and FLAC are `1`-`8`.
@@ -269,6 +286,7 @@
  `enable_separate_recognition_per_channel` to &#39;true&#39;.
 </code></pre><p><code>int32 audio_channel_count = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -290,6 +308,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeakerDiarizationConfig getDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -300,6 +319,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -321,6 +341,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeakerDiarizationConfigOrBuilder getDiarizationConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -331,6 +352,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,11 +373,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getDiarizationSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, specifies the estimated number of speakers in the conversation.
  Defaults to &#39;2&#39;. Ignored unless enable_speaker_diarization is set to true.
  Note: Use diarization_config instead.
 </code></pre><p><code>int32 diarization_speaker_count = 17 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -377,12 +401,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableAutomaticPunctuation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, adds punctuation to recognition result hypotheses.
  This feature is only available in select languages. Setting this for
  requests in other languages has no effect at all.
  The default &#39;false&#39; value does not add punctuation to result hypotheses.
 </code></pre><p><code>bool enable_automatic_punctuation = 11;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,6 +430,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableSeparateRecognitionPerChannel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This needs to be set to `true` explicitly and `audio_channel_count` &gt; 1
  to get each channel recognized separately. The recognition result will
  contain a `channel_tag` field to state which channel that result belongs
@@ -412,6 +439,7 @@
  `audio_channel_count` multiplied by the length of the audio.
 </code></pre><p><code>bool enable_separate_recognition_per_channel = 12;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,12 +461,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
  Note: Use diarization_config instead.
 </code></pre><p><code>bool enable_speaker_diarization = 16 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -460,11 +490,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableWordConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and the
  confidence for those words. If `false`, no word-level confidence
  information is returned. The default is `false`.
 </code></pre><p><code>bool enable_word_confidence = 15;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -486,12 +518,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableWordTimeOffsets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, the top result includes a list of words and
  the start and end time offsets (timestamps) for those words. If
  `false`, no word-level time offset information is returned. The default is
  `false`.
 </code></pre><p><code>bool enable_word_time_offsets = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -513,12 +547,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig.AudioEncoding getEncoding()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -540,12 +576,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getEncodingValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Encoding of audio data sent in all `RecognitionAudio` messages.
  This field is optional for `FLAC` and `WAV` audio files and required
  for all other audio formats. For details, see
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding encoding = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -567,6 +605,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -575,6 +614,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -596,6 +636,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The language of the supplied audio as a
  [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt) language tag.
  Example: &quot;en-US&quot;.
@@ -604,6 +645,7 @@
  of the currently supported language codes.
 </code></pre><p><code>string language_code = 3 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -625,6 +667,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMaxAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of recognition hypotheses to be returned.
  Specifically, the maximum number of `SpeechRecognitionAlternative` messages
  within each `SpeechRecognitionResult`.
@@ -633,6 +676,7 @@
  one. If omitted, will return a maximum of one.
 </code></pre><p><code>int32 max_alternatives = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -654,9 +698,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata getMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,9 +724,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadataOrBuilder getMetadataOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -701,6 +749,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getModel()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -735,6 +784,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,6 +806,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getModelBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Which model to select for the given request. Select the model
  best suited to your domain to get best results. If a model is not
  explicitly specified, then we auto-select a model based on the parameters
@@ -790,6 +841,7 @@
  &lt;/table&gt;
 </code></pre><p><code>string model = 13;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -811,12 +863,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getProfanityFilter()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set to `true`, the server will attempt to filter out
  profanities, replacing all but the initial character in each filtered word
  with asterisks, e.g. &quot;f***&quot;. If set to `false` or omitted, profanities
  won&#39;t be filtered out.
 </code></pre><p><code>bool profanity_filter = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,6 +892,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSampleRateHertz()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sample rate in Hertz of the audio data sent in all
  `RecognitionAudio` messages. Valid values are: 8000-48000.
  16000 is optimal. For best results, set the sampling rate of the audio
@@ -848,6 +903,7 @@
  [AudioEncoding][google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding].
 </code></pre><p><code>int32 sample_rate_hertz = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,6 +925,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContext getSpeechContexts(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -876,6 +933,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -886,12 +944,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -913,6 +973,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeechContextsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -920,6 +981,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -940,6 +1002,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechContext&gt; getSpeechContextsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -947,6 +1010,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -967,6 +1031,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechContextOrBuilder getSpeechContextsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -974,6 +1039,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -984,12 +1050,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1011,6 +1079,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechContextOrBuilder&gt; getSpeechContextsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Array of [SpeechContext][google.cloud.speech.v1p1beta1.SpeechContext].
  A means to provide context to assist the speech recognition. For more
  information, see
@@ -1018,6 +1087,7 @@
  adaptation](https://cloud.google.com/speech-to-text/docs/context-strength).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechContext speech_contexts = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1038,6 +1108,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getUseEnhanced()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Set to true to use an enhanced model for speech recognition.
  If `use_enhanced` is set to true and the `model` field is not set, then
  an appropriate enhanced model is chosen if an enhanced model exists for
@@ -1047,6 +1118,7 @@
  of the specified model.
 </code></pre><p><code>bool use_enhanced = 14;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1068,6 +1140,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAdaptation()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Speech adaptation configuration improves the accuracy of speech
  recognition. When speech adaptation is set it supersedes the
  `speech_contexts` field. For more information, see the [speech
@@ -1075,6 +1148,7 @@
  documentation.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeechAdaptation adaptation = 20;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1096,6 +1170,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasDiarizationConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Config to enable speaker diarization and set additional
  parameters to make diarization better suited for your application.
  Note: When this is enabled, we send all the words from the beginning of the
@@ -1106,6 +1181,7 @@
  in the top alternative of the FINAL SpeechRecognitionResult.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig diarization_config = 19;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1127,9 +1203,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasMetadata()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Metadata regarding this request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata metadata = 9;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,10 +338,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,12 +375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +406,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,9 +435,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -451,9 +461,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,10 +487,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearObfuscatedId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Obfuscated (privacy-protected) ID of the user, to identify number of
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -510,12 +524,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -539,9 +555,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -563,12 +581,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -590,11 +610,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -616,9 +638,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder clearRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -662,10 +686,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -687,10 +713,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,12 +802,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,9 +831,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -825,9 +857,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -849,9 +883,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -873,9 +909,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -897,10 +935,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public long getObfuscatedId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Obfuscated (privacy-protected) ID of the user, to identify number of
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -922,9 +962,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,9 +988,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -970,12 +1014,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -997,12 +1043,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1024,11 +1072,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,11 +1100,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,9 +1128,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1100,9 +1154,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1178,12 +1234,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1215,6 +1273,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1226,6 +1285,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1274,12 +1334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1313,12 +1375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1342,10 +1406,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setAudioTopic(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,6 +1422,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1363,6 +1430,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1385,10 +1453,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setAudioTopicBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1399,6 +1469,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1406,6 +1477,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1438,6 +1510,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1449,6 +1522,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1472,12 +1546,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setIndustryNaicsCodeOfAudio(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1488,6 +1564,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1495,6 +1572,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1517,9 +1595,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setInteractionType(RecognitionMetadata.InteractionType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1530,6 +1610,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html">RecognitionMetadata.InteractionType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1537,6 +1618,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1559,9 +1641,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setInteractionTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1572,6 +1656,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1579,6 +1664,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1601,9 +1687,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setMicrophoneDistance(RecognitionMetadata.MicrophoneDistance value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1614,6 +1702,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html">RecognitionMetadata.MicrophoneDistance</a></td>
         <td><span class="parametername">value</span></td>
@@ -1621,6 +1710,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1643,9 +1733,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setMicrophoneDistanceValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1656,6 +1748,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1663,6 +1756,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1685,10 +1779,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setObfuscatedId(long value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Obfuscated (privacy-protected) ID of the user, to identify number of
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1699,6 +1795,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">value</span></td>
@@ -1706,6 +1803,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1728,9 +1826,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMediaType(RecognitionMetadata.OriginalMediaType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1741,6 +1841,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html">RecognitionMetadata.OriginalMediaType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1748,6 +1849,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1770,9 +1872,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMediaTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1783,6 +1887,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1790,6 +1895,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1812,12 +1918,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMimeType(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1828,6 +1936,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1835,6 +1944,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1857,12 +1967,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setOriginalMimeTypeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1873,6 +1985,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1880,6 +1993,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1902,11 +2016,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceName(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1917,6 +2033,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1924,6 +2041,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1946,11 +2064,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceNameBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1961,6 +2081,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1968,6 +2089,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1990,9 +2112,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceType(RecognitionMetadata.RecordingDeviceType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2003,6 +2127,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html">RecognitionMetadata.RecordingDeviceType</a></td>
         <td><span class="parametername">value</span></td>
@@ -2010,6 +2135,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2032,9 +2158,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.Builder setRecordingDeviceTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2045,6 +2173,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -2052,6 +2181,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2084,6 +2214,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2100,6 +2231,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2133,12 +2265,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
@@ -458,12 +458,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -487,10 +489,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,10 +516,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -597,12 +603,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -624,9 +632,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -648,9 +658,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -672,9 +684,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,9 +710,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -720,10 +736,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public long getObfuscatedId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Obfuscated (privacy-protected) ID of the user, to identify number of
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -745,9 +763,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -769,9 +789,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,12 +815,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -820,12 +844,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -869,11 +895,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -895,11 +923,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -921,9 +951,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -945,9 +977,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1109,12 +1143,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html">RecognitionMetadata</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1166,12 +1202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1205,12 +1243,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1244,12 +1284,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1296,6 +1338,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1307,6 +1350,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1353,12 +1397,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1405,6 +1451,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1416,6 +1463,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1462,12 +1510,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1514,6 +1564,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1525,6 +1576,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1571,12 +1623,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1623,6 +1677,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1634,6 +1689,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1680,12 +1736,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1732,6 +1790,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1743,6 +1802,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1789,12 +1849,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1841,6 +1903,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1852,6 +1915,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1938,12 +2002,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getAudioTopic()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAudioTopicBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Description of the content. Eg. &quot;Recordings of federal supreme court
  hearings from 2012&quot;.
 </code></pre><p><code>string audio_topic = 10;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -77,12 +81,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getIndustryNaicsCodeOfAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The industry vertical to which this speech recognition request most
  closely applies. This is most indicative of the topics contained
  in the audio.  Use the 6-digit NAICS code to identify the industry
  vertical - see https://www.naics.com/search/.
 </code></pre><p><code>uint32 industry_naics_code_of_audio = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,9 +110,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.InteractionType getInteractionType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -128,9 +136,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getInteractionTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The use case most closely describing the audio content to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType interaction_type = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -152,9 +162,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.MicrophoneDistance getMicrophoneDistance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -176,9 +188,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMicrophoneDistanceValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio type that most closely describes the audio being recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance microphone_distance = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -200,10 +214,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract long getObfuscatedId()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Obfuscated (privacy-protected) ID of the user, to identify number of
  unique users using the service.
 </code></pre><p><code>int64 obfuscated_id = 9 [deprecated = true];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,9 +241,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.OriginalMediaType getOriginalMediaType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -249,9 +267,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getOriginalMediaTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The original media the speech was recorded on.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType original_media_type = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -273,12 +293,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getOriginalMimeType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -300,12 +322,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getOriginalMimeTypeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Mime type of the original audio file.  For example `audio/m4a`,
  `audio/x-alaw-basic`, `audio/mp3`, `audio/3gpp`.
  A list of possible audio mime types is maintained at
  http://www.iana.org/assignments/media-types/media-types.xhtml#audio
 </code></pre><p><code>string original_mime_type = 8;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -327,11 +351,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getRecordingDeviceName()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,11 +379,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getRecordingDeviceNameBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The device used to make the recording.  Examples &#39;Nexus 5X&#39; or
  &#39;Polycom SoundStation IP 6000&#39; or &#39;POTS&#39; or &#39;VoIP&#39; or
  &#39;Cardioid Microphone&#39;.
 </code></pre><p><code>string recording_device_name = 7;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -379,9 +407,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionMetadata.RecordingDeviceType getRecordingDeviceType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -403,9 +433,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getRecordingDeviceTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The type of device the speech was recorded with.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType recording_device_type = 6;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,9 +338,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -359,10 +363,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -393,12 +399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -432,12 +440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -483,9 +493,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,9 +519,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio.Builder getAudioBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,9 +544,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -553,10 +569,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,10 +596,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,10 +622,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -688,9 +710,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -712,10 +736,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -781,9 +807,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -794,12 +822,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -821,10 +851,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -835,12 +867,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -872,12 +906,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -909,6 +945,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -920,6 +957,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -968,12 +1006,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1007,12 +1047,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1036,9 +1078,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setAudio(RecognitionAudio value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1049,12 +1093,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.html">RecognitionAudio</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,9 +1122,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setAudio(RecognitionAudio.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1089,12 +1137,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html">RecognitionAudio.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1116,10 +1166,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1130,12 +1182,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1157,10 +1211,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeRequest.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,12 +1227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1208,6 +1266,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1219,6 +1278,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1252,6 +1312,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1268,6 +1329,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1301,12 +1363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,9 +356,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -378,9 +382,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -401,10 +407,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,10 +434,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,9 +586,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,10 +612,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -721,12 +735,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -778,12 +794,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -817,12 +835,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -856,12 +876,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -908,6 +930,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -919,6 +942,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -965,12 +989,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,6 +1043,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1028,6 +1055,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1074,12 +1102,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1126,6 +1156,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1137,6 +1168,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1183,12 +1215,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1235,6 +1269,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1246,6 +1281,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,12 +1328,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1344,6 +1382,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1355,6 +1394,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1401,12 +1441,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1453,6 +1495,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1464,6 +1507,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1550,12 +1594,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
@@ -27,9 +27,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudio getAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -51,9 +53,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionAudioOrBuilder getAudioOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -74,10 +78,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -99,10 +105,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -123,9 +131,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudio()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The audio data to be recognized.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionAudio audio = 2 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -147,10 +157,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
@@ -232,10 +232,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addAllResults(Iterable&lt;? extends SpeechRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,6 +287,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -294,6 +299,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,10 +323,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,12 +339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,10 +368,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +384,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html">SpeechRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -399,10 +413,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -413,6 +429,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -424,6 +441,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -445,10 +463,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder addResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +479,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -470,6 +491,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -491,10 +513,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -515,10 +539,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,12 +555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -628,12 +656,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -667,12 +697,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -696,10 +728,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -804,10 +838,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -845,10 +883,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -859,12 +899,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -886,10 +928,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,10 +954,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -934,10 +980,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -958,10 +1006,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,12 +1022,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -999,10 +1051,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1077,12 +1131,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponse.html">RecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1114,6 +1170,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1125,6 +1182,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1173,12 +1231,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,12 +1272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,10 +1303,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,12 +1319,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1292,6 +1358,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1303,6 +1370,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,6 +1404,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1352,6 +1421,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,10 +1445,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setResults(int index, SpeechRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,6 +1461,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1400,6 +1473,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1421,10 +1495,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse.Builder setResults(int index, SpeechRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1435,6 +1511,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1446,6 +1523,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1477,12 +1555,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
@@ -308,12 +308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -419,10 +421,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -433,12 +437,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -460,10 +466,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,10 +492,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -508,10 +518,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -522,12 +534,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -549,10 +563,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -713,12 +729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponse.html">RecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -770,12 +788,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -809,12 +829,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -848,12 +870,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -900,6 +924,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -911,6 +936,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -957,12 +983,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1009,6 +1037,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1020,6 +1049,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1066,12 +1096,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1118,6 +1150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1129,6 +1162,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1175,12 +1209,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1227,6 +1263,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1238,6 +1275,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1284,12 +1322,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1336,6 +1376,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1347,6 +1388,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1393,12 +1435,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1445,6 +1489,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1456,6 +1501,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1542,12 +1588,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -41,12 +43,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -68,10 +72,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,10 +98,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -116,10 +124,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -130,12 +140,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -157,10 +169,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Sequential list of transcription results corresponding to
  sequential portions of audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,11 +338,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -401,11 +407,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -427,11 +435,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,12 +473,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -492,9 +504,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder clearSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,11 +614,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,11 +642,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -652,11 +670,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -678,9 +698,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -756,12 +778,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -793,6 +817,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -804,6 +829,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -852,12 +878,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -891,12 +919,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -920,11 +950,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setEnableSpeakerDiarization(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -935,6 +967,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -942,6 +975,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -974,6 +1008,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -985,6 +1020,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,11 +1044,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setMaxSpeakerCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1023,6 +1061,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1030,6 +1069,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1052,11 +1092,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setMinSpeakerCount(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1067,6 +1109,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1074,6 +1117,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1106,6 +1150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1122,6 +1167,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1145,9 +1191,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeakerDiarizationConfig.Builder setSpeakerTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,6 +1206,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1165,6 +1214,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1197,12 +1247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
@@ -363,12 +363,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -452,11 +454,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -478,11 +482,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -504,11 +510,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,9 +582,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -716,12 +726,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html">SpeakerDiarizationConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -773,12 +785,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -812,12 +826,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -851,12 +867,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -903,6 +921,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -914,6 +933,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -960,12 +980,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1012,6 +1034,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1023,6 +1046,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1069,12 +1093,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,6 +1147,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1132,6 +1159,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1178,12 +1206,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1230,6 +1260,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1241,6 +1272,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1287,12 +1319,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1339,6 +1373,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1350,6 +1385,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1396,12 +1432,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1448,6 +1486,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1459,6 +1498,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1545,12 +1585,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
@@ -27,11 +27,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getEnableSpeakerDiarization()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If &#39;true&#39;, enables speaker detection for each recognized word in
  the top alternative of the recognition result using a speaker_tag provided
  in the WordInfo.
 </code></pre><p><code>bool enable_speaker_diarization = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -53,11 +55,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMaxSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Maximum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 6.
 </code></pre><p><code>int32 max_speaker_count = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -79,11 +83,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getMinSpeakerCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Minimum number of speakers in the conversation. This range gives you more
  flexibility by allowing the system to automatically determine the correct
  number of speakers. If not set, the default value is 2.
 </code></pre><p><code>int32 min_speaker_count = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,9 +111,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. Unused.
 </code></pre><p><code>int32 speaker_tag = 5 [deprecated = true, (.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
@@ -230,12 +230,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addAllCustomClasses(Iterable&lt;? extends CustomClass&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.CustomClass</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -273,9 +277,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addAllPhraseSetReferences(Iterable&lt;String&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -286,6 +292,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">values</span></td>
@@ -293,6 +300,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -315,11 +323,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addAllPhraseSets(Iterable&lt;? extends PhraseSet&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -330,12 +340,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.PhraseSet</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -357,12 +369,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addCustomClasses(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,12 +387,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +416,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addCustomClasses(CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -416,12 +434,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html">CustomClass.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -443,12 +463,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addCustomClasses(int index, CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +481,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -470,6 +493,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -491,12 +515,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addCustomClasses(int index, CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,6 +533,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -518,6 +545,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -539,12 +567,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addCustomClassesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -565,12 +595,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder addCustomClassesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -581,12 +613,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -608,9 +642,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSetReferences(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -621,6 +657,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -628,6 +665,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -650,9 +688,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSetReferencesBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,6 +703,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -670,6 +711,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -692,11 +734,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSets(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -707,12 +751,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -734,11 +780,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSets(PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,12 +797,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html">PhraseSet.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -776,11 +826,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSets(int index, PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,6 +843,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -802,6 +855,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -823,11 +877,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder addPhraseSets(int index, PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -838,6 +894,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -849,6 +906,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -870,11 +928,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhraseSetsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -895,11 +955,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder addPhraseSetsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -910,12 +972,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -947,6 +1011,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -958,6 +1023,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1043,12 +1109,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clearCustomClasses()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1079,12 +1147,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1118,12 +1188,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1147,9 +1219,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clearPhraseSetReferences()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1171,11 +1245,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder clearPhraseSets()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1218,12 +1294,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1234,12 +1312,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1261,12 +1341,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder getCustomClassesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1277,12 +1359,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1304,12 +1388,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass.Builder&gt; getCustomClassesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1330,12 +1416,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1356,12 +1444,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1382,12 +1472,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1398,12 +1490,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1425,12 +1519,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1513,9 +1609,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSetReferences(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1526,6 +1624,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1533,6 +1632,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1555,9 +1655,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhraseSetReferencesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1568,6 +1670,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1575,6 +1678,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1597,9 +1701,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetReferencesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1621,9 +1727,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhraseSetReferencesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1645,11 +1753,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1660,12 +1770,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1687,11 +1799,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder getPhraseSetsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1702,12 +1816,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1729,11 +1845,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet.Builder&gt; getPhraseSetsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1754,11 +1872,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1779,11 +1899,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1804,11 +1926,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1819,12 +1943,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1846,11 +1972,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1925,12 +2053,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html">SpeechAdaptation</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1962,6 +2092,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1973,6 +2104,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2021,12 +2153,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2060,12 +2194,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2089,12 +2225,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder removeCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2105,12 +2243,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2132,11 +2272,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder removePhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2147,12 +2289,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2174,12 +2318,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setCustomClasses(int index, CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2190,6 +2336,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2201,6 +2348,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2222,12 +2370,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setCustomClasses(int index, CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2238,6 +2388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2249,6 +2400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2280,6 +2432,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2291,6 +2444,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2314,9 +2468,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setPhraseSetReferences(int index, String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2327,6 +2483,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2340,6 +2497,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2362,11 +2520,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setPhraseSets(int index, PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2377,6 +2537,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2388,6 +2549,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2409,11 +2571,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechAdaptation.Builder setPhraseSets(int index, PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2424,6 +2588,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -2435,6 +2600,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2466,6 +2632,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2482,6 +2649,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2515,12 +2683,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -373,12 +375,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,12 +393,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -416,12 +422,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -442,12 +450,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,12 +478,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,12 +496,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -511,12 +525,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -619,9 +635,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhraseSetReferences(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -632,6 +650,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -639,6 +658,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -661,9 +681,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhraseSetReferencesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -674,6 +696,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -681,6 +704,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -703,9 +727,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetReferencesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,9 +753,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhraseSetReferencesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,11 +779,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -766,12 +796,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -793,11 +825,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -818,11 +852,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -843,11 +879,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -858,12 +896,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -885,11 +925,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1050,12 +1092,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html">SpeechAdaptation</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1107,12 +1151,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1146,12 +1192,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1185,12 +1233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,6 +1287,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1248,6 +1299,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,12 +1346,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,6 +1400,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1357,6 +1412,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1403,12 +1459,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1455,6 +1513,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1466,6 +1525,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1512,12 +1572,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1564,6 +1626,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1575,6 +1638,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1621,12 +1685,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1673,6 +1739,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1684,6 +1751,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1730,12 +1798,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1782,6 +1852,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1793,6 +1864,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1879,12 +1951,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass getCustomClasses(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -43,12 +45,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -70,12 +74,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getCustomClassesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,12 +102,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;CustomClass&gt; getCustomClassesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,12 +130,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClassOrBuilder getCustomClassesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,12 +148,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -165,12 +177,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends CustomClassOrBuilder&gt; getCustomClassesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of custom classes. To specify the classes inline, leave the
  class&#39; `name` blank and fill in the rest of its fields, giving it a unique
  `custom_class_id`. Refer to the inline defined class in phrase hints by its
  `custom_class_id`.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.CustomClass custom_classes = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,9 +205,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPhraseSetReferences(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -204,6 +220,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -211,6 +228,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -233,9 +251,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPhraseSetReferencesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,6 +266,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -253,6 +274,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -275,9 +297,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhraseSetReferencesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -299,9 +323,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;String&gt; getPhraseSetReferencesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase set resource names to use.
 </code></pre><p><code>repeated string phrase_set_references = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -323,11 +349,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet getPhraseSets(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -338,12 +366,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -365,11 +395,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhraseSetsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,11 +422,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;PhraseSet&gt; getPhraseSetsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,11 +449,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSetOrBuilder getPhraseSetsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -430,12 +466,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -457,11 +495,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends PhraseSetOrBuilder&gt; getPhraseSetsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A collection of phrase sets. To specify the hints inline, leave the
  phrase set&#39;s `name` blank and fill in the rest of its fields. Any
  phrase set can use any custom class.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.PhraseSet phrase_sets = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
@@ -94,12 +94,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistry</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechAdaptationProto_registerAllExtensions_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.registerAllExtensions*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechAdaptationProto_registerAllExtensions_com_google_protobuf_ExtensionRegistryLite_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.registerAllExtensions(com.google.protobuf.ExtensionRegistryLite)" class="notranslate">registerAllExtensions(ExtensionRegistryLite registry)</h3>
@@ -116,12 +118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistryLite</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
@@ -96,8 +96,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected SpeechClient(SpeechSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -108,12 +110,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechClient_SpeechClient_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.SpeechClient*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechClient_SpeechClient_com_google_cloud_speech_v1p1beta1_stub_SpeechStub_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechClient.SpeechClient(com.google.cloud.speech.v1p1beta1.stub.SpeechStub)" class="notranslate">SpeechClient(SpeechStub stub)</h3>
@@ -130,12 +134,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html">SpeechStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -154,6 +160,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -165,6 +172,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -206,8 +214,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient with default settings.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,8 +253,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create(SpeechSettings settings)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given settings. The channels are created based on the settings passed in, or defaults for any settings that are not set.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -255,12 +267,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -297,8 +311,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final SpeechClient create(SpeechStub stub)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of SpeechClient, using the given stub for making calls. This is for advanced usage - prefer using create(SpeechSettings).</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html">SpeechStub</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,8 +354,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationsClient getOperationsClient()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the OperationsClient that can be used to query the status of a long-running operation returned by another API method call.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -438,6 +458,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationFuture&lt;LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeAsync(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -449,6 +470,7 @@
    LongRunningRecognizeResponse response = speechClient.longRunningRecognizeAsync(request).get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -459,6 +481,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -466,6 +489,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -487,6 +511,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationFuture&lt;LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeAsync(RecognitionConfig config, RecognitionAudio audio)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -496,6 +521,7 @@
        speechClient.longRunningRecognizeAsync(config, audio).get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -506,6 +532,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">config</span></td>
@@ -520,6 +547,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -541,6 +569,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -554,6 +583,7 @@
    Operation response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,6 +604,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final OperationCallable&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs asynchronous speech recognition: receive results via the google.longrunning.Operations interface. Returns either an `Operation.error` or an `Operation.response` which contains a `LongRunningRecognizeResponse` message. For more information on asynchronous speech recognition, see the [how-to](<a href="https://cloud.google.com/speech-to-text/docs/async-recognize">https://cloud.google.com/speech-to-text/docs/async-recognize</a>).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -588,6 +619,7 @@
    LongRunningRecognizeResponse response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,6 +640,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse recognize(RecognitionConfig config, RecognitionAudio audio)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -616,6 +649,7 @@
    RecognizeResponse response = speechClient.recognize(config, audio);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,6 +660,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">config</span></td>
@@ -640,6 +675,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -661,6 +697,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final RecognizeResponse recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -672,6 +709,7 @@
    RecognizeResponse response = speechClient.recognize(request);
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -682,6 +720,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -689,6 +728,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -710,6 +750,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final UnaryCallable&lt;RecognizeRequest,RecognizeResponse&gt; recognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs synchronous speech recognition: receive results after all audio has been sent and processed.</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -723,6 +764,7 @@
    RecognizeResponse response = future.get();
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -753,6 +795,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public final BidiStreamingCallable&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeCallable()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Performs bidirectional streaming speech recognition: receive results while sending audio. This method is only available via the gRPC API (not REST).</p>
 <p>Sample code:</p>
 <pre><code class="lang-java">try (SpeechClient speechClient = SpeechClient.create()) {
@@ -765,6 +808,7 @@
    }
  }
 </code></pre></div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
@@ -231,6 +231,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addAllPhrases(Iterable&lt;String&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -244,6 +245,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -254,6 +256,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">java.lang.String</span>&gt;</td>
         <td><span class="parametername">values</span></td>
@@ -261,6 +264,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -283,6 +287,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrases(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -296,6 +301,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -306,6 +312,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -313,6 +320,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -335,6 +343,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder addPhrasesBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -348,6 +357,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -358,6 +368,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -365,6 +376,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -397,6 +409,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -408,6 +421,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -493,6 +507,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -503,6 +518,7 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,12 +550,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -573,12 +591,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -602,6 +622,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder clearPhrases()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -615,6 +636,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -658,6 +680,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -668,6 +691,7 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,6 +775,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -764,6 +789,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -774,6 +800,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -781,6 +808,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -803,6 +831,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -816,6 +845,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -826,6 +856,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -833,6 +864,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -855,6 +887,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -868,6 +901,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,6 +923,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -902,6 +937,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -977,12 +1013,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1014,6 +1052,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1025,6 +1064,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1073,12 +1113,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1112,12 +1154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1141,6 +1185,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setBoost(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -1151,6 +1196,7 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1161,6 +1207,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -1168,6 +1215,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,6 +1248,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1211,6 +1260,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1234,6 +1284,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechContext.Builder setPhrases(int index, String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -1247,6 +1298,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1257,6 +1309,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1270,6 +1323,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1302,6 +1356,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1318,6 +1373,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1351,12 +1407,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
@@ -326,12 +326,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -355,6 +357,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -365,6 +368,7 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,6 +472,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -481,6 +486,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -491,6 +497,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -498,6 +505,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -520,6 +528,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -533,6 +542,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -543,6 +553,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -550,6 +561,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -572,6 +584,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -585,6 +598,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -606,6 +620,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ProtocolStringList getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -619,6 +634,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -780,12 +796,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContext.html">SpeechContext</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -837,12 +855,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -876,12 +896,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -915,12 +937,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -967,6 +991,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -978,6 +1003,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1024,12 +1050,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,6 +1104,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1087,6 +1116,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1133,12 +1163,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1185,6 +1217,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1196,6 +1229,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1242,12 +1276,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,6 +1330,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1305,6 +1342,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1351,12 +1389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1403,6 +1443,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1414,6 +1455,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1460,12 +1502,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1512,6 +1556,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1523,6 +1568,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1609,12 +1655,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getBoost()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Hint Boost. Positive value will increase the probability that a specific
  phrase will be recognized over other similar sounding phrases. The higher
  the boost, the higher the chance of false positive recognition as well.
@@ -37,6 +38,7 @@
  finding the optimal value for your use case.
 </code></pre><p><code>float boost = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,6 +60,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getPhrases(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -71,6 +74,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,6 +85,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -88,6 +93,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -110,6 +116,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getPhrasesBytes(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -123,6 +130,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -133,6 +141,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -140,6 +149,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -162,6 +172,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getPhrasesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -175,6 +186,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -196,6 +208,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;String&gt; getPhrasesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of strings containing words and phrases &quot;hints&quot; so that
  the speech recognition is more likely to recognize them. This can be used
  to improve the accuracy for specific words and phrases, for example, if
@@ -209,6 +222,7 @@
  months.
 </code></pre><p><code>repeated string phrases = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Operation longRunningRecognize(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -204,9 +210,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognizeResponse recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,12 +225,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;Operation&gt; longRunningRecognize(LongRunningRecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -204,9 +210,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ListenableFuture&lt;RecognizeResponse&gt; recognize(RecognizeRequest request)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,12 +225,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
@@ -97,6 +97,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void longRunningRecognize(LongRunningRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -104,6 +105,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,6 +116,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -125,15 +128,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_recognize_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.recognize*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_recognize_com_google_cloud_speech_v1p1beta1_RecognizeRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_RecognizeResponse__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.recognize(com.google.cloud.speech.v1p1beta1.RecognizeRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.RecognizeResponse&gt;)" class="notranslate">recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,6 +150,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -155,15 +162,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_streamingRecognize_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.streamingRecognize*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechImplBase_streamingRecognize_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponse__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.streamingRecognize(io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse&gt;)" class="notranslate">streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -174,12 +184,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
@@ -126,6 +126,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
@@ -137,6 +138,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -160,6 +162,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public void longRunningRecognize(LongRunningRecognizeRequest request, StreamObserver&lt;Operation&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs asynchronous speech recognition: receive results via the
  google.longrunning.Operations interface. Returns either an
  `Operation.error` or an `Operation.response` which contains
@@ -167,6 +170,7 @@
  For more information on asynchronous speech recognition, see the
  [how-to](https://cloud.google.com/speech-to-text/docs/async-recognize).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -177,6 +181,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html">LongRunningRecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -188,15 +193,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechStub_recognize_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.recognize*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechStub_recognize_com_google_cloud_speech_v1p1beta1_RecognizeRequest_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_RecognizeResponse__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.recognize(com.google.cloud.speech.v1p1beta1.RecognizeRequest,io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.RecognizeResponse&gt;)" class="notranslate">recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public void recognize(RecognizeRequest request, StreamObserver&lt;RecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs synchronous speech recognition: receive results after all audio
  has been sent and processed.
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -207,6 +215,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequest.html">RecognizeRequest</a></td>
         <td><span class="parametername">request</span></td>
@@ -218,15 +227,18 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechStub_streamingRecognize_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.streamingRecognize*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechGrpc_SpeechStub_streamingRecognize_io_grpc_stub_StreamObserver_com_google_cloud_speech_v1p1beta1_StreamingRecognizeResponse__" data-uid="com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.streamingRecognize(io.grpc.stub.StreamObserver&lt;com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse&gt;)" class="notranslate">streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamObserver&lt;StreamingRecognizeRequest&gt; streamingRecognize(StreamObserver&lt;StreamingRecognizeResponse&gt; responseObserver)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Performs bidirectional streaming speech recognition: receive results while
  sending audio. This method is only available via the gRPC API (not REST).
 </code></pre></div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -237,12 +249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.stub.StreamObserver</span>&lt;<a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a>&gt;</td>
         <td><span class="parametername">responseObserver</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
@@ -167,8 +167,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechBlockingStub newBlockingStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new blocking-style stub that supports unary and streaming output calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -179,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -206,8 +210,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechFutureStub newFutureStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new ListenableFuture-style stub that supports unary calls on the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -218,12 +224,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -245,8 +253,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechGrpc.SpeechStub newStub(Channel channel)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Creates a new async stub that supports all call types for the service</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -257,12 +267,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">io.grpc.Channel</span></td>
         <td><span class="parametername">channel</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechProto.html
@@ -94,12 +94,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistry</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechProto_registerAllExtensions_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechProto.registerAllExtensions*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechProto_registerAllExtensions_com_google_protobuf_ExtensionRegistryLite_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechProto.registerAllExtensions(com.google.protobuf.ExtensionRegistryLite)" class="notranslate">registerAllExtensions(ExtensionRegistryLite registry)</h3>
@@ -116,12 +118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistryLite</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
@@ -230,11 +230,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAllWords(Iterable&lt;? extends WordInfo&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,12 +247,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.WordInfo</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -282,6 +286,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -293,6 +298,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -316,11 +322,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,12 +339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,11 +368,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,12 +385,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html">WordInfo.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,11 +414,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(int index, WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -415,6 +431,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -426,6 +443,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -447,11 +465,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addWords(int index, WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -462,6 +482,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -473,6 +494,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -494,11 +516,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addWordsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,11 +543,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder addWordsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -534,12 +560,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -623,6 +651,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -632,6 +661,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -663,12 +693,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -702,12 +734,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -731,9 +765,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -755,11 +791,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder clearWords()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -802,6 +840,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -811,6 +850,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -894,9 +934,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -918,9 +960,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,11 +986,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -957,12 +1003,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -984,11 +1032,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder getWordsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -999,12 +1049,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1026,11 +1078,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo.Builder&gt; getWordsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1051,11 +1105,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1076,11 +1132,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1101,11 +1159,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1116,12 +1176,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1143,11 +1205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1222,12 +1286,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1259,6 +1325,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1270,6 +1337,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1318,12 +1386,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1357,12 +1427,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1386,11 +1458,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder removeWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1401,12 +1475,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1428,6 +1504,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setConfidence(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -1437,6 +1514,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1447,6 +1525,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -1454,6 +1533,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1486,6 +1566,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1497,6 +1578,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1530,6 +1612,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1546,6 +1629,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1569,9 +1653,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscript(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1582,6 +1668,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1589,6 +1676,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1611,9 +1699,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setTranscriptBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1624,6 +1714,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1631,6 +1722,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1663,12 +1755,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1692,11 +1786,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setWords(int index, WordInfo value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1707,6 +1803,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1718,6 +1815,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1739,11 +1837,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder setWords(int index, WordInfo.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1754,6 +1854,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1765,6 +1866,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -373,6 +375,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -382,6 +385,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,9 +511,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -531,9 +537,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -577,11 +585,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,12 +602,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -619,11 +631,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -644,11 +658,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -669,11 +685,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -684,12 +702,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -711,11 +731,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -832,12 +854,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -889,12 +913,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -928,12 +954,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -967,12 +995,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1019,6 +1049,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1030,6 +1061,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1076,12 +1108,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1128,6 +1162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1139,6 +1174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1185,12 +1221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,6 +1275,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1248,6 +1287,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1294,12 +1334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1346,6 +1388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1357,6 +1400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1403,12 +1447,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1455,6 +1501,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1466,6 +1513,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1512,12 +1560,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1564,6 +1614,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1575,6 +1626,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1661,12 +1713,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -36,6 +37,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -57,9 +59,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getTranscript()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -81,9 +85,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getTranscriptBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Transcript text representing the words that the user spoke.
 </code></pre><p><code>string transcript = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -105,11 +111,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract WordInfo getWords(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -120,12 +128,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -147,11 +157,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getWordsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -172,11 +184,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;WordInfo&gt; getWordsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -197,11 +211,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract WordInfoOrBuilder getWordsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -212,12 +228,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -239,11 +257,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends WordInfoOrBuilder&gt; getWordsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>A list of word-specific information for each recognized word.
  Note: When `enable_speaker_diarization` is true, you will see all the words
  from the beginning of the audio.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.WordInfo words = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
@@ -230,12 +230,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -246,12 +248,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -273,12 +277,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -289,12 +295,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -316,12 +324,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -332,12 +342,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -359,12 +371,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,6 +389,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -386,6 +401,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -407,12 +423,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -423,6 +441,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -434,6 +453,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -455,12 +475,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,12 +503,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,12 +521,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -534,6 +560,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -545,6 +572,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -630,12 +658,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -656,11 +686,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -692,12 +724,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -721,11 +755,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -757,12 +793,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -808,12 +846,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -824,12 +864,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -851,12 +893,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -867,12 +911,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -894,12 +940,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -920,12 +968,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -946,12 +996,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -972,12 +1024,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -988,12 +1042,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1015,12 +1071,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1041,11 +1099,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1129,11 +1189,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1155,11 +1217,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1235,12 +1299,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1272,6 +1338,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1283,6 +1350,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1331,12 +1399,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1370,12 +1440,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1399,12 +1471,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1415,12 +1489,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1442,12 +1518,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1458,6 +1536,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1469,6 +1548,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1490,12 +1570,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1506,6 +1588,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1517,6 +1600,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1538,11 +1622,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setChannelTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1553,6 +1639,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1560,6 +1647,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1592,6 +1680,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1603,6 +1692,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1626,11 +1716,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1641,6 +1733,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1648,6 +1741,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1670,11 +1764,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionResult.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1685,6 +1781,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1692,6 +1789,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1724,6 +1822,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1740,6 +1839,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1773,12 +1873,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
@@ -344,12 +344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -373,12 +375,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -389,12 +393,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -416,12 +422,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -442,12 +450,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -468,12 +478,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -484,12 +496,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -511,12 +525,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -537,11 +553,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -623,11 +641,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -649,11 +669,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -837,12 +859,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html">SpeechRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -894,12 +918,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -933,12 +959,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -972,12 +1000,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1024,6 +1054,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1035,6 +1066,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1081,12 +1113,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1133,6 +1167,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1144,6 +1179,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1190,12 +1226,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1242,6 +1280,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1253,6 +1292,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1299,12 +1339,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1351,6 +1393,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1362,6 +1405,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1408,12 +1452,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1460,6 +1506,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1471,6 +1518,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1517,12 +1565,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1569,6 +1619,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1580,6 +1631,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1666,12 +1718,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -43,12 +45,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -70,12 +74,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,12 +102,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,12 +130,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,12 +148,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -165,12 +177,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,11 +205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,11 +233,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -243,11 +261,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
@@ -94,12 +94,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistry</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechResourceProto_registerAllExtensions_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechResourceProto.registerAllExtensions*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechResourceProto_registerAllExtensions_com_google_protobuf_ExtensionRegistryLite_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechResourceProto.registerAllExtensions(com.google.protobuf.ExtensionRegistryLite)" class="notranslate">registerAllExtensions(ExtensionRegistryLite registry)</h3>
@@ -116,12 +118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ExtensionRegistryLite</span></td>
         <td><span class="parametername">registry</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
 </article>
     </div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
@@ -154,12 +154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_SpeechSettings_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.SpeechSettings)" class="notranslate">Builder(SpeechSettings settings)</h3>
@@ -176,12 +178,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechSettings.html">SpeechSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_SpeechSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder)" class="notranslate">Builder(SpeechStubSettings.Builder stubSettings)</h3>
@@ -198,12 +202,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html">SpeechStubSettings.Builder</a></td>
         <td><span class="parametername">stubSettings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -212,9 +218,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -225,12 +233,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -324,8 +334,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings.Builder&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,8 +358,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,8 +382,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -390,8 +406,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings.Builder&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html">SpeechSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -156,12 +158,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">stub</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -218,8 +222,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,8 +246,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -262,8 +270,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -304,8 +314,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -326,8 +338,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -348,8 +362,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -370,8 +386,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -392,8 +410,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -414,8 +434,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -426,12 +448,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -453,8 +477,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -475,8 +501,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -497,8 +525,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
@@ -241,6 +241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -252,6 +253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -337,10 +339,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -371,12 +375,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -400,12 +406,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -437,12 +445,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -466,6 +476,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder clearSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -486,6 +497,7 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,10 +541,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,10 +568,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig.Builder getConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -578,10 +594,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -664,12 +682,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -691,6 +711,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -711,6 +732,7 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -732,10 +754,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,10 +825,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder mergeConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -815,12 +841,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -852,12 +880,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -889,6 +919,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -900,6 +931,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -948,12 +980,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -987,12 +1021,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1016,10 +1052,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1030,12 +1068,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.html">RecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1057,10 +1097,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setConfig(RecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1071,12 +1113,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html">RecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1108,6 +1152,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1119,6 +1164,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1142,12 +1188,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setInterimResults(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1158,6 +1206,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1165,6 +1214,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1197,6 +1247,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1213,6 +1264,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1236,6 +1288,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder setSingleUtterance(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -1256,6 +1309,7 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1266,6 +1320,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1273,6 +1328,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1305,12 +1361,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
@@ -345,12 +345,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -374,10 +376,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -399,10 +403,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -483,12 +489,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -554,6 +562,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -574,6 +583,7 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,10 +627,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -738,12 +750,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -795,12 +809,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -834,12 +850,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -873,12 +891,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -925,6 +945,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -936,6 +957,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -982,12 +1004,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1034,6 +1058,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1045,6 +1070,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1091,12 +1117,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1143,6 +1171,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1154,6 +1183,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1200,12 +1230,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1252,6 +1284,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1263,6 +1296,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1309,12 +1343,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1361,6 +1397,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1372,6 +1409,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1418,12 +1456,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1470,6 +1510,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1481,6 +1522,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1567,12 +1609,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfig getConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract RecognitionConfigOrBuilder getConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -76,12 +80,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getInterimResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `true`, interim results (tentative hypotheses) may be
  returned as they become available (these interim results are indicated with
  the `is_final=false` flag).
  If `false` or omitted, only `is_final=true` result(s) are returned.
 </code></pre><p><code>bool interim_results = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -103,6 +109,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getSingleUtterance()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false` or omitted, the recognizer will perform continuous
  recognition (continuing to wait for and process audio even if the user
  pauses speaking) until the client closes the input stream (gRPC API) or
@@ -123,6 +130,7 @@
    `RecognitionConfig`.
 </code></pre><p><code>bool single_utterance = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -144,10 +152,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. Provides information to the recognizer that specifies how to
  process the request.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.RecognitionConfig config = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
@@ -231,12 +231,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAllAlternatives(Iterable&lt;? extends SpeechRecognitionAlternative&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -247,12 +249,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -274,12 +278,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -290,12 +296,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html">SpeechRecognitionAlternative</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -317,12 +325,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -333,12 +343,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html">SpeechRecognitionAlternative.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -360,12 +372,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -376,6 +390,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -387,6 +402,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -408,12 +424,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -424,6 +442,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -435,6 +454,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -456,12 +476,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -482,12 +504,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder addAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -498,12 +522,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -535,6 +561,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -546,6 +573,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -631,12 +659,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearAlternatives()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -657,11 +687,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -693,12 +725,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -722,6 +756,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -729,6 +764,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -750,11 +786,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,12 +824,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -815,10 +855,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -839,6 +881,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder clearStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -846,6 +889,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -889,12 +933,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -905,12 +951,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -932,12 +980,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative.Builder getAlternativesBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -948,12 +998,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -975,12 +1027,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative.Builder&gt; getAlternativesBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1001,12 +1055,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1027,12 +1083,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1053,12 +1111,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1069,12 +1129,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1096,12 +1158,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1122,11 +1186,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1210,6 +1276,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1217,6 +1284,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1238,11 +1306,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1264,11 +1334,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1290,10 +1362,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1315,10 +1389,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getResultEndTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1339,10 +1415,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1363,6 +1441,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -1370,6 +1449,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1391,10 +1471,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1470,12 +1552,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1507,6 +1591,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1518,6 +1603,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1566,12 +1652,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1595,10 +1683,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder mergeResultEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1609,12 +1699,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1646,12 +1738,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1675,12 +1769,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder removeAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1691,12 +1787,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1718,12 +1816,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1734,6 +1834,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1745,6 +1846,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1766,12 +1868,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setAlternatives(int index, SpeechRecognitionAlternative.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1782,6 +1886,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1793,6 +1898,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1814,11 +1920,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setChannelTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1829,6 +1937,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1836,6 +1945,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1868,6 +1978,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1879,6 +1990,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1902,6 +2014,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setIsFinal(boolean value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -1909,6 +2022,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1919,6 +2033,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">boolean</span></td>
         <td><span class="parametername">value</span></td>
@@ -1926,6 +2041,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1948,11 +2064,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setLanguageCode(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1963,6 +2081,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1970,6 +2089,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1992,11 +2112,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setLanguageCodeBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2007,6 +2129,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -2014,6 +2137,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2046,6 +2170,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -2062,6 +2187,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2085,10 +2211,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setResultEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2099,12 +2227,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2126,10 +2256,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setResultEndTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2140,12 +2272,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2167,6 +2301,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder setStability(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -2174,6 +2309,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -2184,6 +2320,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -2191,6 +2328,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -2223,12 +2361,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
@@ -402,12 +402,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -431,12 +433,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -447,12 +451,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -474,12 +480,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,12 +508,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -526,12 +536,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -542,12 +554,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -569,12 +583,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -595,11 +611,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -681,6 +699,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -688,6 +707,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,11 +729,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -735,11 +757,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -783,10 +807,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,10 +834,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -854,6 +882,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -861,6 +890,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -904,10 +934,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1025,12 +1057,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1082,12 +1116,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1121,12 +1157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,12 +1198,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,6 +1252,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1223,6 +1264,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1269,12 +1311,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,6 +1365,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1332,6 +1377,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1378,12 +1424,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1430,6 +1478,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1441,6 +1490,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1487,12 +1537,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,6 +1591,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1550,6 +1603,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,12 +1650,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1648,6 +1704,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1659,6 +1716,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1705,12 +1763,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1757,6 +1817,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1768,6 +1829,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1854,12 +1916,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternative getAlternatives(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -43,12 +45,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -70,12 +74,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getAlternativesCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -96,12 +102,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;SpeechRecognitionAlternative&gt; getAlternativesList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -122,12 +130,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract SpeechRecognitionAlternativeOrBuilder getAlternativesOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -138,12 +148,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -165,12 +177,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends SpeechRecognitionAlternativeOrBuilder&gt; getAlternativesOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>May contain one or more recognition hypotheses (up to the
  maximum specified in `max_alternatives`).
  These alternatives are ordered in terms of accuracy, with the top (first)
  alternative being the most probable, as ranked by the recognizer.
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative alternatives = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -191,11 +205,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getChannelTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>For multi-channel audio, this is the channel number corresponding to the
  recognized result for the audio from that channel.
  For audio_channel_count = N, its output values can range from &#39;1&#39; to &#39;N&#39;.
 </code></pre><p><code>int32 channel_tag = 5;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -217,6 +233,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean getIsFinal()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If `false`, this `StreamingRecognitionResult` represents an
  interim result that may change. If `true`, this is the final time the
  speech service will return this particular `StreamingRecognitionResult`,
@@ -224,6 +241,7 @@
  the transcript and corresponding audio.
 </code></pre><p><code>bool is_final = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,11 +263,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getLanguageCode()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -271,11 +291,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getLanguageCodeBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. The [BCP-47](https://www.rfc-editor.org/rfc/bcp/bcp47.txt)
  language tag of the language in this result. This language code was
  detected to have the most likelihood of being spoken in the audio.
 </code></pre><p><code>string language_code = 6 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -297,10 +319,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -322,10 +346,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getResultEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -346,6 +372,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getStability()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>An estimate of the likelihood that the recognizer will not
  change its guess about this interim result. Values range from 0.0
  (completely unstable) to 1.0 (completely stable).
@@ -353,6 +380,7 @@
  The default of 0.0 is a sentinel value indicating `stability` was not set.
 </code></pre><p><code>float stability = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -374,10 +402,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasResultEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset of the end of this result relative to the
  beginning of the audio.
 </code></pre><p><code>.google.protobuf.Duration result_end_time = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
@@ -244,6 +244,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -255,6 +256,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -340,6 +342,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -350,6 +353,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,12 +385,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -420,12 +426,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -449,11 +457,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder clearStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -516,6 +526,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -526,6 +537,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -609,11 +621,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -635,11 +649,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig.Builder getStreamingConfigBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -660,11 +676,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -705,6 +723,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -715,6 +734,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -736,11 +756,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -816,12 +838,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -853,6 +877,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -864,6 +889,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -912,12 +938,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -941,11 +969,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder mergeStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -956,12 +986,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -993,12 +1025,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1022,6 +1056,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setAudioContent(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -1032,6 +1067,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1042,6 +1078,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1049,6 +1086,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1081,6 +1119,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1092,6 +1131,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1125,6 +1165,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1141,6 +1182,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1164,11 +1206,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1179,12 +1223,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html">StreamingRecognitionConfig</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1206,11 +1252,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeRequest.Builder setStreamingConfig(StreamingRecognitionConfig.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1221,12 +1269,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html">StreamingRecognitionConfig.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1258,12 +1308,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
@@ -329,12 +329,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -358,6 +360,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -368,6 +371,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,11 +497,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -519,11 +525,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -586,6 +594,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -596,6 +605,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -617,11 +627,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -739,12 +751,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html">StreamingRecognizeRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -796,12 +810,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -835,12 +851,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -874,12 +892,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -926,6 +946,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -937,6 +958,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -983,12 +1005,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1035,6 +1059,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1046,6 +1071,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1092,12 +1118,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1144,6 +1172,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1155,6 +1184,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1201,12 +1231,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1253,6 +1285,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1264,6 +1297,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1310,12 +1344,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1362,6 +1398,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1373,6 +1410,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1419,12 +1457,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1471,6 +1511,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1482,6 +1523,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1568,12 +1610,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -37,6 +38,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -58,11 +60,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfig getStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -84,11 +88,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionConfigOrBuilder getStreamingConfigOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -129,6 +135,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasAudioContent()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The audio data to be recognized. Sequential chunks of audio data are sent
  in sequential `StreamingRecognizeRequest` messages. The first
  `StreamingRecognizeRequest` message must not contain `audio_content` data
@@ -139,6 +146,7 @@
  [content limits](https://cloud.google.com/speech-to-text/quotas#content).
 </code></pre><p><code>bytes audio_content = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -160,11 +168,13 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStreamingConfig()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Provides information to the recognizer that specifies how to process the
  request. The first `StreamingRecognizeRequest` message must contain a
  `streaming_config`  message.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig streaming_config = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
@@ -265,12 +265,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addAllResults(Iterable&lt;? extends StreamingRecognitionResult&gt; values)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -281,12 +283,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Iterable</span>&lt;<span class="xref">? extends com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult</span>&gt;</td>
         <td><span class="parametername">values</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -318,6 +322,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -329,6 +334,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -352,12 +358,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -368,12 +376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html">StreamingRecognitionResult</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -395,12 +405,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -411,12 +423,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html">StreamingRecognitionResult.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -438,12 +452,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -454,6 +470,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -465,6 +482,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -486,12 +504,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder addResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -502,6 +522,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -513,6 +534,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -534,12 +556,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -560,12 +584,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder addResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -576,12 +602,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -665,10 +693,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -699,12 +729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -738,12 +770,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -767,12 +801,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearResults()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -793,9 +829,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder clearSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -901,10 +939,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -926,10 +966,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status.Builder getErrorBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -950,10 +992,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -974,12 +1018,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -990,12 +1036,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1017,12 +1065,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult.Builder getResultsBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1033,12 +1083,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1060,12 +1112,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult.Builder&gt; getResultsBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1086,12 +1140,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1112,12 +1168,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1138,12 +1196,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1154,12 +1214,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1181,12 +1243,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1207,9 +1271,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1231,9 +1297,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1255,10 +1323,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1324,10 +1394,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder mergeError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1338,12 +1410,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1375,12 +1449,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1412,6 +1488,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1423,6 +1500,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1471,12 +1549,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1510,12 +1590,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,12 +1621,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder removeResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1555,12 +1639,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1582,10 +1668,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1596,12 +1684,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1623,10 +1713,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setError(Status.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1637,12 +1729,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.rpc.Status.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1674,6 +1768,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1685,6 +1780,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1718,6 +1814,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1734,6 +1831,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1757,12 +1855,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1773,6 +1873,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1784,6 +1885,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1805,12 +1907,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setResults(int index, StreamingRecognitionResult.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1821,6 +1925,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
@@ -1832,6 +1937,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1853,9 +1959,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setSpeechEventType(StreamingRecognizeResponse.SpeechEventType value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1866,6 +1974,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html">StreamingRecognizeResponse.SpeechEventType</a></td>
         <td><span class="parametername">value</span></td>
@@ -1873,6 +1982,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1895,9 +2005,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.Builder setSpeechEventTypeValue(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1908,6 +2020,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1915,6 +2028,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1947,12 +2061,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
@@ -379,12 +379,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -468,10 +470,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -493,10 +497,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -539,12 +545,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -555,12 +563,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -582,12 +592,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -608,12 +620,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -634,12 +648,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,12 +666,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -677,12 +695,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -725,9 +745,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -749,9 +771,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -795,10 +819,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -916,12 +942,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html">StreamingRecognizeResponse</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -973,12 +1001,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1012,12 +1042,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1051,12 +1083,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1103,6 +1137,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1114,6 +1149,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1160,12 +1196,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1212,6 +1250,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1223,6 +1262,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1269,12 +1309,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1321,6 +1363,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1332,6 +1375,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1378,12 +1422,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1430,6 +1476,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1441,6 +1488,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1487,12 +1535,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1539,6 +1589,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1550,6 +1601,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1596,12 +1648,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1648,6 +1702,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1659,6 +1714,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1745,12 +1801,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -27,10 +27,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Status getError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -52,10 +54,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StatusOrBuilder getErrorOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -76,12 +80,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResult getResults(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -92,12 +98,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -119,12 +127,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getResultsCount()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -145,12 +155,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;StreamingRecognitionResult&gt; getResultsList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,12 +183,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognitionResultOrBuilder getResultsOrBuilder(int index)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -187,12 +201,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">index</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -214,12 +230,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract List&lt;? extends StreamingRecognitionResultOrBuilder&gt; getResultsOrBuilderList()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>This repeated list contains zero or more results that
  correspond to consecutive portions of the audio currently being processed.
  It contains zero or one `is_final=true` result (the newly settled portion),
  followed by zero or more `is_final=false` results (the interim results).
 </code></pre><p><code>repeated .google.cloud.speech.v1p1beta1.StreamingRecognitionResult results = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -240,9 +258,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract StreamingRecognizeResponse.SpeechEventType getSpeechEventType()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -264,9 +284,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeechEventTypeValue()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Indicates the type of speech event.
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType speech_event_type = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -288,10 +310,12 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasError()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>If set, returns a [google.rpc.Status][google.rpc.Status] message that
  specifies the error for the operation.
 </code></pre><p><code>.google.rpc.Status error = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,12 +338,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clearCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -372,12 +376,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -411,12 +417,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -440,9 +448,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder clearUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,12 +495,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -512,12 +524,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass.Builder getCustomClassBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -538,12 +552,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,9 +642,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,9 +668,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask.Builder getUpdateMaskBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,9 +693,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,12 +718,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,9 +747,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -791,12 +817,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder mergeCustomClass(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -807,12 +835,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -844,12 +874,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -881,6 +913,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -892,6 +925,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -940,12 +974,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -979,12 +1015,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,9 +1046,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder mergeUpdateMask(FieldMask value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,12 +1061,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1048,12 +1090,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setCustomClass(CustomClass value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1064,12 +1108,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.html">CustomClass</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1091,12 +1137,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setCustomClass(CustomClass.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1107,12 +1155,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html">CustomClass.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1144,6 +1194,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1155,6 +1206,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1188,6 +1240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1204,6 +1257,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,12 +1291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1266,9 +1322,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setUpdateMask(FieldMask value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,12 +1337,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1306,9 +1366,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdateCustomClassRequest.Builder setUpdateMask(FieldMask.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1319,12 +1381,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -354,12 +356,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -381,12 +385,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,9 +539,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,9 +565,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,12 +590,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,9 +619,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,12 +741,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html">UpdateCustomClassRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -784,12 +800,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -823,12 +841,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,12 +882,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -914,6 +936,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -925,6 +948,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,12 +995,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1023,6 +1049,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1034,6 +1061,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1080,12 +1108,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1132,6 +1162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1143,6 +1174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1189,12 +1221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,6 +1275,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1252,6 +1287,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1298,12 +1334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1350,6 +1388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1361,6 +1400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1407,12 +1447,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1459,6 +1501,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1470,6 +1513,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1556,12 +1600,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClass getCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -54,12 +56,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract CustomClassOrBuilder getCustomClassOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,9 +84,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,9 +110,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,12 +135,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasCustomClass()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The custom class to update.
  The custom class&#39;s `name` field is used to identify the custom class to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/customClasses/{custom_class}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.CustomClass custom_class = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,9 +164,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -346,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -385,12 +389,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -414,12 +420,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clearPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -440,9 +448,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder clearUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -547,12 +557,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,12 +586,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet.Builder getPhraseSetBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -600,12 +614,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -626,9 +642,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -650,9 +668,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask.Builder getUpdateMaskBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -673,9 +693,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -696,12 +718,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,9 +747,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -801,12 +827,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -838,6 +866,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -849,6 +878,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -897,12 +927,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -926,12 +958,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder mergePhraseSet(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -942,12 +976,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -979,12 +1015,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1008,9 +1046,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder mergeUpdateMask(FieldMask value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1021,12 +1061,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1058,6 +1100,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1069,6 +1112,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1092,12 +1136,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setPhraseSet(PhraseSet value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1108,12 +1154,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.html">PhraseSet</a></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1135,12 +1183,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setPhraseSet(PhraseSet.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1151,12 +1201,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html">PhraseSet.Builder</a></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1188,6 +1240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1204,6 +1257,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1237,12 +1291,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1266,9 +1322,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setUpdateMask(FieldMask value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1279,12 +1337,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1306,9 +1366,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UpdatePhraseSetRequest.Builder setUpdateMask(FieldMask.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1319,12 +1381,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.FieldMask.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
@@ -325,12 +325,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -436,12 +438,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,12 +467,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -533,9 +539,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -557,9 +565,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -580,12 +590,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -607,9 +619,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -727,12 +741,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html">UpdatePhraseSetRequest</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -784,12 +800,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -823,12 +841,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -862,12 +882,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -914,6 +936,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -925,6 +948,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -971,12 +995,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1023,6 +1049,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1034,6 +1061,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1080,12 +1108,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1132,6 +1162,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1143,6 +1174,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1189,12 +1221,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1241,6 +1275,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1252,6 +1287,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1298,12 +1334,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1350,6 +1388,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1361,6 +1400,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1407,12 +1447,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1459,6 +1501,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1470,6 +1513,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1556,12 +1600,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
@@ -27,12 +27,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSet getPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -54,12 +56,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract PhraseSetOrBuilder getPhraseSetOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -80,9 +84,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract FieldMask getUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -104,9 +110,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract FieldMaskOrBuilder getUpdateMaskOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,12 +135,14 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasPhraseSet()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Required. The phrase set to update.
  The phrase set&#39;s `name` field is used to identify the set to be
  updated. Format:
  {api_version}/projects/{project}/locations/{location}/phraseSets/{phrase_set}
 </code></pre><p><code>.google.cloud.speech.v1p1beta1.PhraseSet phrase_set = 1 [(.google.api.field_behavior) = REQUIRED];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -154,9 +164,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasUpdateMask()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The list of fields to be updated.
 </code></pre><p><code>.google.protobuf.FieldMask update_mask = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
@@ -240,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -251,6 +252,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -336,6 +338,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -345,6 +348,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -366,6 +370,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -374,6 +379,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -404,12 +410,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -443,12 +451,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.OneofDescriptor</span></td>
         <td><span class="parametername">oneof</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -472,6 +482,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -479,6 +490,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -500,6 +512,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -508,6 +521,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -528,9 +542,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder clearWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -574,6 +590,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -583,6 +600,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -666,6 +684,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -674,6 +693,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -695,6 +715,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getEndTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -703,6 +724,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -723,6 +745,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -731,6 +754,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -751,6 +775,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -758,6 +783,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -779,6 +805,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -787,6 +814,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -808,6 +836,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration.Builder getStartTimeBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -816,6 +845,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -836,6 +866,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -844,6 +875,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -864,9 +896,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -888,9 +922,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -912,6 +948,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -920,6 +957,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -941,6 +979,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -949,6 +988,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1014,6 +1054,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1022,6 +1063,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1032,12 +1074,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1069,12 +1113,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1106,6 +1152,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1117,6 +1164,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1165,12 +1213,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Message</span></td>
         <td><span class="parametername">other</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1194,6 +1244,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder mergeStartTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1202,6 +1253,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1212,12 +1264,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1249,12 +1303,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1278,6 +1334,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setConfidence(float value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -1287,6 +1344,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1297,6 +1355,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">float</span></td>
         <td><span class="parametername">value</span></td>
@@ -1304,6 +1363,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1326,6 +1386,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setEndTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1334,6 +1395,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1344,12 +1406,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1371,6 +1435,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setEndTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1379,6 +1444,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1389,12 +1455,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1426,6 +1494,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1437,6 +1506,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1470,6 +1540,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Descriptors.FieldDescriptor</span></td>
         <td><span class="parametername">field</span></td>
@@ -1486,6 +1557,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1509,6 +1581,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setSpeakerTag(int value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -1516,6 +1589,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1526,6 +1600,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">int</span></td>
         <td><span class="parametername">value</span></td>
@@ -1533,6 +1608,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1555,6 +1631,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setStartTime(Duration value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1563,6 +1640,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1573,12 +1651,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration</span></td>
         <td><span class="parametername">value</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1600,6 +1680,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setStartTime(Duration.Builder builderForValue)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -1608,6 +1689,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1618,12 +1700,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.Duration.Builder</span></td>
         <td><span class="parametername">builderForValue</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1655,12 +1739,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.UnknownFieldSet</span></td>
         <td><span class="parametername">unknownFields</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1684,9 +1770,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setWord(String value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1697,6 +1785,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.String</span></td>
         <td><span class="parametername">value</span></td>
@@ -1704,6 +1793,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1726,9 +1816,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public WordInfo.Builder setWordBytes(ByteString value)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -1739,6 +1831,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">value</span></td>
@@ -1746,6 +1839,7 @@
 </td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
@@ -382,12 +382,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.lang.Object</span></td>
         <td><span class="parametername">obj</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -411,6 +413,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -420,6 +423,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -501,6 +505,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -509,6 +514,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -530,6 +536,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -538,6 +545,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -602,6 +610,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -609,6 +618,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -630,6 +640,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -638,6 +649,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -659,6 +671,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -667,6 +680,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -709,9 +723,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -733,9 +749,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -757,6 +775,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -765,6 +784,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -786,6 +806,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -794,6 +815,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -911,12 +933,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfo.html">WordInfo</a></td>
         <td><span class="parametername">prototype</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -968,12 +992,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.BuilderParent</span></td>
         <td><span class="parametername">parent</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1007,12 +1033,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.GeneratedMessageV3.UnusedPrivateParameter</span></td>
         <td><span class="parametername">unused</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1046,12 +1074,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1098,6 +1128,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1109,6 +1140,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1155,12 +1187,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1207,6 +1241,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">byte</span>[]</td>
         <td><span class="parametername">data</span></td>
@@ -1218,6 +1253,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1264,12 +1300,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1316,6 +1354,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.ByteString</span></td>
         <td><span class="parametername">data</span></td>
@@ -1327,6 +1366,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1373,12 +1413,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1425,6 +1467,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedInputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1436,6 +1479,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1482,12 +1526,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1534,6 +1580,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.io.InputStream</span></td>
         <td><span class="parametername">input</span></td>
@@ -1545,6 +1592,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1591,12 +1639,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1643,6 +1693,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">java.nio.ByteBuffer</span></td>
         <td><span class="parametername">data</span></td>
@@ -1654,6 +1705,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -1740,12 +1792,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.protobuf.CodedOutputStream</span></td>
         <td><span class="parametername">output</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Overrides</strong>
   <div><span class="xref">com.google.protobuf.GeneratedMessageV3.writeTo(com.google.protobuf.CodedOutputStream)</span></div>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
@@ -27,6 +27,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract float getConfidence()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The confidence estimate between 0.0 and 1.0. A higher number
  indicates an estimated greater likelihood that the recognized words are
  correct. This field is set only for the top alternative of a non-streaming
@@ -36,6 +37,7 @@
  The default of 0.0 is a sentinel value indicating `confidence` was not set.
 </code></pre><p><code>float confidence = 4;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -57,6 +59,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -65,6 +68,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -86,6 +90,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getEndTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -94,6 +99,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -114,6 +120,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract int getSpeakerTag()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Output only. A distinct integer value is assigned for every speaker within
  the audio. This field specifies which one of those speakers was detected to
  have spoken this word. Value ranges from &#39;1&#39; to diarization_speaker_count.
@@ -121,6 +128,7 @@
  top alternative.
 </code></pre><p><code>int32 speaker_tag = 5 [(.google.api.field_behavior) = OUTPUT_ONLY];</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -142,6 +150,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract Duration getStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -150,6 +159,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -171,6 +181,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract DurationOrBuilder getStartTimeOrBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -179,6 +190,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -199,9 +211,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract String getWord()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,9 +237,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract ByteString getWordBytes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>The word corresponding to this set of information.
 </code></pre><p><code>string word = 3;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -247,6 +263,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasEndTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the end of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -255,6 +272,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration end_time = 2;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -276,6 +294,7 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public abstract boolean hasStartTime()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><pre><code>Time offset relative to the beginning of the audio,
  and corresponding to the start of the spoken word.
  This field is only set if `enable_word_time_offsets=true` and only
@@ -284,6 +303,7 @@
  vary.
 </code></pre><p><code>.google.protobuf.Duration start_time = 1;</code></p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
@@ -157,12 +157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_" data-uid="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings)" class="notranslate">Builder(AdaptationStubSettings settings)</h3>
@@ -179,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html">AdaptationStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -193,9 +197,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStubSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +212,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,8 +293,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,8 +317,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to createPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -329,8 +341,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deleteCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,8 +365,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to deletePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -373,8 +389,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -395,8 +413,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to getPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -417,8 +437,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings.Builder&lt;ListCustomClassesRequest,ListCustomClassesResponse,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listCustomClasses.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -439,8 +461,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings.Builder&lt;ListPhraseSetRequest,ListPhraseSetResponse,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to listPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -481,8 +505,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updateCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -503,8 +529,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to updatePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html">AdaptationStubSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -146,8 +148,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;CreateCustomClassRequest,CustomClass&gt; createCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -168,8 +172,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;CreatePhraseSetRequest,PhraseSet&gt; createPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to createPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,8 +251,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -267,8 +275,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -289,8 +299,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,8 +343,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;DeleteCustomClassRequest,Empty&gt; deleteCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deleteCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,8 +367,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;DeletePhraseSetRequest,Empty&gt; deletePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to deletePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,8 +391,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;GetCustomClassRequest,CustomClass&gt; getCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,8 +415,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -419,8 +439,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -441,8 +463,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;GetPhraseSetRequest,PhraseSet&gt; getPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to getPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -463,8 +487,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings&lt;ListCustomClassesRequest,ListCustomClassesResponse,AdaptationClient.ListCustomClassesPagedResponse&gt; listCustomClassesSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listCustomClasses.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -485,8 +511,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public PagedCallSettings&lt;ListPhraseSetRequest,ListPhraseSetResponse,AdaptationClient.ListPhraseSetPagedResponse&gt; listPhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to listPhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -507,8 +535,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationStubSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -529,8 +559,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static AdaptationStubSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -541,12 +573,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -568,8 +602,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public AdaptationStubSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -592,8 +628,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;UpdateCustomClassRequest,CustomClass&gt; updateCustomClassSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updateCustomClass.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -614,8 +652,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;UpdatePhraseSetRequest,PhraseSet&gt; updatePhraseSetSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to updatePhraseSet.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
@@ -88,6 +88,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">com.google.longrunning.Operation</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -109,6 +110,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -140,6 +142,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -156,6 +159,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -187,6 +191,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -203,6 +208,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -234,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -250,6 +257,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -281,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -297,6 +306,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -328,6 +338,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -344,6 +355,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,6 +387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -391,6 +404,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
@@ -107,8 +107,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcAdaptationStub(AdaptationStubSettings settings, ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcAdaptationStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -119,6 +121,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html">AdaptationStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -130,14 +133,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_GrpcAdaptationStub_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.GrpcAdaptationStub*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcAdaptationStub_GrpcAdaptationStub_com_google_cloud_speech_v1p1beta1_stub_AdaptationStubSettings_com_google_api_gax_rpc_ClientContext_com_google_api_gax_grpc_GrpcStubCallableFactory_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.GrpcAdaptationStub(com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings,com.google.api.gax.rpc.ClientContext,com.google.api.gax.grpc.GrpcStubCallableFactory)" class="notranslate">GrpcAdaptationStub(AdaptationStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcAdaptationStub(AdaptationStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcAdaptationStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -148,6 +154,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html">AdaptationStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -164,6 +171,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -182,6 +190,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -193,6 +202,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -246,12 +256,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -298,6 +310,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
@@ -309,6 +322,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -355,12 +369,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html">AdaptationStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
@@ -88,6 +88,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">com.google.longrunning.Operation</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -109,6 +110,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -140,6 +142,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -156,6 +159,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -187,6 +191,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -203,6 +208,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -234,6 +240,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -250,6 +257,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -281,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -297,6 +306,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -328,6 +338,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -344,6 +355,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -375,6 +387,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.grpc.GrpcCallSettings</span>&lt;<span class="xref">RequestT</span>,<span class="xref">ResponseT</span>&gt;</td>
         <td><span class="parametername">grpcCallSettings</span></td>
@@ -391,6 +404,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
@@ -86,8 +86,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -98,6 +100,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -109,14 +112,17 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_GrpcSpeechStub_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.GrpcSpeechStub*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_GrpcSpeechStub_GrpcSpeechStub_com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_com_google_api_gax_rpc_ClientContext_com_google_api_gax_grpc_GrpcStubCallableFactory_" data-uid="com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.GrpcSpeechStub(com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings,com.google.api.gax.rpc.ClientContext,com.google.api.gax.grpc.GrpcStubCallableFactory)" class="notranslate">GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</h3>
   <div class="codewrapper">
     <pre><code class="prettyprint">protected GrpcSpeechStub(SpeechStubSettings settings, ClientContext clientContext, GrpcStubCallableFactory callableFactory)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Constructs an instance of GrpcSpeechStub, using the given settings. This is protected so that it is easy to make a subclass, but otherwise, the static factory methods should be preferred.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameters</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -127,6 +133,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
@@ -143,6 +150,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -161,6 +169,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">long</span></td>
         <td><span class="parametername">duration</span></td>
@@ -172,6 +181,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -225,12 +235,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -277,6 +289,7 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
@@ -288,6 +301,7 @@
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -334,12 +348,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html
@@ -157,12 +157,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <a id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_Builder_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.Builder*"></a>
   <h3 id="com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_Builder_Builder_com_google_cloud_speech_v1p1beta1_stub_SpeechStubSettings_" data-uid="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.Builder(com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings)" class="notranslate">Builder(SpeechStubSettings settings)</h3>
@@ -179,12 +181,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html">SpeechStubSettings</a></td>
         <td><span class="parametername">settings</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -193,9 +197,11 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder applyToAllUnaryMethods(ApiFunction&lt;UnaryCallSettings.Builder&lt;?,?&gt;,Void&gt; settingsUpdater)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Applies the given settings updater function to all of the unary API methods in this service.</p>
 <p>Note: This method does not support applying settings to streaming methods.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -206,12 +212,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.core.ApiFunction</span>&lt;<span class="xref">com.google.api.gax.rpc.UnaryCallSettings.Builder</span>&lt;<span class="xref">?</span>,<span class="xref">?</span>&gt;,<span class="xref">java.lang.Void</span>&gt;</td>
         <td><span class="parametername">settingsUpdater</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -285,8 +293,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings.Builder&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -307,8 +317,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -329,8 +341,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings.Builder&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -351,8 +365,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings.Builder&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the builder for the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
@@ -132,12 +132,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><a class="xref" href="com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html">SpeechStubSettings.Builder</a></td>
         <td><span class="parametername">settingsBuilder</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <h2 id="methods">Methods
   </h2>
@@ -201,8 +203,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static GoogleCredentialsProvider.Builder defaultCredentialsProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default credentials for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -223,8 +227,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingExecutorProvider.Builder defaultExecutorProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ExecutorProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -245,8 +251,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static InstantiatingGrpcChannelProvider.Builder defaultGrpcTransportProviderBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder for the default ChannelProvider for this service.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -287,8 +295,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static String getDefaultEndpoint()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service endpoint.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -309,8 +319,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static List&lt;String&gt; getDefaultServiceScopes()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the default service scopes.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -331,8 +343,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public OperationCallSettings&lt;LongRunningRecognizeRequest,LongRunningRecognizeResponse,LongRunningRecognizeMetadata&gt; longRunningRecognizeOperationSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -353,8 +367,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;LongRunningRecognizeRequest,Operation&gt; longRunningRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to longRunningRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -375,8 +391,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechStubSettings.Builder newBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -397,8 +415,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public static SpeechStubSettings.Builder newBuilder(ClientContext clientContext)</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a new builder for this class.</p>
 </div>
+  {% endverbatim %}
   <strong>Parameter</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -409,12 +429,14 @@
       </tr>
     </thead>
     <tbody>
+    {% verbatim %}
       <tr>
         <td><span class="xref">com.google.api.gax.rpc.ClientContext</span></td>
         <td><span class="parametername">clientContext</span></td>
         <td></td>
       </tr>
     </tbody>
+    {% endverbatim %}
   </table>
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
@@ -436,8 +458,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public UnaryCallSettings&lt;RecognizeRequest,RecognizeResponse&gt; recognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to recognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -458,8 +482,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public StreamingCallSettings&lt;StreamingRecognizeRequest,StreamingRecognizeResponse&gt; streamingRecognizeSettings()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns the object with the settings used for calls to streamingRecognize.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>
@@ -480,8 +506,10 @@
   <div class="codewrapper">
     <pre><code class="prettyprint">public SpeechStubSettings.Builder toBuilder()</code></pre>
   </div>
+  {% verbatim %}
   <div class="markdown level1 summary"><p>Returns a builder containing all the values of this settings class.</p>
 </div>
+  {% endverbatim %}
   <strong>Returns</strong>
   <table class="table table-bordered table-striped table-condensed">
     <thead>

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -25,7 +25,9 @@
 </div>
 {{/syntax.content.0}}
 {{#summary}}
+{% verbatim %}
 <div class="markdown level1 summary">{{{summary}}}</div>
+{% endverbatim %}
 {{/summary}}
 {{#conceptual}}
 <div class="markdown level1 conceptual">{{{conceptual}}}</div>
@@ -42,6 +44,7 @@
     </tr>
   </thead>
   <tbody>
+  {% verbatim %}
 {{/parameters.0}}
 {{#parameters}}
     <tr>
@@ -52,6 +55,7 @@
 {{/parameters}}
 {{#parameters.0}}
   </tbody>
+  {% endverbatim %}
 </table>
 {{/parameters.0}}
 {{#return}}


### PR DESCRIPTION
The first commit has the actual template changes. The second commit updates the goldens.

Here is one example line this "fixes": https://github.com/googleapis/doc-templates/compare/verbatim?expand=1#diff-1e222f0de082f7185a28cf1465a8fc65c447998d1b679d5b4b5c43ec05555fe0R251