### PR TITLE
tests: add java-xref golden

### DIFF
--- a/testdata/goldens/java-xref/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.html
+++ b/testdata/goldens/java-xref/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.html
@@ -1,0 +1,32 @@
+﻿<!DOCTYPE html>
+<html devsite="">
+  <head>
+    <meta name="project_path" value="/java/_project.yaml">
+    <meta name="book_path" value="/java/_book.yaml">
+  </head>
+  <body>
+    <div>
+      <article data-uid="com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder">
+<h1 class="page-title">Class StreamingTranslateSpeechRequest.Builder
+</h1>
+  
+  
+  {% verbatim %}
+  <div class="codewrapper">
+    <pre><code class="prettyprint">public static final class StreamingTranslateSpeechRequest.Builder extends GeneratedMessageV3.Builder&lt;StreamingTranslateSpeechRequest.Builder&gt; implements StreamingTranslateSpeechRequestOrBuilder</code></pre>
+  </div>
+  <div class="markdown level0 summary"><p>Testing xrefs</p>
+</div>
+  <div class="inheritance">
+    <h2>Inheritance</h2>
+    <span><span class="xref">java.lang.Object</span></span> <span> &gt; </span>
+    <span><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.AbstractMessageLite.Builder.html">AbstractMessageLite.Builder&lt;MessageType,BuilderType&gt;</a></span> <span> &gt; </span>
+    <span><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.AbstractMessage.Builder.html">AbstractMessage.Builder&lt;BuilderType&gt;</a></span> <span> &gt; </span>
+    <span><span class="xref">com.google.protobuf.GeneratedMessageV3.Builder</span></span> <span> &gt; </span>
+    <span class="xref">StreamingTranslateSpeechRequest.Builder</span>
+  </div>
+  {% endverbatim %}
+</article>
+    </div>
+  </body>
+</html>

--- a/testdata/goldens/java-xref/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.html
+++ b/testdata/goldens/java-xref/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.html
@@ -5,13 +5,13 @@
     <meta name="book_path" value="/java/_book.yaml">
   </head>
   <body>
+    {% verbatim %}
     <div>
       <article data-uid="com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder">
 <h1 class="page-title">Class StreamingTranslateSpeechRequest.Builder
 </h1>
   
   
-  {% verbatim %}
   <div class="codewrapper">
     <pre><code class="prettyprint">public static final class StreamingTranslateSpeechRequest.Builder extends GeneratedMessageV3.Builder&lt;StreamingTranslateSpeechRequest.Builder&gt; implements StreamingTranslateSpeechRequestOrBuilder</code></pre>
   </div>
@@ -25,8 +25,8 @@
     <span><span class="xref">com.google.protobuf.GeneratedMessageV3.Builder</span></span> <span> &gt; </span>
     <span class="xref">StreamingTranslateSpeechRequest.Builder</span>
   </div>
-  {% endverbatim %}
 </article>
     </div>
+    {% endverbatim %}
   </body>
 </html>

--- a/testdata/goldens/java-xref/toc.yaml
+++ b/testdata/goldens/java-xref/toc.yaml
@@ -1,0 +1,6 @@
+
+toc:
+- title: google-cloud-mediatranslation
+  section:
+  - title: StreamingTranslateSpeechRequest.Builder
+    path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.html

--- a/testdata/java-xref/README.md
+++ b/testdata/java-xref/README.md
@@ -1,0 +1,1 @@
+Testing that Java xrefs work, because sometimes they don't.

--- a/testdata/java-xref/docfx.json
+++ b/testdata/java-xref/docfx.json
@@ -1,0 +1,30 @@
+{
+  "license": "See LICENSE file at root of repo.",
+  "build": {
+    "content": [
+      {
+        "files": ["**/*.yml", "**/*.md"],
+        "src": "obj/api",
+        "dest": "api"
+      }
+    ],
+    "globalMetadata": {
+      "_appTitle": "google-cloud-mediatranslation",
+      "_disableContribution": true,
+      "_appFooter": " ",
+      "_disableNavbar": true,
+      "_disableBreadcrumb": true,
+      "_enableSearch": false,
+      "_disableToc": true,
+      "_disableSideFilter": true,
+      "_disableAffix": true,
+      "_disableFooter": true,
+      "_rootPath": "/java/docs/reference/cloud.google.com/java/latest",
+      "_projectPath": "/java/"
+    },
+    "dest": "site",
+    "xref": [
+      "xrefs/xref.yml"
+    ]
+  }
+}

--- a/testdata/java-xref/obj/api/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.yml
+++ b/testdata/java-xref/obj/api/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.yml
@@ -1,0 +1,20 @@
+### YamlMime:ManagedReference
+items:
+- uid: "com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder"
+  id: "Builder"
+  parent: "com.google.cloud.mediatranslation.v1beta1"
+  langs:
+  - "java"
+  name: "StreamingTranslateSpeechRequest.Builder"
+  nameWithType: "StreamingTranslateSpeechRequest.Builder"
+  fullName: "com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder"
+  type: "Class"
+  package: "com.google.cloud.mediatranslation.v1beta1"
+  summary: "Testing xrefs"
+  syntax:
+    content: "public static final class StreamingTranslateSpeechRequest.Builder extends GeneratedMessageV3.Builder<StreamingTranslateSpeechRequest.Builder> implements StreamingTranslateSpeechRequestOrBuilder"
+  inheritance:
+  - "java.lang.Object"
+  - "com.google.protobuf.AbstractMessageLite.Builder"
+  - "com.google.protobuf.AbstractMessage.Builder"
+  - "com.google.protobuf.GeneratedMessageV3.Builder"

--- a/testdata/java-xref/obj/api/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.yml
+++ b/testdata/java-xref/obj/api/com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder.yml
@@ -18,3 +18,8 @@ items:
   - "com.google.protobuf.AbstractMessageLite.Builder"
   - "com.google.protobuf.AbstractMessage.Builder"
   - "com.google.protobuf.GeneratedMessageV3.Builder"
+references:
+- uid: "com.google.protobuf.GeneratedMessageV3.Builder"
+  name: "GeneratedMessageV3.Builder"
+  nameWithType: "GeneratedMessageV3.Builder"
+  fullName: "com.google.protobuf.GeneratedMessageV3.Builder"

--- a/testdata/java-xref/obj/api/toc.yml
+++ b/testdata/java-xref/obj/api/toc.yml
@@ -1,0 +1,5 @@
+### YamlMime:TableOfContent
+- name: "google-cloud-mediatranslation"
+  items:
+  - uid: "com.google.cloud.mediatranslation.v1beta1.StreamingTranslateSpeechRequest.Builder"
+    name: "StreamingTranslateSpeechRequest.Builder"

--- a/testdata/java-xref/xrefs/xref.yml
+++ b/testdata/java-xref/xrefs/xref.yml
@@ -1,0 +1,19 @@
+### YamlMime:XRefMap
+baseUrl: https://cloud.google.com/java/docs/reference/protobuf/latest/
+sorted: true
+references:
+- uid: com.google.protobuf.AbstractMessage.Builder
+  name: AbstractMessage.Builder<BuilderType>
+  href: com.google.protobuf.AbstractMessage.Builder.html
+  fullName: com.google.protobuf.AbstractMessage.Builder<BuilderType>
+  nameWithType: AbstractMessage.Builder<BuilderType>
+- uid: com.google.protobuf.AbstractMessageLite.Builder
+  name: AbstractMessageLite.Builder<MessageType,BuilderType>
+  href: com.google.protobuf.AbstractMessageLite.Builder.html
+  fullName: com.google.protobuf.AbstractMessageLite.Builder<MessageType,BuilderType>
+  nameWithType: AbstractMessageLite.Builder<MessageType,BuilderType>
+- uid: com.google.protobuf.GeneratedMessageV3.Builder
+  name: GeneratedMessageV3.Builder<BuilderType>
+  href: com.google.protobuf.GeneratedMessageV3.Builder.html
+  fullName: com.google.protobuf.GeneratedMessageV3.Builder<BuilderType>
+  nameWithType: GeneratedMessageV3.Builder<BuilderType>

--- a/tests/test_goldens.py
+++ b/tests/test_goldens.py
@@ -23,7 +23,17 @@ from docuploader import shell
 import pytest
 
 
-@pytest.mark.parametrize("test_dir", ["python-small", "go", "dotnet", "nodejs", "java"])
+@pytest.mark.parametrize(
+    "test_dir",
+    [
+        "python-small",
+        "go",
+        "dotnet",
+        "nodejs",
+        "java",
+        "java-xref",
+    ],
+)
 def test_goldens(update_goldens, test_dir):
     build_dir = Path("testdata") / test_dir
     golden_dir = Path("testdata/goldens") / test_dir


### PR DESCRIPTION
This shows the issue Java is having with xrefs. There is one xref in
particular that is not working, even though other xrefs from the same
xrefmap are working.

If you search `com.google.protobuf.GeneratedMessageV3.Builder` in
the diff for this change, you can see the xref is not working.

Because the UID is in the `references` section of the `yml` file, the xref
doesn't look in the xrefmap file for the URL. :monocle_face: 