### PR TITLE
chore: update java goldens with package summary

### DIFF
--- a/testdata/goldens/java/toc.yaml
+++ b/testdata/goldens/java/toc.yaml
@@ -8,6 +8,8 @@ toc:
     path: /java/docs/reference/cloud.google.com/java/latest/history.md
   - title: com.google.cloud.speech.v1
     section:
+    - title: Package summary
+      path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.html
     - title: LongRunningRecognizeMetadata
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
     - title: LongRunningRecognizeMetadata.Builder
@@ -146,6 +148,8 @@ toc:
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.WordInfoOrBuilder.html
   - title: com.google.cloud.speech.v1.stub
     section:
+    - title: Package summary
+      path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.html
     - title: GrpcSpeechCallableFactory
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
     - title: GrpcSpeechStub
@@ -158,6 +162,8 @@ toc:
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
   - title: com.google.cloud.speech.v1beta1
     section:
+    - title: Package summary
+      path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.html
     - title: AsyncRecognizeMetadata
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
     - title: AsyncRecognizeMetadata.Builder
@@ -264,6 +270,8 @@ toc:
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
   - title: com.google.cloud.speech.v1p1beta1
     section:
+    - title: Package summary
+      path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.html
     - title: AdaptationClient
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
     - title: AdaptationClient.ListCustomClassesFixedSizeCollection
@@ -556,6 +564,8 @@ toc:
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
   - title: com.google.cloud.speech.v1p1beta1.stub
     section:
+    - title: Package summary
+      path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.html
     - title: AdaptationStub
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
     - title: AdaptationStubSettings

--- a/testdata/java/obj/api/toc.yml
+++ b/testdata/java/obj/api/toc.yml
@@ -8,6 +8,8 @@
   - uid: "com.google.cloud.speech.v1"
     name: "com.google.cloud.speech.v1"
     items:
+    - uid: "com.google.cloud.speech.v1"
+      name: "Package summary"
     - uid: "com.google.cloud.speech.v1.LongRunningRecognizeMetadata"
       name: "LongRunningRecognizeMetadata"
     - uid: "com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder"
@@ -147,6 +149,8 @@
   - uid: "com.google.cloud.speech.v1.stub"
     name: "com.google.cloud.speech.v1.stub"
     items:
+    - uid: "com.google.cloud.speech.v1.stub"
+      name: "Package summary"
     - uid: "com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory"
       name: "GrpcSpeechCallableFactory"
     - uid: "com.google.cloud.speech.v1.stub.GrpcSpeechStub"
@@ -160,6 +164,8 @@
   - uid: "com.google.cloud.speech.v1beta1"
     name: "com.google.cloud.speech.v1beta1"
     items:
+    - uid: "com.google.cloud.speech.v1beta1"
+      name: "Package summary"
     - uid: "com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata"
       name: "AsyncRecognizeMetadata"
     - uid: "com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder"
@@ -267,6 +273,8 @@
   - uid: "com.google.cloud.speech.v1p1beta1"
     name: "com.google.cloud.speech.v1p1beta1"
     items:
+    - uid: "com.google.cloud.speech.v1p1beta1"
+      name: "Package summary"
     - uid: "com.google.cloud.speech.v1p1beta1.AdaptationClient"
       name: "AdaptationClient"
     - uid: "com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection"
@@ -560,6 +568,8 @@
   - uid: "com.google.cloud.speech.v1p1beta1.stub"
     name: "com.google.cloud.speech.v1p1beta1.stub"
     items:
+    - uid: "com.google.cloud.speech.v1p1beta1.stub"
+      name: "Package summary"
     - uid: "com.google.cloud.speech.v1p1beta1.stub.AdaptationStub"
       name: "AdaptationStub"
     - uid: "com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings"


### PR DESCRIPTION
Update goldens to include output from updated doclet [change](https://github.com/googleapis/java-docfx-doclet/pull/53)

These package summary pages already exist but were not referenced in toc. Fixes b/194728230