### PR TITLE
feat: add status disclaimer to top of pages

### DIFF
--- a/testdata/go/obj/api/index.yml
+++ b/testdata/go/obj/api/index.yml
@@ -243,6 +243,7 @@ items:
   - cloud.google.com/go/storage.Writer.Write
   - cloud.google.com/go/storage.SignedURL
   alt_link: https://pkg.go.dev/cloud.google.com/go/storage
+  status: beta
 - uid: cloud.google.com/go/storage.DeleteAction,SetStorageClassAction
   name: DeleteAction, SetStorageClassAction
   id: DeleteAction,SetStorageClassAction

--- a/testdata/goldens/go/index.html
+++ b/testdata/goldens/go/index.html
@@ -11,6 +11,16 @@
 <h1 class="page-title">Package cloud.google.com/go/storage
 </h1>
   
+  <aside class="beta">
+    <p><strong>Beta<p>
+    <p>
+    This library is covered by the <a href="/terms/service-terms#1">Pre-GA Offerings Terms</a>
+    of the  Terms of Service. Pre-GA libraries might have limited support,
+    and changes to pre-GA libraries might not be compatible with other pre-GA versions.
+    For more information, see the
+    <a href="/products/#product-launch-stages">launch stage descriptions</a>.
+    </p>
+  </strong></aside>
   <aside class="note">
     <strong>Note:</strong> To get more information about this package, such as access to older versions, view <a href="https://pkg.go.dev/cloud.google.com/go/storage" class="external">this package on pkg.go.dev</a>.
   </aside>

--- a/third_party/docfx/templates/devsite/ManagedReference.common.js
+++ b/third_party/docfx/templates/devsite/ManagedReference.common.js
@@ -288,8 +288,27 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
     }
   }
 
-  // Set the status as a property so we can check it in the template.
   if (vm.status) {
+    // Set the status as a property so we can check it in the template.
     vm[vm.status] = true;
+    // Set status_title to use in any preview disclaimers as needed.
+    if (vm.status == "preview") {
+      vm.status_title = "Preview"
+    }
+    else if (vm.status == "private_preview") {
+      vm.status_title = "Private preview"
+    }
+    else if (vm.status == "experimental") {
+      vm.status_title = "Experimental"
+    }
+    else if (vm.status == "alpha") {
+      vm.status_title = "Alpha"
+    }
+    else if (vm.status == "beta") {
+      vm.status_title = "Beta"
+    }
+    else if (vm.status == "eap") {
+      vm.status_title = "Early access"
+    }
   }
 }

--- a/third_party/docfx/templates/devsite/UniversalReference.common.js
+++ b/third_party/docfx/templates/devsite/UniversalReference.common.js
@@ -132,9 +132,28 @@ function handleItem(vm, gitContribute, gitUrlPattern) {
     }
   }
 
-  // Set the status as a property so we can check it in the template.
   if (vm.status) {
+    // Set the status as a property so we can check it in the template.
     vm[vm.status] = true;
+    // Set status_title to use in any preview disclaimers as needed.
+    if (vm.status == "preview") {
+      vm.status_title = "Preview"
+    }
+    else if (vm.status == "private_preview") {
+      vm.status_title = "Private preview"
+    }
+    else if (vm.status == "experimental") {
+      vm.status_title = "Experimental"
+    }
+    else if (vm.status == "alpha") {
+      vm.status_title = "Alpha"
+    }
+    else if (vm.status == "beta") {
+      vm.status_title = "Beta"
+    }
+    else if (vm.status == "eap") {
+      vm.status_title = "Early access"
+    }
   }
 }
 

--- a/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/class.header.tmpl.partial
@@ -1,5 +1,6 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{>partials/disclaimer}}
 {{#syntax.content.0}}
 <div class="codewrapper">
   <pre class="prettyprint"><code>{{syntax.content.0.value}}</code></pre>

--- a/third_party/docfx/templates/devsite/partials/disclaimer.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/disclaimer.tmpl.partial
@@ -1,0 +1,12 @@
+{{#status_title}}
+<aside class="beta">
+  <p><strong>{{status_title}}</strong</p>
+  <p>
+  This library is covered by the <a href="/terms/service-terms#1">Pre-GA Offerings Terms</a>
+  of the {{gcp_name}} Terms of Service. Pre-GA libraries might have limited support,
+  and changes to pre-GA libraries might not be compatible with other pre-GA versions.
+  For more information, see the
+  <a href="/products/#product-launch-stages">launch stage descriptions</a>.
+  </p>
+</aside>
+{{/status_title}}

--- a/third_party/docfx/templates/devsite/partials/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/namespace.tmpl.partial
@@ -1,5 +1,6 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{>partials/disclaimer}}
 {{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
 {{/summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/class.header.tmpl.partial
@@ -1,5 +1,6 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{>partials/disclaimer}}
 {{#summary}}
 <div class="markdown level0 summary">{{{summary}}}</div>
 {{/summary}}

--- a/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/uref/namespace.tmpl.partial
@@ -1,5 +1,6 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
+{{>partials/disclaimer}}
 {{#alt_link}}
 <aside class="note">
   <strong>Note:</strong> To get more information about this package, such as access to older versions, view <a href="{{alt_link}}" class="external">this package on pkg.go.dev</a>.


### PR DESCRIPTION
I updated the Go test YAML to (incorrectly) call the package beta so the
goldens would show the new aside.

Note: there are no unnecessary whitespace changes in other output files.

See b/197007831.