### PR TITLE
chore: remove duplicate implements

### DIFF
--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
@@ -124,22 +124,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
@@ -78,22 +78,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
@@ -131,22 +131,6 @@ If it&apos;s not finished until then, you will get a  DEADLINE_EXCEEDED error.</
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
@@ -170,22 +170,6 @@ fully explored to answer the query.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
@@ -150,22 +150,6 @@ enabled.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Asset.html
@@ -402,22 +402,6 @@ create/update/delete operation is performed.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
@@ -202,22 +202,6 @@ window overlap with read_time_window.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
@@ -102,22 +102,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.BigQueryDestination.html
@@ -235,22 +235,6 @@ will be created.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ConditionEvaluation.html
@@ -102,22 +102,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.CreateFeedRequest.html
@@ -155,22 +155,6 @@ should be created in. It can only be an organization number (such as
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.DeleteFeedRequest.html
@@ -125,22 +125,6 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsRequest.html
@@ -235,22 +235,6 @@ running the same query may get different results.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ExportAssetsResponse.html
@@ -152,22 +152,6 @@ once it exceeds a single Google Cloud Storage object limit.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Feed.html
@@ -267,22 +267,6 @@ project/folder/organization.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedName.html
@@ -958,13 +958,6 @@ Or may be in any format if <code data-dev-comment-type="paramref" class="paramre
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Api.Gax.IResourceName</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.FeedOutputConfig.html
@@ -122,22 +122,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsDestination.html
@@ -159,22 +159,6 @@ already exists.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GcsOutputResult.html
@@ -103,22 +103,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.GetFeedRequest.html
@@ -127,22 +127,6 @@ organizations/organization_number/feeds/feed_id</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
@@ -190,22 +190,6 @@ if BigQuery is able to complete the job successfully. Details are at
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
@@ -109,22 +109,6 @@ overwritten with the analysis result.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
@@ -144,22 +144,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
@@ -128,22 +128,6 @@ less than 10.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
@@ -124,22 +124,6 @@ INVALID_ARGUMENT error will be returned.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
@@ -113,22 +113,6 @@ You must give a specific identity.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
@@ -261,22 +261,6 @@ Default is false.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
@@ -106,22 +106,6 @@ types</a>.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
@@ -220,22 +220,6 @@ folder number (such as &quot;folders/123&quot;), a project ID (such as
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
@@ -166,22 +166,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
@@ -196,22 +196,6 @@ present only if the output_resource_edges option is enabled in request.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
@@ -126,22 +126,6 @@ name for a resource node or an email of an identity.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
@@ -136,22 +136,6 @@ as:</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
@@ -135,22 +135,6 @@ presented:</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
@@ -125,22 +125,6 @@ name</a></p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
@@ -196,22 +196,6 @@ potentially match identity selector specified in the request.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
@@ -132,22 +132,6 @@ in time;</li>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
@@ -102,22 +102,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
@@ -108,22 +108,6 @@ map is populated only for requests with permission queries.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.IamPolicySearchResult.html
@@ -199,22 +199,6 @@ for more information.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsRequest.html
@@ -261,25 +261,6 @@ running the same query may get different results.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageRequest</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListAssetsResponse.html
@@ -197,31 +197,6 @@ remaining results.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageResponse&lt;TResource&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.Generic.IEnumerable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.IEnumerable</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsRequest.html
@@ -104,22 +104,6 @@ listed. It can only be using project/folder/organization number (such as
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ListFeedsResponse.html
@@ -100,22 +100,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputConfig.html
@@ -145,22 +145,6 @@ proto as columns in BigQuery.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.OutputResult.html
@@ -122,22 +122,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PartitionSpec.html
@@ -102,22 +102,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.PubsubDestination.html
@@ -103,22 +103,6 @@ Example: <code>projects/PROJECT_ID/topics/TOPIC_ID</code>.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.Resource.html
@@ -255,22 +255,6 @@ URL returns the resource itself. Example:
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.ResourceSearchResult.html
@@ -609,22 +609,6 @@ contains it.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
@@ -223,25 +223,6 @@ permission on the desired scope.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageRequest</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
@@ -176,31 +176,6 @@ as the associated resource is returned along with the policy.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageResponse&lt;TResource&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.Generic.IEnumerable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.IEnumerable</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
@@ -301,25 +301,6 @@ permission on the desired scope.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageRequest</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
@@ -176,31 +176,6 @@ standard metadata information.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Api.Gax.Grpc.IPageResponse&lt;TResource&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.Generic.IEnumerable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.Collections.IEnumerable</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TemporalAsset.html
@@ -192,22 +192,6 @@ Currently this is only set for responses in Real-Time Feed.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.TimeWindow.html
@@ -125,22 +125,6 @@ timestamp is used instead.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
+++ b/testdata/goldens/dotnet/Google.Cloud.Asset.V1.UpdateFeedRequest.html
@@ -130,22 +130,6 @@ are immutable or only set by the server.</p>
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">System.IEquatable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IDeepCloneable&lt;T&gt;</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IBufferMessage</span>
-  </div>
-  <div>
-      <span class="xref">Google.Protobuf.IMessage</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
@@ -1411,10 +1411,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
@@ -1616,10 +1616,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
@@ -188,10 +188,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
@@ -1325,10 +1325,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
@@ -1574,10 +1574,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
@@ -166,10 +166,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
@@ -1502,10 +1502,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
@@ -1567,10 +1567,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
@@ -175,10 +175,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
@@ -1223,10 +1223,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudio.html
@@ -1593,10 +1593,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
@@ -183,10 +183,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
@@ -3587,10 +3587,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfig.html
@@ -2443,10 +2443,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
@@ -807,10 +807,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
@@ -2063,10 +2063,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadata.html
@@ -1917,10 +1917,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
@@ -396,10 +396,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
@@ -1324,10 +1324,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequest.html
@@ -1573,10 +1573,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
@@ -166,10 +166,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
@@ -1500,10 +1500,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponse.html
@@ -1565,10 +1565,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
@@ -175,10 +175,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
@@ -1220,10 +1220,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
@@ -1568,10 +1568,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
@@ -123,10 +123,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechClient.html
@@ -779,10 +779,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.Builder.html
@@ -1263,10 +1263,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContext.html
@@ -1582,10 +1582,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
@@ -193,10 +193,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
@@ -195,10 +195,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">io.grpc.BindableService</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
@@ -1780,10 +1780,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
@@ -1684,10 +1684,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
@@ -258,10 +258,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
@@ -1630,10 +1630,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResult.html
@@ -1618,10 +1618,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
@@ -211,10 +211,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
@@ -1304,10 +1304,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
@@ -1582,10 +1582,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
@@ -155,10 +155,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
@@ -2246,10 +2246,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResult.html
@@ -1877,10 +1877,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
@@ -393,10 +393,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
@@ -1281,10 +1281,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
@@ -1591,10 +1591,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
@@ -180,10 +180,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
@@ -1970,10 +1970,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
@@ -1768,10 +1768,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
@@ -307,10 +307,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.Builder.html
@@ -1654,10 +1654,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.WordInfoOrBuilder.html">WordInfoOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfo.html
@@ -1714,10 +1714,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1.WordInfoOrBuilder.html">WordInfoOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.WordInfoOrBuilder.html
@@ -269,10 +269,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
@@ -406,10 +406,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.grpc.GrpcStubCallableFactory.html">GrpcStubCallableFactory</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1.stub.SpeechStub.html
@@ -177,10 +177,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
@@ -1403,10 +1403,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html">AsyncRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
@@ -1572,10 +1572,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html">AsyncRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
@@ -183,10 +183,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
@@ -1320,10 +1320,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html">AsyncRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
@@ -1530,10 +1530,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html">AsyncRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
@@ -162,10 +162,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
@@ -1501,10 +1501,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html">AsyncRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
@@ -1527,10 +1527,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html">AsyncRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
@@ -175,10 +175,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
@@ -1151,10 +1151,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudio.html
@@ -1493,10 +1493,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
@@ -122,10 +122,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
@@ -1690,10 +1690,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfig.html
@@ -1716,10 +1716,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
@@ -271,10 +271,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
@@ -1202,10 +1202,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContext.html
@@ -1517,10 +1517,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
@@ -167,10 +167,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
@@ -195,10 +195,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">io.grpc.BindableService</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
@@ -1095,10 +1095,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
@@ -1464,10 +1464,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -96,10 +96,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
@@ -1498,10 +1498,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
@@ -1524,10 +1524,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
@@ -175,10 +175,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
@@ -1291,10 +1291,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
@@ -1538,10 +1538,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -150,10 +150,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
@@ -1695,10 +1695,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
@@ -1617,10 +1617,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
@@ -229,10 +229,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
@@ -1244,10 +1244,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
@@ -1518,10 +1518,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -146,10 +146,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
@@ -2061,10 +2061,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
@@ -1777,10 +1777,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -328,10 +328,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
@@ -1320,10 +1320,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html">SyncRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
@@ -1530,10 +1530,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html">SyncRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
@@ -162,10 +162,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
@@ -1500,10 +1500,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html">SyncRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
@@ -1526,10 +1526,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html">SyncRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
@@ -175,10 +175,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
@@ -2167,10 +2167,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
@@ -383,10 +383,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">io.grpc.BindableService</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
@@ -1416,10 +1416,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html">CreateCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
@@ -1624,10 +1624,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html">CreateCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
@@ -198,10 +198,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
@@ -1416,10 +1416,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html">CreatePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
@@ -1624,10 +1624,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html">CreatePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
@@ -198,10 +198,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
@@ -1799,10 +1799,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html">CustomClassOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
@@ -998,10 +998,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html">CustomClass.ClassItemOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
@@ -1457,10 +1457,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html">CustomClass.ClassItemOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
@@ -69,10 +69,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClass.html
@@ -1696,10 +1696,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html">CustomClassOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassName.html
@@ -551,10 +551,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">com.google.api.resourcenames.ResourceName</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
@@ -268,10 +268,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
@@ -1008,10 +1008,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html">DeleteCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
@@ -1461,10 +1461,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html">DeleteCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
@@ -73,10 +73,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
@@ -1008,10 +1008,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html">DeletePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
@@ -1461,10 +1461,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html">DeletePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
@@ -73,10 +73,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
@@ -1008,10 +1008,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html">GetCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
@@ -1461,10 +1461,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html">GetCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
@@ -73,10 +73,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
@@ -1008,10 +1008,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html">GetPhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
@@ -1461,10 +1461,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html">GetPhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
@@ -73,10 +73,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
@@ -1278,10 +1278,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html">ListCustomClassesRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
@@ -1580,10 +1580,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html">ListCustomClassesRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
@@ -154,10 +154,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
@@ -1641,10 +1641,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html">ListCustomClassesResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
@@ -1627,10 +1627,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html">ListCustomClassesResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
@@ -220,10 +220,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
@@ -1278,10 +1278,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html">ListPhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
@@ -1580,10 +1580,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html">ListPhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
@@ -154,10 +154,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
@@ -1641,10 +1641,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html">ListPhraseSetResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
@@ -1627,10 +1627,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html">ListPhraseSetResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
@@ -220,10 +220,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LocationName.html
@@ -521,10 +521,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">com.google.api.resourcenames.ResourceName</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
@@ -1809,10 +1809,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
@@ -1775,10 +1775,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html">LongRunningRecognizeMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
@@ -309,10 +309,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
@@ -1562,10 +1562,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
@@ -1664,10 +1664,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html">LongRunningRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
@@ -237,10 +237,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
@@ -2213,10 +2213,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
@@ -1837,10 +1837,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html">LongRunningRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
@@ -388,10 +388,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
@@ -1751,10 +1751,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html">PhraseSetOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
@@ -1132,10 +1132,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html">PhraseSet.PhraseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
@@ -1526,10 +1526,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html">PhraseSet.PhraseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
@@ -102,10 +102,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSet.html
@@ -1677,10 +1677,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html">PhraseSetOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
@@ -551,10 +551,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">com.google.api.resourcenames.ResourceName</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
@@ -250,10 +250,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
@@ -1223,10 +1223,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
@@ -1593,10 +1593,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html">RecognitionAudioOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
@@ -183,10 +183,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
@@ -5121,10 +5121,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
@@ -3083,10 +3083,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html">RecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
@@ -1314,10 +1314,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
@@ -2156,10 +2156,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
@@ -1961,10 +1961,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html">RecognitionMetadataOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
@@ -421,10 +421,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
@@ -1324,10 +1324,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
@@ -1573,10 +1573,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html">RecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
@@ -166,10 +166,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
@@ -1737,10 +1737,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
@@ -1655,10 +1655,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html">RecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
@@ -246,10 +246,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
@@ -1220,10 +1220,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
@@ -1568,10 +1568,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html">SpeakerDiarizationConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
@@ -123,10 +123,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
@@ -2538,10 +2538,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html">SpeechAdaptationOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
@@ -1902,10 +1902,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html">SpeechAdaptationOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
@@ -476,10 +476,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechClient.html
@@ -782,10 +782,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
@@ -1374,10 +1374,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContext.html
@@ -1632,10 +1632,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html">SpeechContextOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
@@ -224,10 +224,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
@@ -195,10 +195,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <span class="xref">io.grpc.BindableService</span>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
@@ -1780,10 +1780,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
@@ -1684,10 +1684,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html">SpeechRecognitionAlternativeOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
@@ -258,10 +258,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
@@ -1796,10 +1796,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
@@ -1689,10 +1689,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html">SpeechRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
@@ -263,10 +263,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
@@ -1328,10 +1328,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
@@ -1590,10 +1590,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html">StreamingRecognitionConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
@@ -163,10 +163,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
@@ -2246,10 +2246,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
@@ -1877,10 +1877,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html">StreamingRecognitionResultOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
@@ -393,10 +393,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
@@ -1281,10 +1281,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
@@ -1591,10 +1591,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html">StreamingRecognizeRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
@@ -180,10 +180,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
@@ -2215,10 +2215,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
@@ -1861,10 +1861,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html">StreamingRecognizeResponseOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
@@ -381,10 +381,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.Builder.html
@@ -1074,10 +1074,6 @@
   </table>
   <strong>Overrides</strong>
   <div><a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.GeneratedMessageV3.Builder.html#com_google_protobuf_GeneratedMessageV3_Builder_setUnknownFields_com_google_protobuf_UnknownFieldSet_">GeneratedMessageV3.Builder&lt;BuilderType&gt;.setUnknownFields(UnknownFieldSet unknownFields)</a></div>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.TranscriptOutputConfigOrBuilder.html">TranscriptOutputConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.html
@@ -1507,10 +1507,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.TranscriptOutputConfigOrBuilder.html">TranscriptOutputConfigOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfigOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfigOrBuilder.html
@@ -119,10 +119,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
@@ -1340,10 +1340,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html">UpdateCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
@@ -1579,10 +1579,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html">UpdateCustomClassRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
@@ -172,10 +172,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
@@ -1340,10 +1340,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html">UpdatePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
@@ -1579,10 +1579,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html">UpdatePhraseSetRequestOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
@@ -172,10 +172,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
@@ -1762,10 +1762,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html">WordInfoOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfo.html
@@ -1763,10 +1763,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html">WordInfoOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
@@ -299,10 +299,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/protobuf/latest/com.google.protobuf.MessageOrBuilder.html">MessageOrBuilder</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
@@ -317,10 +317,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
@@ -406,10 +406,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.grpc.GrpcStubCallableFactory.html">GrpcStubCallableFactory</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
@@ -406,10 +406,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.grpc.GrpcStubCallableFactory.html">GrpcStubCallableFactory</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
+++ b/testdata/goldens/java/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
@@ -177,10 +177,6 @@
       </tr>
     </tbody>
   </table>
-  <h2 id="implements">Implements</h2>
-  <div>
-      <a class="xref" href="https://cloud.google.com/java/docs/reference/gax/latest/com.google.api.gax.core.BackgroundResource.html">BackgroundResource</a>
-  </div>
 </article>
     </div>
     {% endverbatim %}

--- a/third_party/docfx/templates/devsite/partials/class.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.tmpl.partial
@@ -196,19 +196,6 @@
 {{/seealso.0}}
 {{/children}}
 {{/children}}
-{{#implements.0}}
-<h2 id="implements">{{__global.implements}}</h2>
-{{/implements.0}}
-{{#implements}}
-<div>
-  {{#definition}}
-    <xref uid="{{definition}}" altProperty="fullName" displayProperty="nameWithType"/>
-  {{/definition}}
-  {{^definition}}
-    <xref uid="{{uid}}" altProperty="fullName" displayProperty="nameWithType"/>
-  {{/definition}}
-</div>
-{{/implements}}
 {{#extensionMethods.0}}
 <h2 id="extensionmethods">{{__global.extensionMethod}}{{#extensionMethods.1}}s{{/extensionMethods.1}}</h2>
 {{/extensionMethods.0}}


### PR DESCRIPTION
Fixes #195003443

Removes the duplicate 'implements' section at the bottom. This is also impacting .NET. @jskeet is this desired behavior?