### PR TITLE
fix: quote strings in TOCs

### DIFF
--- a/testdata/goldens/dotnet/toc.yaml
+++ b/testdata/goldens/dotnet/toc.yaml
@@ -1,188 +1,188 @@
 
 toc:
-- title: Google.Cloud.Asset.V1
+- title: 'Google.Cloud.Asset.V1'
   section:
-  - title: Overview
+  - title: 'Overview'
     section:
-    - title: Getting started
+    - title: 'Getting started'
       path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/index.html
-    - title: Version history
+    - title: 'Version history'
       path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/history.html
-  - title: All types
+  - title: 'All types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.html
-  - title: AnalyzeIamPolicyLongrunningRequest
+  - title: 'AnalyzeIamPolicyLongrunningRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningRequest.html
-  - title: AnalyzeIamPolicyLongrunningResponse
+  - title: 'AnalyzeIamPolicyLongrunningResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyLongrunningResponse.html
-  - title: AnalyzeIamPolicyRequest
+  - title: 'AnalyzeIamPolicyRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyRequest.html
-  - title: AnalyzeIamPolicyResponse
+  - title: 'AnalyzeIamPolicyResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.html
-  - title: AnalyzeIamPolicyResponse.Types
+  - title: 'AnalyzeIamPolicyResponse.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.html
-  - title: AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis
+  - title: 'AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AnalyzeIamPolicyResponse.Types.IamPolicyAnalysis.html
-  - title: Asset
+  - title: 'Asset'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.Asset.html
-  - title: Asset.AccessContextPolicyOneofCase
+  - title: 'Asset.AccessContextPolicyOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.Asset.AccessContextPolicyOneofCase.html
-  - title: AssetService
+  - title: 'AssetService'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetService.html
-  - title: AssetService.AssetServiceBase
+  - title: 'AssetService.AssetServiceBase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetService.AssetServiceBase.html
-  - title: AssetService.AssetServiceClient
+  - title: 'AssetService.AssetServiceClient'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetService.AssetServiceClient.html
-  - title: AssetServiceClient
+  - title: 'AssetServiceClient'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetServiceClient.html
-  - title: AssetServiceClientBuilder
+  - title: 'AssetServiceClientBuilder'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetServiceClientBuilder.html
-  - title: AssetServiceClientImpl
+  - title: 'AssetServiceClientImpl'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetServiceClientImpl.html
-  - title: AssetServiceSettings
+  - title: 'AssetServiceSettings'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.AssetServiceSettings.html
-  - title: BatchGetAssetsHistoryRequest
+  - title: 'BatchGetAssetsHistoryRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.BatchGetAssetsHistoryRequest.html
-  - title: BatchGetAssetsHistoryResponse
+  - title: 'BatchGetAssetsHistoryResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.BatchGetAssetsHistoryResponse.html
-  - title: BigQueryDestination
+  - title: 'BigQueryDestination'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.BigQueryDestination.html
-  - title: ConditionEvaluation
+  - title: 'ConditionEvaluation'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ConditionEvaluation.html
-  - title: ConditionEvaluation.Types
+  - title: 'ConditionEvaluation.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ConditionEvaluation.Types.html
-  - title: ConditionEvaluation.Types.EvaluationValue
+  - title: 'ConditionEvaluation.Types.EvaluationValue'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ConditionEvaluation.Types.EvaluationValue.html
-  - title: ContentType
+  - title: 'ContentType'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ContentType.html
-  - title: CreateFeedRequest
+  - title: 'CreateFeedRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.CreateFeedRequest.html
-  - title: DeleteFeedRequest
+  - title: 'DeleteFeedRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.DeleteFeedRequest.html
-  - title: ExportAssetsRequest
+  - title: 'ExportAssetsRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ExportAssetsRequest.html
-  - title: ExportAssetsResponse
+  - title: 'ExportAssetsResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ExportAssetsResponse.html
-  - title: Feed
+  - title: 'Feed'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.Feed.html
-  - title: FeedName
+  - title: 'FeedName'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.FeedName.html
-  - title: FeedName.ResourceNameType
+  - title: 'FeedName.ResourceNameType'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.FeedName.ResourceNameType.html
-  - title: FeedOutputConfig
+  - title: 'FeedOutputConfig'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.FeedOutputConfig.html
-  - title: FeedOutputConfig.DestinationOneofCase
+  - title: 'FeedOutputConfig.DestinationOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.FeedOutputConfig.DestinationOneofCase.html
-  - title: GcsDestination
+  - title: 'GcsDestination'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.GcsDestination.html
-  - title: GcsDestination.ObjectUriOneofCase
+  - title: 'GcsDestination.ObjectUriOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.GcsDestination.ObjectUriOneofCase.html
-  - title: GcsOutputResult
+  - title: 'GcsOutputResult'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.GcsOutputResult.html
-  - title: GetFeedRequest
+  - title: 'GetFeedRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.GetFeedRequest.html
-  - title: IamPolicyAnalysisOutputConfig
+  - title: 'IamPolicyAnalysisOutputConfig'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.html
-  - title: IamPolicyAnalysisOutputConfig.DestinationOneofCase
+  - title: 'IamPolicyAnalysisOutputConfig.DestinationOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.DestinationOneofCase.html
-  - title: IamPolicyAnalysisOutputConfig.Types
+  - title: 'IamPolicyAnalysisOutputConfig.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.html
-  - title: IamPolicyAnalysisOutputConfig.Types.BigQueryDestination
+  - title: 'IamPolicyAnalysisOutputConfig.Types.BigQueryDestination'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.html
-  - title: IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types
+  - title: 'IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.html
-  - title: IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey
+  - title: 'IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.BigQueryDestination.Types.PartitionKey.html
-  - title: IamPolicyAnalysisOutputConfig.Types.GcsDestination
+  - title: 'IamPolicyAnalysisOutputConfig.Types.GcsDestination'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisOutputConfig.Types.GcsDestination.html
-  - title: IamPolicyAnalysisQuery
+  - title: 'IamPolicyAnalysisQuery'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.html
-  - title: IamPolicyAnalysisQuery.Types
+  - title: 'IamPolicyAnalysisQuery.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.html
-  - title: IamPolicyAnalysisQuery.Types.AccessSelector
+  - title: 'IamPolicyAnalysisQuery.Types.AccessSelector'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.AccessSelector.html
-  - title: IamPolicyAnalysisQuery.Types.ConditionContext
+  - title: 'IamPolicyAnalysisQuery.Types.ConditionContext'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.html
-  - title: IamPolicyAnalysisQuery.Types.ConditionContext.TimeContextOneofCase
+  - title: 'IamPolicyAnalysisQuery.Types.ConditionContext.TimeContextOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ConditionContext.TimeContextOneofCase.html
-  - title: IamPolicyAnalysisQuery.Types.IdentitySelector
+  - title: 'IamPolicyAnalysisQuery.Types.IdentitySelector'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.IdentitySelector.html
-  - title: IamPolicyAnalysisQuery.Types.Options
+  - title: 'IamPolicyAnalysisQuery.Types.Options'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.Options.html
-  - title: IamPolicyAnalysisQuery.Types.ResourceSelector
+  - title: 'IamPolicyAnalysisQuery.Types.ResourceSelector'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisQuery.Types.ResourceSelector.html
-  - title: IamPolicyAnalysisResult
+  - title: 'IamPolicyAnalysisResult'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.html
-  - title: IamPolicyAnalysisResult.Types
+  - title: 'IamPolicyAnalysisResult.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.html
-  - title: IamPolicyAnalysisResult.Types.Access
+  - title: 'IamPolicyAnalysisResult.Types.Access'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.html
-  - title: IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase
+  - title: 'IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Access.OneofAccessOneofCase.html
-  - title: IamPolicyAnalysisResult.Types.AccessControlList
+  - title: 'IamPolicyAnalysisResult.Types.AccessControlList'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.AccessControlList.html
-  - title: IamPolicyAnalysisResult.Types.Edge
+  - title: 'IamPolicyAnalysisResult.Types.Edge'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Edge.html
-  - title: IamPolicyAnalysisResult.Types.Identity
+  - title: 'IamPolicyAnalysisResult.Types.Identity'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Identity.html
-  - title: IamPolicyAnalysisResult.Types.IdentityList
+  - title: 'IamPolicyAnalysisResult.Types.IdentityList'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.IdentityList.html
-  - title: IamPolicyAnalysisResult.Types.Resource
+  - title: 'IamPolicyAnalysisResult.Types.Resource'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisResult.Types.Resource.html
-  - title: IamPolicyAnalysisState
+  - title: 'IamPolicyAnalysisState'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicyAnalysisState.html
-  - title: IamPolicySearchResult
+  - title: 'IamPolicySearchResult'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicySearchResult.html
-  - title: IamPolicySearchResult.Types
+  - title: 'IamPolicySearchResult.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.html
-  - title: IamPolicySearchResult.Types.Explanation
+  - title: 'IamPolicySearchResult.Types.Explanation'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.html
-  - title: IamPolicySearchResult.Types.Explanation.Types
+  - title: 'IamPolicySearchResult.Types.Explanation.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.html
-  - title: IamPolicySearchResult.Types.Explanation.Types.Permissions
+  - title: 'IamPolicySearchResult.Types.Explanation.Types.Permissions'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.IamPolicySearchResult.Types.Explanation.Types.Permissions.html
-  - title: ListAssetsRequest
+  - title: 'ListAssetsRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ListAssetsRequest.html
-  - title: ListAssetsResponse
+  - title: 'ListAssetsResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ListAssetsResponse.html
-  - title: ListFeedsRequest
+  - title: 'ListFeedsRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ListFeedsRequest.html
-  - title: ListFeedsResponse
+  - title: 'ListFeedsResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ListFeedsResponse.html
-  - title: OutputConfig
+  - title: 'OutputConfig'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.OutputConfig.html
-  - title: OutputConfig.DestinationOneofCase
+  - title: 'OutputConfig.DestinationOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.OutputConfig.DestinationOneofCase.html
-  - title: OutputResult
+  - title: 'OutputResult'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.OutputResult.html
-  - title: OutputResult.ResultOneofCase
+  - title: 'OutputResult.ResultOneofCase'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.OutputResult.ResultOneofCase.html
-  - title: PartitionSpec
+  - title: 'PartitionSpec'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.PartitionSpec.html
-  - title: PartitionSpec.Types
+  - title: 'PartitionSpec.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.PartitionSpec.Types.html
-  - title: PartitionSpec.Types.PartitionKey
+  - title: 'PartitionSpec.Types.PartitionKey'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.PartitionSpec.Types.PartitionKey.html
-  - title: PubsubDestination
+  - title: 'PubsubDestination'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.PubsubDestination.html
-  - title: Resource
+  - title: 'Resource'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.Resource.html
-  - title: ResourceSearchResult
+  - title: 'ResourceSearchResult'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.ResourceSearchResult.html
-  - title: SearchAllIamPoliciesRequest
+  - title: 'SearchAllIamPoliciesRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.SearchAllIamPoliciesRequest.html
-  - title: SearchAllIamPoliciesResponse
+  - title: 'SearchAllIamPoliciesResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.SearchAllIamPoliciesResponse.html
-  - title: SearchAllResourcesRequest
+  - title: 'SearchAllResourcesRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.SearchAllResourcesRequest.html
-  - title: SearchAllResourcesResponse
+  - title: 'SearchAllResourcesResponse'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.SearchAllResourcesResponse.html
-  - title: TemporalAsset
+  - title: 'TemporalAsset'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.TemporalAsset.html
-  - title: TemporalAsset.Types
+  - title: 'TemporalAsset.Types'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.TemporalAsset.Types.html
-  - title: TemporalAsset.Types.PriorAssetState
+  - title: 'TemporalAsset.Types.PriorAssetState'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.TemporalAsset.Types.PriorAssetState.html
-  - title: TimeWindow
+  - title: 'TimeWindow'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.TimeWindow.html
-  - title: UpdateFeedRequest
+  - title: 'UpdateFeedRequest'
     path: /dotnet/docs/reference/Google.Cloud.Asset.V1/latest/Google.Cloud.Asset.V1.UpdateFeedRequest.html

--- a/testdata/goldens/go/toc.yaml
+++ b/testdata/goldens/go/toc.yaml
@@ -1,7 +1,7 @@
 
 toc:
-- title: cloud.google.com/go/storage
+- title: 'cloud.google.com/go/storage'
   section:
-  - title: cloud.google.com/go/storage
+  - title: 'cloud.google.com/go/storage'
     status: deprecated
     path: /go/docs/reference/cloud.google.com/go/latest/index.html

--- a/testdata/goldens/java/toc.yaml
+++ b/testdata/goldens/java/toc.yaml
@@ -1,615 +1,615 @@
 
 toc:
-- title: google-cloud-speech
+- title: 'google-cloud-speech'
   section:
-  - title: Overview
+  - title: 'Overview'
     path: /java/docs/reference/cloud.google.com/java/latest/overview.html
-  - title: Version history
+  - title: 'Version history'
     path: /java/docs/reference/cloud.google.com/java/latest/history.md
-  - title: com.google.cloud.speech.v1
+  - title: 'com.google.cloud.speech.v1'
     section:
-    - title: Package summary
+    - title: 'Package summary'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.html
-    - heading: Interfaces
-    - title: LongRunningRecognizeMetadataOrBuilder
+    - heading: 'Interfaces'
+    - title: 'LongRunningRecognizeMetadataOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeMetadataOrBuilder.html
-    - title: LongRunningRecognizeRequestOrBuilder
+    - title: 'LongRunningRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeRequestOrBuilder.html
-    - title: LongRunningRecognizeResponseOrBuilder
+    - title: 'LongRunningRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeResponseOrBuilder.html
-    - title: RecognitionAudioOrBuilder
+    - title: 'RecognitionAudioOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionAudioOrBuilder.html
-    - title: RecognitionConfigOrBuilder
+    - title: 'RecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionConfigOrBuilder.html
-    - title: RecognitionMetadataOrBuilder
+    - title: 'RecognitionMetadataOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadataOrBuilder.html
-    - title: RecognizeRequestOrBuilder
+    - title: 'RecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeRequestOrBuilder.html
-    - title: RecognizeResponseOrBuilder
+    - title: 'RecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeResponseOrBuilder.html
-    - title: SpeakerDiarizationConfigOrBuilder
+    - title: 'SpeakerDiarizationConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeakerDiarizationConfigOrBuilder.html
-    - title: SpeechContextOrBuilder
+    - title: 'SpeechContextOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechContextOrBuilder.html
-    - title: SpeechRecognitionAlternativeOrBuilder
+    - title: 'SpeechRecognitionAlternativeOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionAlternativeOrBuilder.html
-    - title: SpeechRecognitionResultOrBuilder
+    - title: 'SpeechRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionResultOrBuilder.html
-    - title: StreamingRecognitionConfigOrBuilder
+    - title: 'StreamingRecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionConfigOrBuilder.html
-    - title: StreamingRecognitionResultOrBuilder
+    - title: 'StreamingRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionResultOrBuilder.html
-    - title: StreamingRecognizeRequestOrBuilder
+    - title: 'StreamingRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeRequestOrBuilder.html
-    - title: StreamingRecognizeResponseOrBuilder
+    - title: 'StreamingRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeResponseOrBuilder.html
-    - title: WordInfoOrBuilder
+    - title: 'WordInfoOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.WordInfoOrBuilder.html
-    - heading: Classes
-    - title: LongRunningRecognizeMetadata
+    - heading: 'Classes'
+    - title: 'LongRunningRecognizeMetadata'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.html
-    - title: LongRunningRecognizeMetadata.Builder
+    - title: 'LongRunningRecognizeMetadata.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeMetadata.Builder.html
-    - title: LongRunningRecognizeRequest
+    - title: 'LongRunningRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeRequest.html
-    - title: LongRunningRecognizeRequest.Builder
+    - title: 'LongRunningRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeRequest.Builder.html
-    - title: LongRunningRecognizeResponse
+    - title: 'LongRunningRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeResponse.html
-    - title: LongRunningRecognizeResponse.Builder
+    - title: 'LongRunningRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.LongRunningRecognizeResponse.Builder.html
-    - title: RecognitionAudio
+    - title: 'RecognitionAudio'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionAudio.html
-    - title: RecognitionAudio.Builder
+    - title: 'RecognitionAudio.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionAudio.Builder.html
-    - title: RecognitionConfig
+    - title: 'RecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionConfig.html
-    - title: RecognitionConfig.Builder
+    - title: 'RecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionConfig.Builder.html
-    - title: RecognitionMetadata
+    - title: 'RecognitionMetadata'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.html
-    - title: RecognitionMetadata.Builder
+    - title: 'RecognitionMetadata.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.Builder.html
-    - title: RecognizeRequest
+    - title: 'RecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeRequest.html
-    - title: RecognizeRequest.Builder
+    - title: 'RecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeRequest.Builder.html
-    - title: RecognizeResponse
+    - title: 'RecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeResponse.html
-    - title: RecognizeResponse.Builder
+    - title: 'RecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognizeResponse.Builder.html
-    - title: SpeakerDiarizationConfig
+    - title: 'SpeakerDiarizationConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeakerDiarizationConfig.html
-    - title: SpeakerDiarizationConfig.Builder
+    - title: 'SpeakerDiarizationConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeakerDiarizationConfig.Builder.html
-    - title: SpeechClient
+    - title: 'SpeechClient'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechClient.html
-    - title: SpeechContext
+    - title: 'SpeechContext'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechContext.html
-    - title: SpeechContext.Builder
+    - title: 'SpeechContext.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechContext.Builder.html
-    - title: SpeechGrpc
+    - title: 'SpeechGrpc'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechGrpc.html
-    - title: SpeechGrpc.SpeechBlockingStub
+    - title: 'SpeechGrpc.SpeechBlockingStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechGrpc.SpeechBlockingStub.html
-    - title: SpeechGrpc.SpeechFutureStub
+    - title: 'SpeechGrpc.SpeechFutureStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechGrpc.SpeechFutureStub.html
-    - title: SpeechGrpc.SpeechImplBase
+    - title: 'SpeechGrpc.SpeechImplBase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechGrpc.SpeechImplBase.html
-    - title: SpeechGrpc.SpeechStub
+    - title: 'SpeechGrpc.SpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechGrpc.SpeechStub.html
-    - title: SpeechProto
+    - title: 'SpeechProto'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechProto.html
-    - title: SpeechRecognitionAlternative
+    - title: 'SpeechRecognitionAlternative'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionAlternative.html
-    - title: SpeechRecognitionAlternative.Builder
+    - title: 'SpeechRecognitionAlternative.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionAlternative.Builder.html
-    - title: SpeechRecognitionResult
+    - title: 'SpeechRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionResult.html
-    - title: SpeechRecognitionResult.Builder
+    - title: 'SpeechRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechRecognitionResult.Builder.html
-    - title: SpeechSettings
+    - title: 'SpeechSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechSettings.html
-    - title: SpeechSettings.Builder
+    - title: 'SpeechSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.SpeechSettings.Builder.html
-    - title: StreamingRecognitionConfig
+    - title: 'StreamingRecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionConfig.html
-    - title: StreamingRecognitionConfig.Builder
+    - title: 'StreamingRecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionConfig.Builder.html
-    - title: StreamingRecognitionResult
+    - title: 'StreamingRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionResult.html
-    - title: StreamingRecognitionResult.Builder
+    - title: 'StreamingRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognitionResult.Builder.html
-    - title: StreamingRecognizeRequest
+    - title: 'StreamingRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeRequest.html
-    - title: StreamingRecognizeRequest.Builder
+    - title: 'StreamingRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeRequest.Builder.html
-    - title: StreamingRecognizeResponse
+    - title: 'StreamingRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeResponse.html
-    - title: StreamingRecognizeResponse.Builder
+    - title: 'StreamingRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeResponse.Builder.html
-    - title: WordInfo
+    - title: 'WordInfo'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.WordInfo.html
-    - title: WordInfo.Builder
+    - title: 'WordInfo.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.WordInfo.Builder.html
-    - heading: Enums
-    - title: RecognitionAudio.AudioSourceCase
+    - heading: 'Enums'
+    - title: 'RecognitionAudio.AudioSourceCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionAudio.AudioSourceCase.html
-    - title: RecognitionConfig.AudioEncoding
+    - title: 'RecognitionConfig.AudioEncoding'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionConfig.AudioEncoding.html
-    - title: RecognitionMetadata.InteractionType
+    - title: 'RecognitionMetadata.InteractionType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.InteractionType.html
-    - title: RecognitionMetadata.MicrophoneDistance
+    - title: 'RecognitionMetadata.MicrophoneDistance'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.MicrophoneDistance.html
-    - title: RecognitionMetadata.OriginalMediaType
+    - title: 'RecognitionMetadata.OriginalMediaType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.OriginalMediaType.html
-    - title: RecognitionMetadata.RecordingDeviceType
+    - title: 'RecognitionMetadata.RecordingDeviceType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.RecognitionMetadata.RecordingDeviceType.html
-    - title: StreamingRecognizeRequest.StreamingRequestCase
+    - title: 'StreamingRecognizeRequest.StreamingRequestCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeRequest.StreamingRequestCase.html
-    - title: StreamingRecognizeResponse.SpeechEventType
+    - title: 'StreamingRecognizeResponse.SpeechEventType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.StreamingRecognizeResponse.SpeechEventType.html
-  - title: com.google.cloud.speech.v1.stub
+  - title: 'com.google.cloud.speech.v1.stub'
     section:
-    - title: Package summary
+    - title: 'Package summary'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.html
-    - heading: Classes
-    - title: GrpcSpeechCallableFactory
+    - heading: 'Classes'
+    - title: 'GrpcSpeechCallableFactory'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.GrpcSpeechCallableFactory.html
-    - title: GrpcSpeechStub
+    - title: 'GrpcSpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.GrpcSpeechStub.html
-    - title: SpeechStub
+    - title: 'SpeechStub'
       status: deprecated
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.SpeechStub.html
-    - title: SpeechStubSettings
+    - title: 'SpeechStubSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.SpeechStubSettings.html
-    - title: SpeechStubSettings.Builder
+    - title: 'SpeechStubSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1.stub.SpeechStubSettings.Builder.html
-  - title: com.google.cloud.speech.v1beta1
+  - title: 'com.google.cloud.speech.v1beta1'
     status: beta
     section:
-    - title: Package summary
+    - title: 'Package summary'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.html
-    - heading: Interfaces
-    - title: AsyncRecognizeMetadataOrBuilder
+    - heading: 'Interfaces'
+    - title: 'AsyncRecognizeMetadataOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadataOrBuilder.html
-    - title: AsyncRecognizeRequestOrBuilder
+    - title: 'AsyncRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeRequestOrBuilder.html
-    - title: AsyncRecognizeResponseOrBuilder
+    - title: 'AsyncRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeResponseOrBuilder.html
-    - title: RecognitionAudioOrBuilder
+    - title: 'RecognitionAudioOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionAudioOrBuilder.html
-    - title: RecognitionConfigOrBuilder
+    - title: 'RecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionConfigOrBuilder.html
-    - title: SpeechContextOrBuilder
+    - title: 'SpeechContextOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechContextOrBuilder.html
-    - title: SpeechRecognitionAlternativeOrBuilder
+    - title: 'SpeechRecognitionAlternativeOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternativeOrBuilder.html
-    - title: SpeechRecognitionResultOrBuilder
+    - title: 'SpeechRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionResultOrBuilder.html
-    - title: StreamingRecognitionConfigOrBuilder
+    - title: 'StreamingRecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionConfigOrBuilder.html
-    - title: StreamingRecognitionResultOrBuilder
+    - title: 'StreamingRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionResultOrBuilder.html
-    - title: StreamingRecognizeRequestOrBuilder
+    - title: 'StreamingRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeRequestOrBuilder.html
-    - title: StreamingRecognizeResponseOrBuilder
+    - title: 'StreamingRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeResponseOrBuilder.html
-    - title: SyncRecognizeRequestOrBuilder
+    - title: 'SyncRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeRequestOrBuilder.html
-    - title: SyncRecognizeResponseOrBuilder
+    - title: 'SyncRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeResponseOrBuilder.html
-    - heading: Classes
-    - title: AsyncRecognizeMetadata
+    - heading: 'Classes'
+    - title: 'AsyncRecognizeMetadata'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.html
-    - title: AsyncRecognizeMetadata.Builder
+    - title: 'AsyncRecognizeMetadata.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeMetadata.Builder.html
-    - title: AsyncRecognizeRequest
+    - title: 'AsyncRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.html
-    - title: AsyncRecognizeRequest.Builder
+    - title: 'AsyncRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeRequest.Builder.html
-    - title: AsyncRecognizeResponse
+    - title: 'AsyncRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.html
-    - title: AsyncRecognizeResponse.Builder
+    - title: 'AsyncRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.AsyncRecognizeResponse.Builder.html
-    - title: RecognitionAudio
+    - title: 'RecognitionAudio'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionAudio.html
-    - title: RecognitionAudio.Builder
+    - title: 'RecognitionAudio.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionAudio.Builder.html
-    - title: RecognitionConfig
+    - title: 'RecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionConfig.html
-    - title: RecognitionConfig.Builder
+    - title: 'RecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionConfig.Builder.html
-    - title: SpeechContext
+    - title: 'SpeechContext'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechContext.html
-    - title: SpeechContext.Builder
+    - title: 'SpeechContext.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechContext.Builder.html
-    - title: SpeechGrpc
+    - title: 'SpeechGrpc'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechGrpc.html
-    - title: SpeechGrpc.SpeechBlockingStub
+    - title: 'SpeechGrpc.SpeechBlockingStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechBlockingStub.html
-    - title: SpeechGrpc.SpeechFutureStub
+    - title: 'SpeechGrpc.SpeechFutureStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechFutureStub.html
-    - title: SpeechGrpc.SpeechImplBase
+    - title: 'SpeechGrpc.SpeechImplBase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechImplBase.html
-    - title: SpeechGrpc.SpeechStub
+    - title: 'SpeechGrpc.SpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechGrpc.SpeechStub.html
-    - title: SpeechProto
+    - title: 'SpeechProto'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechProto.html
-    - title: SpeechRecognitionAlternative
+    - title: 'SpeechRecognitionAlternative'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.html
-    - title: SpeechRecognitionAlternative.Builder
+    - title: 'SpeechRecognitionAlternative.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionAlternative.Builder.html
-    - title: SpeechRecognitionResult
+    - title: 'SpeechRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.html
-    - title: SpeechRecognitionResult.Builder
+    - title: 'SpeechRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SpeechRecognitionResult.Builder.html
-    - title: StreamingRecognitionConfig
+    - title: 'StreamingRecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.html
-    - title: StreamingRecognitionConfig.Builder
+    - title: 'StreamingRecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionConfig.Builder.html
-    - title: StreamingRecognitionResult
+    - title: 'StreamingRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.html
-    - title: StreamingRecognitionResult.Builder
+    - title: 'StreamingRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognitionResult.Builder.html
-    - title: StreamingRecognizeRequest
+    - title: 'StreamingRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.html
-    - title: StreamingRecognizeRequest.Builder
+    - title: 'StreamingRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.Builder.html
-    - title: StreamingRecognizeResponse
+    - title: 'StreamingRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.html
-    - title: StreamingRecognizeResponse.Builder
+    - title: 'StreamingRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.Builder.html
-    - title: SyncRecognizeRequest
+    - title: 'SyncRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.html
-    - title: SyncRecognizeRequest.Builder
+    - title: 'SyncRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeRequest.Builder.html
-    - title: SyncRecognizeResponse
+    - title: 'SyncRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.html
-    - title: SyncRecognizeResponse.Builder
+    - title: 'SyncRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.SyncRecognizeResponse.Builder.html
-    - heading: Enums
-    - title: RecognitionAudio.AudioSourceCase
+    - heading: 'Enums'
+    - title: 'RecognitionAudio.AudioSourceCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionAudio.AudioSourceCase.html
-    - title: RecognitionConfig.AudioEncoding
+    - title: 'RecognitionConfig.AudioEncoding'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.RecognitionConfig.AudioEncoding.html
-    - title: StreamingRecognizeRequest.StreamingRequestCase
+    - title: 'StreamingRecognizeRequest.StreamingRequestCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
-    - title: StreamingRecognizeResponse.EndpointerType
+    - title: 'StreamingRecognizeResponse.EndpointerType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1beta1.StreamingRecognizeResponse.EndpointerType.html
-  - title: com.google.cloud.speech.v1p1beta1
+  - title: 'com.google.cloud.speech.v1p1beta1'
     status: beta
     section:
-    - title: Package summary
+    - title: 'Package summary'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.html
-    - heading: Interfaces
-    - title: CreateCustomClassRequestOrBuilder
+    - heading: 'Interfaces'
+    - title: 'CreateCustomClassRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequestOrBuilder.html
-    - title: CreatePhraseSetRequestOrBuilder
+    - title: 'CreatePhraseSetRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequestOrBuilder.html
-    - title: CustomClass.ClassItemOrBuilder
+    - title: 'CustomClass.ClassItemOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItemOrBuilder.html
-    - title: CustomClassOrBuilder
+    - title: 'CustomClassOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClassOrBuilder.html
-    - title: DeleteCustomClassRequestOrBuilder
+    - title: 'DeleteCustomClassRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequestOrBuilder.html
-    - title: DeletePhraseSetRequestOrBuilder
+    - title: 'DeletePhraseSetRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequestOrBuilder.html
-    - title: GetCustomClassRequestOrBuilder
+    - title: 'GetCustomClassRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetCustomClassRequestOrBuilder.html
-    - title: GetPhraseSetRequestOrBuilder
+    - title: 'GetPhraseSetRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequestOrBuilder.html
-    - title: ListCustomClassesRequestOrBuilder
+    - title: 'ListCustomClassesRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequestOrBuilder.html
-    - title: ListCustomClassesResponseOrBuilder
+    - title: 'ListCustomClassesResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponseOrBuilder.html
-    - title: ListPhraseSetRequestOrBuilder
+    - title: 'ListPhraseSetRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequestOrBuilder.html
-    - title: ListPhraseSetResponseOrBuilder
+    - title: 'ListPhraseSetResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponseOrBuilder.html
-    - title: LongRunningRecognizeMetadataOrBuilder
+    - title: 'LongRunningRecognizeMetadataOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadataOrBuilder.html
-    - title: LongRunningRecognizeRequestOrBuilder
+    - title: 'LongRunningRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequestOrBuilder.html
-    - title: LongRunningRecognizeResponseOrBuilder
+    - title: 'LongRunningRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponseOrBuilder.html
-    - title: PhraseSet.PhraseOrBuilder
+    - title: 'PhraseSet.PhraseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSet.PhraseOrBuilder.html
-    - title: PhraseSetOrBuilder
+    - title: 'PhraseSetOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSetOrBuilder.html
-    - title: RecognitionAudioOrBuilder
+    - title: 'RecognitionAudioOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionAudioOrBuilder.html
-    - title: RecognitionConfigOrBuilder
+    - title: 'RecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionConfigOrBuilder.html
-    - title: RecognitionMetadataOrBuilder
+    - title: 'RecognitionMetadataOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadataOrBuilder.html
-    - title: RecognizeRequestOrBuilder
+    - title: 'RecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeRequestOrBuilder.html
-    - title: RecognizeResponseOrBuilder
+    - title: 'RecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeResponseOrBuilder.html
-    - title: SpeakerDiarizationConfigOrBuilder
+    - title: 'SpeakerDiarizationConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfigOrBuilder.html
-    - title: SpeechAdaptationOrBuilder
+    - title: 'SpeechAdaptationOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechAdaptationOrBuilder.html
-    - title: SpeechContextOrBuilder
+    - title: 'SpeechContextOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechContextOrBuilder.html
-    - title: SpeechRecognitionAlternativeOrBuilder
+    - title: 'SpeechRecognitionAlternativeOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternativeOrBuilder.html
-    - title: SpeechRecognitionResultOrBuilder
+    - title: 'SpeechRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResultOrBuilder.html
-    - title: StreamingRecognitionConfigOrBuilder
+    - title: 'StreamingRecognitionConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfigOrBuilder.html
-    - title: StreamingRecognitionResultOrBuilder
+    - title: 'StreamingRecognitionResultOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResultOrBuilder.html
-    - title: StreamingRecognizeRequestOrBuilder
+    - title: 'StreamingRecognizeRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequestOrBuilder.html
-    - title: StreamingRecognizeResponseOrBuilder
+    - title: 'StreamingRecognizeResponseOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponseOrBuilder.html
-    - title: TranscriptNormalization.EntryOrBuilder
+    - title: 'TranscriptNormalization.EntryOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalization.EntryOrBuilder.html
-    - title: TranscriptNormalizationOrBuilder
+    - title: 'TranscriptNormalizationOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalizationOrBuilder.html
-    - title: TranscriptOutputConfigOrBuilder
+    - title: 'TranscriptOutputConfigOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfigOrBuilder.html
-    - title: UpdateCustomClassRequestOrBuilder
+    - title: 'UpdateCustomClassRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequestOrBuilder.html
-    - title: UpdatePhraseSetRequestOrBuilder
+    - title: 'UpdatePhraseSetRequestOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequestOrBuilder.html
-    - title: WordInfoOrBuilder
+    - title: 'WordInfoOrBuilder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.WordInfoOrBuilder.html
-    - heading: Classes
-    - title: AdaptationClient
+    - heading: 'Classes'
+    - title: 'AdaptationClient'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.html
-    - title: AdaptationClient.ListCustomClassesFixedSizeCollection
+    - title: 'AdaptationClient.ListCustomClassesFixedSizeCollection'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesFixedSizeCollection.html
-    - title: AdaptationClient.ListCustomClassesPage
+    - title: 'AdaptationClient.ListCustomClassesPage'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPage.html
-    - title: AdaptationClient.ListCustomClassesPagedResponse
+    - title: 'AdaptationClient.ListCustomClassesPagedResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListCustomClassesPagedResponse.html
-    - title: AdaptationClient.ListPhraseSetFixedSizeCollection
+    - title: 'AdaptationClient.ListPhraseSetFixedSizeCollection'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetFixedSizeCollection.html
-    - title: AdaptationClient.ListPhraseSetPage
+    - title: 'AdaptationClient.ListPhraseSetPage'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPage.html
-    - title: AdaptationClient.ListPhraseSetPagedResponse
+    - title: 'AdaptationClient.ListPhraseSetPagedResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationClient.ListPhraseSetPagedResponse.html
-    - title: AdaptationGrpc
+    - title: 'AdaptationGrpc'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.html
-    - title: AdaptationGrpc.AdaptationBlockingStub
+    - title: 'AdaptationGrpc.AdaptationBlockingStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationBlockingStub.html
-    - title: AdaptationGrpc.AdaptationFutureStub
+    - title: 'AdaptationGrpc.AdaptationFutureStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationFutureStub.html
-    - title: AdaptationGrpc.AdaptationImplBase
+    - title: 'AdaptationGrpc.AdaptationImplBase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationImplBase.html
-    - title: AdaptationGrpc.AdaptationStub
+    - title: 'AdaptationGrpc.AdaptationStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationGrpc.AdaptationStub.html
-    - title: AdaptationSettings
+    - title: 'AdaptationSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationSettings.html
-    - title: AdaptationSettings.Builder
+    - title: 'AdaptationSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.AdaptationSettings.Builder.html
-    - title: CreateCustomClassRequest
+    - title: 'CreateCustomClassRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.html
-    - title: CreateCustomClassRequest.Builder
+    - title: 'CreateCustomClassRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreateCustomClassRequest.Builder.html
-    - title: CreatePhraseSetRequest
+    - title: 'CreatePhraseSetRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.html
-    - title: CreatePhraseSetRequest.Builder
+    - title: 'CreatePhraseSetRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CreatePhraseSetRequest.Builder.html
-    - title: CustomClass
+    - title: 'CustomClass'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClass.html
-    - title: CustomClass.Builder
+    - title: 'CustomClass.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClass.Builder.html
-    - title: CustomClass.ClassItem
+    - title: 'CustomClass.ClassItem'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.html
-    - title: CustomClass.ClassItem.Builder
+    - title: 'CustomClass.ClassItem.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClass.ClassItem.Builder.html
-    - title: CustomClassName
+    - title: 'CustomClassName'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClassName.html
-    - title: CustomClassName.Builder
+    - title: 'CustomClassName.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.CustomClassName.Builder.html
-    - title: DeleteCustomClassRequest
+    - title: 'DeleteCustomClassRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.html
-    - title: DeleteCustomClassRequest.Builder
+    - title: 'DeleteCustomClassRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeleteCustomClassRequest.Builder.html
-    - title: DeletePhraseSetRequest
+    - title: 'DeletePhraseSetRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.html
-    - title: DeletePhraseSetRequest.Builder
+    - title: 'DeletePhraseSetRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.DeletePhraseSetRequest.Builder.html
-    - title: GetCustomClassRequest
+    - title: 'GetCustomClassRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.html
-    - title: GetCustomClassRequest.Builder
+    - title: 'GetCustomClassRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetCustomClassRequest.Builder.html
-    - title: GetPhraseSetRequest
+    - title: 'GetPhraseSetRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.html
-    - title: GetPhraseSetRequest.Builder
+    - title: 'GetPhraseSetRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.GetPhraseSetRequest.Builder.html
-    - title: ListCustomClassesRequest
+    - title: 'ListCustomClassesRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.html
-    - title: ListCustomClassesRequest.Builder
+    - title: 'ListCustomClassesRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesRequest.Builder.html
-    - title: ListCustomClassesResponse
+    - title: 'ListCustomClassesResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.html
-    - title: ListCustomClassesResponse.Builder
+    - title: 'ListCustomClassesResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListCustomClassesResponse.Builder.html
-    - title: ListPhraseSetRequest
+    - title: 'ListPhraseSetRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.html
-    - title: ListPhraseSetRequest.Builder
+    - title: 'ListPhraseSetRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetRequest.Builder.html
-    - title: ListPhraseSetResponse
+    - title: 'ListPhraseSetResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.html
-    - title: ListPhraseSetResponse.Builder
+    - title: 'ListPhraseSetResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.ListPhraseSetResponse.Builder.html
-    - title: LocationName
+    - title: 'LocationName'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LocationName.html
-    - title: LocationName.Builder
+    - title: 'LocationName.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LocationName.Builder.html
-    - title: LongRunningRecognizeMetadata
+    - title: 'LongRunningRecognizeMetadata'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.html
-    - title: LongRunningRecognizeMetadata.Builder
+    - title: 'LongRunningRecognizeMetadata.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeMetadata.Builder.html
-    - title: LongRunningRecognizeRequest
+    - title: 'LongRunningRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.html
-    - title: LongRunningRecognizeRequest.Builder
+    - title: 'LongRunningRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeRequest.Builder.html
-    - title: LongRunningRecognizeResponse
+    - title: 'LongRunningRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.html
-    - title: LongRunningRecognizeResponse.Builder
+    - title: 'LongRunningRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.LongRunningRecognizeResponse.Builder.html
-    - title: PhraseSet
+    - title: 'PhraseSet'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSet.html
-    - title: PhraseSet.Builder
+    - title: 'PhraseSet.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSet.Builder.html
-    - title: PhraseSet.Phrase
+    - title: 'PhraseSet.Phrase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.html
-    - title: PhraseSet.Phrase.Builder
+    - title: 'PhraseSet.Phrase.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSet.Phrase.Builder.html
-    - title: PhraseSetName
+    - title: 'PhraseSetName'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSetName.html
-    - title: PhraseSetName.Builder
+    - title: 'PhraseSetName.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.PhraseSetName.Builder.html
-    - title: RecognitionAudio
+    - title: 'RecognitionAudio'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionAudio.html
-    - title: RecognitionAudio.Builder
+    - title: 'RecognitionAudio.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionAudio.Builder.html
-    - title: RecognitionConfig
+    - title: 'RecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionConfig.html
-    - title: RecognitionConfig.Builder
+    - title: 'RecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionConfig.Builder.html
-    - title: RecognitionMetadata
+    - title: 'RecognitionMetadata'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.html
-    - title: RecognitionMetadata.Builder
+    - title: 'RecognitionMetadata.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.Builder.html
-    - title: RecognizeRequest
+    - title: 'RecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeRequest.html
-    - title: RecognizeRequest.Builder
+    - title: 'RecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeRequest.Builder.html
-    - title: RecognizeResponse
+    - title: 'RecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeResponse.html
-    - title: RecognizeResponse.Builder
+    - title: 'RecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognizeResponse.Builder.html
-    - title: SpeakerDiarizationConfig
+    - title: 'SpeakerDiarizationConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.html
-    - title: SpeakerDiarizationConfig.Builder
+    - title: 'SpeakerDiarizationConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeakerDiarizationConfig.Builder.html
-    - title: SpeechAdaptation
+    - title: 'SpeechAdaptation'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.html
-    - title: SpeechAdaptation.Builder
+    - title: 'SpeechAdaptation.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechAdaptation.Builder.html
-    - title: SpeechAdaptationProto
+    - title: 'SpeechAdaptationProto'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechAdaptationProto.html
-    - title: SpeechClient
+    - title: 'SpeechClient'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechClient.html
-    - title: SpeechContext
+    - title: 'SpeechContext'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechContext.html
-    - title: SpeechContext.Builder
+    - title: 'SpeechContext.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechContext.Builder.html
-    - title: SpeechGrpc
+    - title: 'SpeechGrpc'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechGrpc.html
-    - title: SpeechGrpc.SpeechBlockingStub
+    - title: 'SpeechGrpc.SpeechBlockingStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechBlockingStub.html
-    - title: SpeechGrpc.SpeechFutureStub
+    - title: 'SpeechGrpc.SpeechFutureStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechFutureStub.html
-    - title: SpeechGrpc.SpeechImplBase
+    - title: 'SpeechGrpc.SpeechImplBase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechImplBase.html
-    - title: SpeechGrpc.SpeechStub
+    - title: 'SpeechGrpc.SpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechGrpc.SpeechStub.html
-    - title: SpeechProto
+    - title: 'SpeechProto'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechProto.html
-    - title: SpeechRecognitionAlternative
+    - title: 'SpeechRecognitionAlternative'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.html
-    - title: SpeechRecognitionAlternative.Builder
+    - title: 'SpeechRecognitionAlternative.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionAlternative.Builder.html
-    - title: SpeechRecognitionResult
+    - title: 'SpeechRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.html
-    - title: SpeechRecognitionResult.Builder
+    - title: 'SpeechRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechRecognitionResult.Builder.html
-    - title: SpeechResourceProto
+    - title: 'SpeechResourceProto'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechResourceProto.html
-    - title: SpeechSettings
+    - title: 'SpeechSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechSettings.html
-    - title: SpeechSettings.Builder
+    - title: 'SpeechSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.SpeechSettings.Builder.html
-    - title: StreamingRecognitionConfig
+    - title: 'StreamingRecognitionConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.html
-    - title: StreamingRecognitionConfig.Builder
+    - title: 'StreamingRecognitionConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionConfig.Builder.html
-    - title: StreamingRecognitionResult
+    - title: 'StreamingRecognitionResult'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.html
-    - title: StreamingRecognitionResult.Builder
+    - title: 'StreamingRecognitionResult.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognitionResult.Builder.html
-    - title: StreamingRecognizeRequest
+    - title: 'StreamingRecognizeRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.html
-    - title: StreamingRecognizeRequest.Builder
+    - title: 'StreamingRecognizeRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.Builder.html
-    - title: StreamingRecognizeResponse
+    - title: 'StreamingRecognizeResponse'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.html
-    - title: StreamingRecognizeResponse.Builder
+    - title: 'StreamingRecognizeResponse.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.Builder.html
-    - title: TranscriptNormalization
+    - title: 'TranscriptNormalization'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalization.html
-    - title: TranscriptNormalization.Builder
+    - title: 'TranscriptNormalization.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalization.Builder.html
-    - title: TranscriptNormalization.Entry
+    - title: 'TranscriptNormalization.Entry'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalization.Entry.html
-    - title: TranscriptNormalization.Entry.Builder
+    - title: 'TranscriptNormalization.Entry.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptNormalization.Entry.Builder.html
-    - title: TranscriptOutputConfig
+    - title: 'TranscriptOutputConfig'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.html
-    - title: TranscriptOutputConfig.Builder
+    - title: 'TranscriptOutputConfig.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.Builder.html
-    - title: UpdateCustomClassRequest
+    - title: 'UpdateCustomClassRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.html
-    - title: UpdateCustomClassRequest.Builder
+    - title: 'UpdateCustomClassRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdateCustomClassRequest.Builder.html
-    - title: UpdatePhraseSetRequest
+    - title: 'UpdatePhraseSetRequest'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.html
-    - title: UpdatePhraseSetRequest.Builder
+    - title: 'UpdatePhraseSetRequest.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.UpdatePhraseSetRequest.Builder.html
-    - title: WordInfo
+    - title: 'WordInfo'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.WordInfo.html
-    - title: WordInfo.Builder
+    - title: 'WordInfo.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.WordInfo.Builder.html
-    - heading: Enums
-    - title: RecognitionAudio.AudioSourceCase
+    - heading: 'Enums'
+    - title: 'RecognitionAudio.AudioSourceCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionAudio.AudioSourceCase.html
-    - title: RecognitionConfig.AudioEncoding
+    - title: 'RecognitionConfig.AudioEncoding'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionConfig.AudioEncoding.html
-    - title: RecognitionMetadata.InteractionType
+    - title: 'RecognitionMetadata.InteractionType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.InteractionType.html
-    - title: RecognitionMetadata.MicrophoneDistance
+    - title: 'RecognitionMetadata.MicrophoneDistance'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.MicrophoneDistance.html
-    - title: RecognitionMetadata.OriginalMediaType
+    - title: 'RecognitionMetadata.OriginalMediaType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.OriginalMediaType.html
-    - title: RecognitionMetadata.RecordingDeviceType
+    - title: 'RecognitionMetadata.RecordingDeviceType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.RecognitionMetadata.RecordingDeviceType.html
-    - title: StreamingRecognizeRequest.StreamingRequestCase
+    - title: 'StreamingRecognizeRequest.StreamingRequestCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeRequest.StreamingRequestCase.html
-    - title: StreamingRecognizeResponse.SpeechEventType
+    - title: 'StreamingRecognizeResponse.SpeechEventType'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.StreamingRecognizeResponse.SpeechEventType.html
-    - title: TranscriptOutputConfig.OutputTypeCase
+    - title: 'TranscriptOutputConfig.OutputTypeCase'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.TranscriptOutputConfig.OutputTypeCase.html
-  - title: com.google.cloud.speech.v1p1beta1.stub
+  - title: 'com.google.cloud.speech.v1p1beta1.stub'
     status: beta
     section:
-    - title: Package summary
+    - title: 'Package summary'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.html
-    - heading: Classes
-    - title: AdaptationStub
+    - heading: 'Classes'
+    - title: 'AdaptationStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.AdaptationStub.html
-    - title: AdaptationStubSettings
+    - title: 'AdaptationStubSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.html
-    - title: AdaptationStubSettings.Builder
+    - title: 'AdaptationStubSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.AdaptationStubSettings.Builder.html
-    - title: GrpcAdaptationCallableFactory
+    - title: 'GrpcAdaptationCallableFactory'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationCallableFactory.html
-    - title: GrpcAdaptationStub
+    - title: 'GrpcAdaptationStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.GrpcAdaptationStub.html
-    - title: GrpcSpeechCallableFactory
+    - title: 'GrpcSpeechCallableFactory'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechCallableFactory.html
-    - title: GrpcSpeechStub
+    - title: 'GrpcSpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.GrpcSpeechStub.html
-    - title: SpeechStub
+    - title: 'SpeechStub'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.SpeechStub.html
-    - title: SpeechStubSettings
+    - title: 'SpeechStubSettings'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.html
-    - title: SpeechStubSettings.Builder
+    - title: 'SpeechStubSettings.Builder'
       path: /java/docs/reference/cloud.google.com/java/latest/com.google.cloud.speech.v1p1beta1.stub.SpeechStubSettings.Builder.html

--- a/testdata/goldens/nodejs/toc.yaml
+++ b/testdata/goldens/nodejs/toc.yaml
@@ -1,176 +1,176 @@
 
 toc:
-- title: scheduler
+- title: 'scheduler'
   section:
-  - title: CustomHttpPattern
+  - title: 'CustomHttpPattern'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FieldBehavior
+  - title: 'FieldBehavior'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Http
+  - title: 'Http'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: HttpRule
+  - title: 'HttpRule'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ResourceDescriptor (Class)
+  - title: 'ResourceDescriptor (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: History
+  - title: 'History'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ResourceReference
+  - title: 'ResourceReference'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: AppEngineHttpTarget
+  - title: 'AppEngineHttpTarget'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.appenginehttptarget.html
-  - title: AppEngineRouting
+  - title: 'AppEngineRouting'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.appenginerouting.html
-  - title: CloudScheduler (Class)
+  - title: 'CloudScheduler (Class)'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.cloudscheduler-class.html
-  - title: CreateJobRequest
+  - title: 'CreateJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.createjobrequest.html
-  - title: DeleteJobRequest
+  - title: 'DeleteJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.deletejobrequest.html
-  - title: GetJobRequest
+  - title: 'GetJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.getjobrequest.html
-  - title: HttpMethod
+  - title: 'HttpMethod'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.httpmethod.html
-  - title: HttpTarget
+  - title: 'HttpTarget'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.httptarget.html
-  - title: Job (Class)
+  - title: 'Job (Class)'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.job-class.html
-  - title: State
+  - title: 'State'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.job.state.html
-  - title: ListJobsRequest
+  - title: 'ListJobsRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.listjobsrequest.html
-  - title: ListJobsResponse
+  - title: 'ListJobsResponse'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.listjobsresponse.html
-  - title: OAuthToken
+  - title: 'OAuthToken'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.oauthtoken.html
-  - title: OidcToken
+  - title: 'OidcToken'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.oidctoken.html
-  - title: PauseJobRequest
+  - title: 'PauseJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.pausejobrequest.html
-  - title: PubsubTarget
+  - title: 'PubsubTarget'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.pubsubtarget.html
-  - title: ResumeJobRequest
+  - title: 'ResumeJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.resumejobrequest.html
-  - title: RetryConfig
+  - title: 'RetryConfig'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.retryconfig.html
-  - title: RunJobRequest
+  - title: 'RunJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.runjobrequest.html
-  - title: UpdateJobRequest
+  - title: 'UpdateJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/google.cloud.scheduler.v1.updatejobrequest.html
-  - title: AppEngineHttpTarget
+  - title: 'AppEngineHttpTarget'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: AppEngineRouting
+  - title: 'AppEngineRouting'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: CloudScheduler (Class)
+  - title: 'CloudScheduler (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: CreateJobRequest
+  - title: 'CreateJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: DeleteJobRequest
+  - title: 'DeleteJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: GetJobRequest
+  - title: 'GetJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: HttpMethod
+  - title: 'HttpMethod'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: HttpTarget
+  - title: 'HttpTarget'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Job (Class)
+  - title: 'Job (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: State
+  - title: 'State'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ListJobsRequest
+  - title: 'ListJobsRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ListJobsResponse
+  - title: 'ListJobsResponse'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: OAuthToken
+  - title: 'OAuthToken'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: OidcToken
+  - title: 'OidcToken'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: PauseJobRequest
+  - title: 'PauseJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: PubsubTarget
+  - title: 'PubsubTarget'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ResumeJobRequest
+  - title: 'ResumeJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: RetryConfig
+  - title: 'RetryConfig'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: RunJobRequest
+  - title: 'RunJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: UpdateJobRequest
+  - title: 'UpdateJobRequest'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Any
+  - title: 'Any'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: DescriptorProto (Class)
+  - title: 'DescriptorProto (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ExtensionRange
+  - title: 'ExtensionRange'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ReservedRange
+  - title: 'ReservedRange'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Duration
+  - title: 'Duration'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Empty
+  - title: 'Empty'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: EnumDescriptorProto (Class)
+  - title: 'EnumDescriptorProto (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: EnumReservedRange
+  - title: 'EnumReservedRange'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: EnumOptions
+  - title: 'EnumOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: EnumValueDescriptorProto
+  - title: 'EnumValueDescriptorProto'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: EnumValueOptions
+  - title: 'EnumValueOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ExtensionRangeOptions
+  - title: 'ExtensionRangeOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FieldDescriptorProto (Class)
+  - title: 'FieldDescriptorProto (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Label
+  - title: 'Label'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Type
+  - title: 'Type'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FieldMask
+  - title: 'FieldMask'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FieldOptions (Class)
+  - title: 'FieldOptions (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: CType
+  - title: 'CType'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: JSType
+  - title: 'JSType'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FileDescriptorProto
+  - title: 'FileDescriptorProto'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FileDescriptorSet
+  - title: 'FileDescriptorSet'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: FileOptions (Class)
+  - title: 'FileOptions (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: OptimizeMode
+  - title: 'OptimizeMode'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: GeneratedCodeInfo (Class)
+  - title: 'GeneratedCodeInfo (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Annotation
+  - title: 'Annotation'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: MessageOptions
+  - title: 'MessageOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: MethodDescriptorProto
+  - title: 'MethodDescriptorProto'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: MethodOptions (Class)
+  - title: 'MethodOptions (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: IdempotencyLevel
+  - title: 'IdempotencyLevel'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: OneofDescriptorProto
+  - title: 'OneofDescriptorProto'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: OneofOptions
+  - title: 'OneofOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ServiceDescriptorProto
+  - title: 'ServiceDescriptorProto'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: ServiceOptions
+  - title: 'ServiceOptions'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: SourceCodeInfo (Class)
+  - title: 'SourceCodeInfo (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Location
+  - title: 'Location'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Timestamp
+  - title: 'Timestamp'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: UninterpretedOption (Class)
+  - title: 'UninterpretedOption (Class)'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: NamePart
+  - title: 'NamePart'
     path: /nodejs/docs/reference/scheduler/latest/
-  - title: Status
+  - title: 'Status'
     path: /nodejs/docs/reference/scheduler/latest/

--- a/testdata/goldens/python-small/toc.yaml
+++ b/testdata/goldens/python-small/toc.yaml
@@ -1,202 +1,202 @@
 
 toc:
-- title: google-cloud-bigquery-storage
+- title: 'google-cloud-bigquery-storage'
   section:
-  - title: Overview
+  - title: 'Overview'
     path: /python/docs/reference/bigquerystorage/latest/index.html
-  - title: bigquery_storage_v1.client
+  - title: 'bigquery_storage_v1.client'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.client.html
-    - title: BigQueryReadClient
+    - title: 'BigQueryReadClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.client.BigQueryReadClient.html
-  - title: reader
+  - title: 'reader'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.reader.html
-    - title: ReadRowsIterable
+    - title: 'ReadRowsIterable'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.reader.ReadRowsIterable.html
-    - title: ReadRowsPage
+    - title: 'ReadRowsPage'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.reader.ReadRowsPage.html
-    - title: ReadRowsStream
+    - title: 'ReadRowsStream'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.reader.ReadRowsStream.html
-  - title: bigquery_storage_v1.big_query_read
+  - title: 'bigquery_storage_v1.big_query_read'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.services.big_query_read.html
-    - title: BigQueryReadAsyncClient
+    - title: 'BigQueryReadAsyncClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadAsyncClient.html
-    - title: BigQueryReadClient
+    - title: 'BigQueryReadClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.services.big_query_read.BigQueryReadClient.html
-  - title: bigquery_storage_v1.types
+  - title: 'bigquery_storage_v1.types'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.html
-    - title: ArrowRecordBatch
+    - title: 'ArrowRecordBatch'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ArrowRecordBatch.html
-    - title: ArrowSchema
+    - title: 'ArrowSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ArrowSchema.html
-    - title: ArrowSerializationOptions
+    - title: 'ArrowSerializationOptions'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.html
-      - title: CompressionCodec
+      - title: 'CompressionCodec'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ArrowSerializationOptions.CompressionCodec.html
-    - title: AvroRows
+    - title: 'AvroRows'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.AvroRows.html
-    - title: AvroSchema
+    - title: 'AvroSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.AvroSchema.html
-    - title: CreateReadSessionRequest
+    - title: 'CreateReadSessionRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.CreateReadSessionRequest.html
-    - title: DataFormat
+    - title: 'DataFormat'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.DataFormat.html
-    - title: ReadRowsRequest
+    - title: 'ReadRowsRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadRowsRequest.html
-    - title: ReadRowsResponse
+    - title: 'ReadRowsResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadRowsResponse.html
-    - title: ReadSession
+    - title: 'ReadSession'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadSession.html
-      - title: TableModifiers
+      - title: 'TableModifiers'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadSession.TableModifiers.html
-      - title: TableReadOptions
+      - title: 'TableReadOptions'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadSession.TableReadOptions.html
-    - title: ReadStream
+    - title: 'ReadStream'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ReadStream.html
-    - title: SplitReadStreamRequest
+    - title: 'SplitReadStreamRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.SplitReadStreamRequest.html
-    - title: SplitReadStreamResponse
+    - title: 'SplitReadStreamResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.SplitReadStreamResponse.html
-    - title: StreamStats
+    - title: 'StreamStats'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.StreamStats.html
-      - title: Progress
+      - title: 'Progress'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.StreamStats.Progress.html
-    - title: ThrottleState
+    - title: 'ThrottleState'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1.types.ThrottleState.html
-  - title: bigquery_storage_v1beta2.client
+  - title: 'bigquery_storage_v1beta2.client'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.client.html
-    - title: BigQueryReadClient
+    - title: 'BigQueryReadClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.client.BigQueryReadClient.html
-  - title: bigquery_storage_v1beta2.big_query_read
+  - title: 'bigquery_storage_v1beta2.big_query_read'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_read.html
-    - title: BigQueryReadAsyncClient
+    - title: 'BigQueryReadAsyncClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadAsyncClient.html
-    - title: BigQueryReadClient
+    - title: 'BigQueryReadClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_read.BigQueryReadClient.html
-  - title: big_query_write
+  - title: 'big_query_write'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_write.html
-    - title: BigQueryWriteAsyncClient
+    - title: 'BigQueryWriteAsyncClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteAsyncClient.html
-    - title: BigQueryWriteClient
+    - title: 'BigQueryWriteClient'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.services.big_query_write.BigQueryWriteClient.html
-  - title: bigquery_storage_v1beta2.types
+  - title: 'bigquery_storage_v1beta2.types'
     section:
-    - title: Overview
+    - title: 'Overview'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.html
-    - title: AppendRowsRequest
+    - title: 'AppendRowsRequest'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.html
-      - title: ProtoData
+      - title: 'ProtoData'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AppendRowsRequest.ProtoData.html
-    - title: AppendRowsResponse
+    - title: 'AppendRowsResponse'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.html
-      - title: AppendResult
+      - title: 'AppendResult'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AppendRowsResponse.AppendResult.html
-    - title: ArrowRecordBatch
+    - title: 'ArrowRecordBatch'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ArrowRecordBatch.html
-    - title: ArrowSchema
+    - title: 'ArrowSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ArrowSchema.html
-    - title: ArrowSerializationOptions
+    - title: 'ArrowSerializationOptions'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.html
-      - title: Format
+      - title: 'Format'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ArrowSerializationOptions.Format.html
-    - title: AvroRows
+    - title: 'AvroRows'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AvroRows.html
-    - title: AvroSchema
+    - title: 'AvroSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.AvroSchema.html
-    - title: BatchCommitWriteStreamsRequest
+    - title: 'BatchCommitWriteStreamsRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsRequest.html
-    - title: BatchCommitWriteStreamsResponse
+    - title: 'BatchCommitWriteStreamsResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.BatchCommitWriteStreamsResponse.html
-    - title: CreateReadSessionRequest
+    - title: 'CreateReadSessionRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.CreateReadSessionRequest.html
-    - title: CreateWriteStreamRequest
+    - title: 'CreateWriteStreamRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.CreateWriteStreamRequest.html
-    - title: DataFormat
+    - title: 'DataFormat'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.DataFormat.html
-    - title: FinalizeWriteStreamRequest
+    - title: 'FinalizeWriteStreamRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamRequest.html
-    - title: FinalizeWriteStreamResponse
+    - title: 'FinalizeWriteStreamResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.FinalizeWriteStreamResponse.html
-    - title: FlushRowsRequest
+    - title: 'FlushRowsRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.FlushRowsRequest.html
-    - title: FlushRowsResponse
+    - title: 'FlushRowsResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.FlushRowsResponse.html
-    - title: GetWriteStreamRequest
+    - title: 'GetWriteStreamRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.GetWriteStreamRequest.html
-    - title: ProtoRows
+    - title: 'ProtoRows'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ProtoRows.html
-    - title: ProtoSchema
+    - title: 'ProtoSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ProtoSchema.html
-    - title: ReadRowsRequest
+    - title: 'ReadRowsRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadRowsRequest.html
-    - title: ReadRowsResponse
+    - title: 'ReadRowsResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadRowsResponse.html
-    - title: ReadSession
+    - title: 'ReadSession'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadSession.html
-      - title: TableModifiers
+      - title: 'TableModifiers'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableModifiers.html
-      - title: TableReadOptions
+      - title: 'TableReadOptions'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadSession.TableReadOptions.html
-    - title: ReadStream
+    - title: 'ReadStream'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ReadStream.html
-    - title: SplitReadStreamRequest
+    - title: 'SplitReadStreamRequest'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamRequest.html
-    - title: SplitReadStreamResponse
+    - title: 'SplitReadStreamResponse'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.SplitReadStreamResponse.html
-    - title: StorageError
+    - title: 'StorageError'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.StorageError.html
-      - title: StorageErrorCode
+      - title: 'StorageErrorCode'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.StorageError.StorageErrorCode.html
-    - title: StreamStats
+    - title: 'StreamStats'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.StreamStats.html
-      - title: Progress
+      - title: 'Progress'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.StreamStats.Progress.html
-    - title: TableFieldSchema
+    - title: 'TableFieldSchema'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.html
-      - title: Mode
+      - title: 'Mode'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Mode.html
-      - title: Type
+      - title: 'Type'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.TableFieldSchema.Type.html
-    - title: TableSchema
+    - title: 'TableSchema'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.TableSchema.html
-    - title: ThrottleState
+    - title: 'ThrottleState'
       path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.ThrottleState.html
-    - title: WriteStream
+    - title: 'WriteStream'
       section:
-      - title: Overview
+      - title: 'Overview'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.WriteStream.html
-      - title: Type
+      - title: 'Type'
         path: /python/docs/reference/bigquerystorage/latest/google.cloud.bigquery_storage_v1beta2.types.WriteStream.Type.html

--- a/testdata/goldens/ruby/toc.yaml
+++ b/testdata/goldens/ruby/toc.yaml
@@ -1,330 +1,330 @@
 
 toc:
-- title: google-cloud-vision-v1
+- title: 'google-cloud-vision-v1'
   section:
-  - title: Overview
+  - title: 'Overview'
     section:
-    - title: Getting started
+    - title: 'Getting started'
       path: /ruby/docs/reference/google-cloud-vision-v1/latest/index.html
-    - title: License
+    - title: 'License'
       path: /ruby/docs/reference/google-cloud-vision-v1/latest/LICENSE.html
-    - title: Authenticating the library
+    - title: 'Authenticating the library'
       path: /ruby/docs/reference/google-cloud-vision-v1/latest/AUTHENTICATION.html
-  - title: Google
+  - title: 'Google'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google.html
-  - title: Google::Api
+  - title: 'Google::Api'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api.html
-  - title: Google::Api::FieldBehavior
+  - title: 'Google::Api::FieldBehavior'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api-FieldBehavior.html
-  - title: Google::Api::ResourceDescriptor
+  - title: 'Google::Api::ResourceDescriptor'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api-ResourceDescriptor.html
-  - title: Google::Api::ResourceDescriptor::History
+  - title: 'Google::Api::ResourceDescriptor::History'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api-ResourceDescriptor-History.html
-  - title: Google::Api::ResourceDescriptor::Style
+  - title: 'Google::Api::ResourceDescriptor::Style'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api-ResourceDescriptor-Style.html
-  - title: Google::Api::ResourceReference
+  - title: 'Google::Api::ResourceReference'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Api-ResourceReference.html
-  - title: Google::Cloud
+  - title: 'Google::Cloud'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud.html
-  - title: Google::Cloud::Vision
+  - title: 'Google::Cloud::Vision'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision.html
-  - title: Google::Cloud::Vision::V1
+  - title: 'Google::Cloud::Vision::V1'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1.html
-  - title: Google::Cloud::Vision::V1::AddProductToProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::AddProductToProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AddProductToProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::AnnotateFileRequest
+  - title: 'Google::Cloud::Vision::V1::AnnotateFileRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AnnotateFileRequest.html
-  - title: Google::Cloud::Vision::V1::AnnotateFileResponse
+  - title: 'Google::Cloud::Vision::V1::AnnotateFileResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AnnotateFileResponse.html
-  - title: Google::Cloud::Vision::V1::AnnotateImageRequest
+  - title: 'Google::Cloud::Vision::V1::AnnotateImageRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AnnotateImageRequest.html
-  - title: Google::Cloud::Vision::V1::AnnotateImageResponse
+  - title: 'Google::Cloud::Vision::V1::AnnotateImageResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AnnotateImageResponse.html
-  - title: Google::Cloud::Vision::V1::AsyncAnnotateFileRequest
+  - title: 'Google::Cloud::Vision::V1::AsyncAnnotateFileRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncAnnotateFileRequest.html
-  - title: Google::Cloud::Vision::V1::AsyncAnnotateFileResponse
+  - title: 'Google::Cloud::Vision::V1::AsyncAnnotateFileResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncAnnotateFileResponse.html
-  - title: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest
+  - title: 'Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncBatchAnnotateFilesRequest.html
-  - title: Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesResponse
+  - title: 'Google::Cloud::Vision::V1::AsyncBatchAnnotateFilesResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncBatchAnnotateFilesResponse.html
-  - title: Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest
+  - title: 'Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncBatchAnnotateImagesRequest.html
-  - title: Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesResponse
+  - title: 'Google::Cloud::Vision::V1::AsyncBatchAnnotateImagesResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-AsyncBatchAnnotateImagesResponse.html
-  - title: Google::Cloud::Vision::V1::BatchAnnotateFilesRequest
+  - title: 'Google::Cloud::Vision::V1::BatchAnnotateFilesRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchAnnotateFilesRequest.html
-  - title: Google::Cloud::Vision::V1::BatchAnnotateFilesResponse
+  - title: 'Google::Cloud::Vision::V1::BatchAnnotateFilesResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchAnnotateFilesResponse.html
-  - title: Google::Cloud::Vision::V1::BatchAnnotateImagesRequest
+  - title: 'Google::Cloud::Vision::V1::BatchAnnotateImagesRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchAnnotateImagesRequest.html
-  - title: Google::Cloud::Vision::V1::BatchAnnotateImagesResponse
+  - title: 'Google::Cloud::Vision::V1::BatchAnnotateImagesResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchAnnotateImagesResponse.html
-  - title: Google::Cloud::Vision::V1::BatchOperationMetadata
+  - title: 'Google::Cloud::Vision::V1::BatchOperationMetadata'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchOperationMetadata.html
-  - title: Google::Cloud::Vision::V1::BatchOperationMetadata::State
+  - title: 'Google::Cloud::Vision::V1::BatchOperationMetadata::State'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BatchOperationMetadata-State.html
-  - title: Google::Cloud::Vision::V1::Block
+  - title: 'Google::Cloud::Vision::V1::Block'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Block.html
-  - title: Google::Cloud::Vision::V1::Block::BlockType
+  - title: 'Google::Cloud::Vision::V1::Block::BlockType'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Block-BlockType.html
-  - title: Google::Cloud::Vision::V1::BoundingPoly
+  - title: 'Google::Cloud::Vision::V1::BoundingPoly'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-BoundingPoly.html
-  - title: Google::Cloud::Vision::V1::ColorInfo
+  - title: 'Google::Cloud::Vision::V1::ColorInfo'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ColorInfo.html
-  - title: Google::Cloud::Vision::V1::CreateProductRequest
+  - title: 'Google::Cloud::Vision::V1::CreateProductRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CreateProductRequest.html
-  - title: Google::Cloud::Vision::V1::CreateProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::CreateProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CreateProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::CreateReferenceImageRequest
+  - title: 'Google::Cloud::Vision::V1::CreateReferenceImageRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CreateReferenceImageRequest.html
-  - title: Google::Cloud::Vision::V1::CropHint
+  - title: 'Google::Cloud::Vision::V1::CropHint'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CropHint.html
-  - title: Google::Cloud::Vision::V1::CropHintsAnnotation
+  - title: 'Google::Cloud::Vision::V1::CropHintsAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CropHintsAnnotation.html
-  - title: Google::Cloud::Vision::V1::CropHintsParams
+  - title: 'Google::Cloud::Vision::V1::CropHintsParams'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-CropHintsParams.html
-  - title: Google::Cloud::Vision::V1::DeleteProductRequest
+  - title: 'Google::Cloud::Vision::V1::DeleteProductRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-DeleteProductRequest.html
-  - title: Google::Cloud::Vision::V1::DeleteProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::DeleteProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-DeleteProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::DeleteReferenceImageRequest
+  - title: 'Google::Cloud::Vision::V1::DeleteReferenceImageRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-DeleteReferenceImageRequest.html
-  - title: Google::Cloud::Vision::V1::DominantColorsAnnotation
+  - title: 'Google::Cloud::Vision::V1::DominantColorsAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-DominantColorsAnnotation.html
-  - title: Google::Cloud::Vision::V1::EntityAnnotation
+  - title: 'Google::Cloud::Vision::V1::EntityAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-EntityAnnotation.html
-  - title: Google::Cloud::Vision::V1::FaceAnnotation
+  - title: 'Google::Cloud::Vision::V1::FaceAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-FaceAnnotation.html
-  - title: Google::Cloud::Vision::V1::FaceAnnotation::Landmark
+  - title: 'Google::Cloud::Vision::V1::FaceAnnotation::Landmark'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-FaceAnnotation-Landmark.html
-  - title: Google::Cloud::Vision::V1::FaceAnnotation::Landmark::Type
+  - title: 'Google::Cloud::Vision::V1::FaceAnnotation::Landmark::Type'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-FaceAnnotation-Landmark-Type.html
-  - title: Google::Cloud::Vision::V1::Feature
+  - title: 'Google::Cloud::Vision::V1::Feature'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Feature.html
-  - title: Google::Cloud::Vision::V1::Feature::Type
+  - title: 'Google::Cloud::Vision::V1::Feature::Type'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Feature-Type.html
-  - title: Google::Cloud::Vision::V1::GcsDestination
+  - title: 'Google::Cloud::Vision::V1::GcsDestination'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-GcsDestination.html
-  - title: Google::Cloud::Vision::V1::GcsSource
+  - title: 'Google::Cloud::Vision::V1::GcsSource'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-GcsSource.html
-  - title: Google::Cloud::Vision::V1::GetProductRequest
+  - title: 'Google::Cloud::Vision::V1::GetProductRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-GetProductRequest.html
-  - title: Google::Cloud::Vision::V1::GetProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::GetProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-GetProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::GetReferenceImageRequest
+  - title: 'Google::Cloud::Vision::V1::GetReferenceImageRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-GetReferenceImageRequest.html
-  - title: Google::Cloud::Vision::V1::Image
+  - title: 'Google::Cloud::Vision::V1::Image'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Image.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotationContext
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotationContext'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotationContext.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Client
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Client'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Client.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Client::Configuration
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Client::Configuration'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Client-Configuration.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Client::Configuration::Rpcs
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Client::Configuration::Rpcs'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Client-Configuration-Rpcs.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Credentials
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Credentials'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Credentials.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Operations
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Operations'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Operations.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Operations::Configuration
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Operations::Configuration'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Operations-Configuration.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Operations::Configuration::Rpcs
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Operations::Configuration::Rpcs'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Operations-Configuration-Rpcs.html
-  - title: Google::Cloud::Vision::V1::ImageAnnotator::Paths
+  - title: 'Google::Cloud::Vision::V1::ImageAnnotator::Paths'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageAnnotator-Paths.html
-  - title: Google::Cloud::Vision::V1::ImageContext
+  - title: 'Google::Cloud::Vision::V1::ImageContext'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageContext.html
-  - title: Google::Cloud::Vision::V1::ImageProperties
+  - title: 'Google::Cloud::Vision::V1::ImageProperties'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageProperties.html
-  - title: Google::Cloud::Vision::V1::ImageSource
+  - title: 'Google::Cloud::Vision::V1::ImageSource'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImageSource.html
-  - title: Google::Cloud::Vision::V1::ImportProductSetsGcsSource
+  - title: 'Google::Cloud::Vision::V1::ImportProductSetsGcsSource'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImportProductSetsGcsSource.html
-  - title: Google::Cloud::Vision::V1::ImportProductSetsInputConfig
+  - title: 'Google::Cloud::Vision::V1::ImportProductSetsInputConfig'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImportProductSetsInputConfig.html
-  - title: Google::Cloud::Vision::V1::ImportProductSetsRequest
+  - title: 'Google::Cloud::Vision::V1::ImportProductSetsRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImportProductSetsRequest.html
-  - title: Google::Cloud::Vision::V1::ImportProductSetsResponse
+  - title: 'Google::Cloud::Vision::V1::ImportProductSetsResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ImportProductSetsResponse.html
-  - title: Google::Cloud::Vision::V1::InputConfig
+  - title: 'Google::Cloud::Vision::V1::InputConfig'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-InputConfig.html
-  - title: Google::Cloud::Vision::V1::LatLongRect
+  - title: 'Google::Cloud::Vision::V1::LatLongRect'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-LatLongRect.html
-  - title: Google::Cloud::Vision::V1::Likelihood
+  - title: 'Google::Cloud::Vision::V1::Likelihood'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Likelihood.html
-  - title: Google::Cloud::Vision::V1::ListProductSetsRequest
+  - title: 'Google::Cloud::Vision::V1::ListProductSetsRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductSetsRequest.html
-  - title: Google::Cloud::Vision::V1::ListProductSetsResponse
+  - title: 'Google::Cloud::Vision::V1::ListProductSetsResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductSetsResponse.html
-  - title: Google::Cloud::Vision::V1::ListProductsInProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::ListProductsInProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductsInProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::ListProductsInProductSetResponse
+  - title: 'Google::Cloud::Vision::V1::ListProductsInProductSetResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductsInProductSetResponse.html
-  - title: Google::Cloud::Vision::V1::ListProductsRequest
+  - title: 'Google::Cloud::Vision::V1::ListProductsRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductsRequest.html
-  - title: Google::Cloud::Vision::V1::ListProductsResponse
+  - title: 'Google::Cloud::Vision::V1::ListProductsResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListProductsResponse.html
-  - title: Google::Cloud::Vision::V1::ListReferenceImagesRequest
+  - title: 'Google::Cloud::Vision::V1::ListReferenceImagesRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListReferenceImagesRequest.html
-  - title: Google::Cloud::Vision::V1::ListReferenceImagesResponse
+  - title: 'Google::Cloud::Vision::V1::ListReferenceImagesResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ListReferenceImagesResponse.html
-  - title: Google::Cloud::Vision::V1::LocalizedObjectAnnotation
+  - title: 'Google::Cloud::Vision::V1::LocalizedObjectAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-LocalizedObjectAnnotation.html
-  - title: Google::Cloud::Vision::V1::LocationInfo
+  - title: 'Google::Cloud::Vision::V1::LocationInfo'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-LocationInfo.html
-  - title: Google::Cloud::Vision::V1::NormalizedVertex
+  - title: 'Google::Cloud::Vision::V1::NormalizedVertex'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-NormalizedVertex.html
-  - title: Google::Cloud::Vision::V1::OperationMetadata
+  - title: 'Google::Cloud::Vision::V1::OperationMetadata'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-OperationMetadata.html
-  - title: Google::Cloud::Vision::V1::OperationMetadata::State
+  - title: 'Google::Cloud::Vision::V1::OperationMetadata::State'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-OperationMetadata-State.html
-  - title: Google::Cloud::Vision::V1::OutputConfig
+  - title: 'Google::Cloud::Vision::V1::OutputConfig'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-OutputConfig.html
-  - title: Google::Cloud::Vision::V1::Page
+  - title: 'Google::Cloud::Vision::V1::Page'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Page.html
-  - title: Google::Cloud::Vision::V1::Paragraph
+  - title: 'Google::Cloud::Vision::V1::Paragraph'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Paragraph.html
-  - title: Google::Cloud::Vision::V1::Position
+  - title: 'Google::Cloud::Vision::V1::Position'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Position.html
-  - title: Google::Cloud::Vision::V1::Product
+  - title: 'Google::Cloud::Vision::V1::Product'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Product.html
-  - title: Google::Cloud::Vision::V1::Product::KeyValue
+  - title: 'Google::Cloud::Vision::V1::Product::KeyValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Product-KeyValue.html
-  - title: Google::Cloud::Vision::V1::ProductSearch
+  - title: 'Google::Cloud::Vision::V1::ProductSearch'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Client
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Client'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Client.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Client::Configuration
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Client::Configuration'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Client-Configuration.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Client::Configuration::Rpcs
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Client::Configuration::Rpcs'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Client-Configuration-Rpcs.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Credentials
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Credentials'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Credentials.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Operations
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Operations'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Operations.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Operations::Configuration
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Operations::Configuration'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Operations-Configuration.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Operations::Configuration::Rpcs
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Operations::Configuration::Rpcs'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Operations-Configuration-Rpcs.html
-  - title: Google::Cloud::Vision::V1::ProductSearch::Paths
+  - title: 'Google::Cloud::Vision::V1::ProductSearch::Paths'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearch-Paths.html
-  - title: Google::Cloud::Vision::V1::ProductSearchParams
+  - title: 'Google::Cloud::Vision::V1::ProductSearchParams'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearchParams.html
-  - title: Google::Cloud::Vision::V1::ProductSearchResults
+  - title: 'Google::Cloud::Vision::V1::ProductSearchResults'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearchResults.html
-  - title: Google::Cloud::Vision::V1::ProductSearchResults::GroupedResult
+  - title: 'Google::Cloud::Vision::V1::ProductSearchResults::GroupedResult'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearchResults-GroupedResult.html
-  - title: Google::Cloud::Vision::V1::ProductSearchResults::ObjectAnnotation
+  - title: 'Google::Cloud::Vision::V1::ProductSearchResults::ObjectAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearchResults-ObjectAnnotation.html
-  - title: Google::Cloud::Vision::V1::ProductSearchResults::Result
+  - title: 'Google::Cloud::Vision::V1::ProductSearchResults::Result'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSearchResults-Result.html
-  - title: Google::Cloud::Vision::V1::ProductSet
+  - title: 'Google::Cloud::Vision::V1::ProductSet'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSet.html
-  - title: Google::Cloud::Vision::V1::ProductSetPurgeConfig
+  - title: 'Google::Cloud::Vision::V1::ProductSetPurgeConfig'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ProductSetPurgeConfig.html
-  - title: Google::Cloud::Vision::V1::Property
+  - title: 'Google::Cloud::Vision::V1::Property'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Property.html
-  - title: Google::Cloud::Vision::V1::PurgeProductsRequest
+  - title: 'Google::Cloud::Vision::V1::PurgeProductsRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-PurgeProductsRequest.html
-  - title: Google::Cloud::Vision::V1::ReferenceImage
+  - title: 'Google::Cloud::Vision::V1::ReferenceImage'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-ReferenceImage.html
-  - title: Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::RemoveProductFromProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-RemoveProductFromProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::SafeSearchAnnotation
+  - title: 'Google::Cloud::Vision::V1::SafeSearchAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-SafeSearchAnnotation.html
-  - title: Google::Cloud::Vision::V1::Symbol
+  - title: 'Google::Cloud::Vision::V1::Symbol'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Symbol.html
-  - title: Google::Cloud::Vision::V1::TextAnnotation
+  - title: 'Google::Cloud::Vision::V1::TextAnnotation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextAnnotation.html
-  - title: Google::Cloud::Vision::V1::TextAnnotation::DetectedBreak
+  - title: 'Google::Cloud::Vision::V1::TextAnnotation::DetectedBreak'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextAnnotation-DetectedBreak.html
-  - title: Google::Cloud::Vision::V1::TextAnnotation::DetectedBreak::BreakType
+  - title: 'Google::Cloud::Vision::V1::TextAnnotation::DetectedBreak::BreakType'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextAnnotation-DetectedBreak-BreakType.html
-  - title: Google::Cloud::Vision::V1::TextAnnotation::DetectedLanguage
+  - title: 'Google::Cloud::Vision::V1::TextAnnotation::DetectedLanguage'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextAnnotation-DetectedLanguage.html
-  - title: Google::Cloud::Vision::V1::TextAnnotation::TextProperty
+  - title: 'Google::Cloud::Vision::V1::TextAnnotation::TextProperty'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextAnnotation-TextProperty.html
-  - title: Google::Cloud::Vision::V1::TextDetectionParams
+  - title: 'Google::Cloud::Vision::V1::TextDetectionParams'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-TextDetectionParams.html
-  - title: Google::Cloud::Vision::V1::UpdateProductRequest
+  - title: 'Google::Cloud::Vision::V1::UpdateProductRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-UpdateProductRequest.html
-  - title: Google::Cloud::Vision::V1::UpdateProductSetRequest
+  - title: 'Google::Cloud::Vision::V1::UpdateProductSetRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-UpdateProductSetRequest.html
-  - title: Google::Cloud::Vision::V1::Vertex
+  - title: 'Google::Cloud::Vision::V1::Vertex'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Vertex.html
-  - title: Google::Cloud::Vision::V1::WebDetection
+  - title: 'Google::Cloud::Vision::V1::WebDetection'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetection.html
-  - title: Google::Cloud::Vision::V1::WebDetection::WebEntity
+  - title: 'Google::Cloud::Vision::V1::WebDetection::WebEntity'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetection-WebEntity.html
-  - title: Google::Cloud::Vision::V1::WebDetection::WebImage
+  - title: 'Google::Cloud::Vision::V1::WebDetection::WebImage'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetection-WebImage.html
-  - title: Google::Cloud::Vision::V1::WebDetection::WebLabel
+  - title: 'Google::Cloud::Vision::V1::WebDetection::WebLabel'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetection-WebLabel.html
-  - title: Google::Cloud::Vision::V1::WebDetection::WebPage
+  - title: 'Google::Cloud::Vision::V1::WebDetection::WebPage'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetection-WebPage.html
-  - title: Google::Cloud::Vision::V1::WebDetectionParams
+  - title: 'Google::Cloud::Vision::V1::WebDetectionParams'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-WebDetectionParams.html
-  - title: Google::Cloud::Vision::V1::Word
+  - title: 'Google::Cloud::Vision::V1::Word'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Cloud-Vision-V1-Word.html
-  - title: Google::Longrunning
+  - title: 'Google::Longrunning'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning.html
-  - title: Google::Longrunning::CancelOperationRequest
+  - title: 'Google::Longrunning::CancelOperationRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-CancelOperationRequest.html
-  - title: Google::Longrunning::DeleteOperationRequest
+  - title: 'Google::Longrunning::DeleteOperationRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-DeleteOperationRequest.html
-  - title: Google::Longrunning::GetOperationRequest
+  - title: 'Google::Longrunning::GetOperationRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-GetOperationRequest.html
-  - title: Google::Longrunning::ListOperationsRequest
+  - title: 'Google::Longrunning::ListOperationsRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-ListOperationsRequest.html
-  - title: Google::Longrunning::ListOperationsResponse
+  - title: 'Google::Longrunning::ListOperationsResponse'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-ListOperationsResponse.html
-  - title: Google::Longrunning::Operation
+  - title: 'Google::Longrunning::Operation'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-Operation.html
-  - title: Google::Longrunning::OperationInfo
+  - title: 'Google::Longrunning::OperationInfo'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-OperationInfo.html
-  - title: Google::Longrunning::WaitOperationRequest
+  - title: 'Google::Longrunning::WaitOperationRequest'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Longrunning-WaitOperationRequest.html
-  - title: Google::Protobuf
+  - title: 'Google::Protobuf'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf.html
-  - title: Google::Protobuf::Any
+  - title: 'Google::Protobuf::Any'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Any.html
-  - title: Google::Protobuf::BoolValue
+  - title: 'Google::Protobuf::BoolValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-BoolValue.html
-  - title: Google::Protobuf::BytesValue
+  - title: 'Google::Protobuf::BytesValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-BytesValue.html
-  - title: Google::Protobuf::DoubleValue
+  - title: 'Google::Protobuf::DoubleValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-DoubleValue.html
-  - title: Google::Protobuf::Duration
+  - title: 'Google::Protobuf::Duration'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Duration.html
-  - title: Google::Protobuf::Empty
+  - title: 'Google::Protobuf::Empty'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Empty.html
-  - title: Google::Protobuf::FieldMask
+  - title: 'Google::Protobuf::FieldMask'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-FieldMask.html
-  - title: Google::Protobuf::FloatValue
+  - title: 'Google::Protobuf::FloatValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-FloatValue.html
-  - title: Google::Protobuf::Int32Value
+  - title: 'Google::Protobuf::Int32Value'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Int32Value.html
-  - title: Google::Protobuf::Int64Value
+  - title: 'Google::Protobuf::Int64Value'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Int64Value.html
-  - title: Google::Protobuf::StringValue
+  - title: 'Google::Protobuf::StringValue'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-StringValue.html
-  - title: Google::Protobuf::Timestamp
+  - title: 'Google::Protobuf::Timestamp'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-Timestamp.html
-  - title: Google::Protobuf::UInt32Value
+  - title: 'Google::Protobuf::UInt32Value'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-UInt32Value.html
-  - title: Google::Protobuf::UInt64Value
+  - title: 'Google::Protobuf::UInt64Value'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Protobuf-UInt64Value.html
-  - title: Google::Rpc
+  - title: 'Google::Rpc'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Rpc.html
-  - title: Google::Rpc::Status
+  - title: 'Google::Rpc::Status'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Rpc-Status.html
-  - title: Google::Type
+  - title: 'Google::Type'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Type.html
-  - title: Google::Type::Color
+  - title: 'Google::Type::Color'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Type-Color.html
-  - title: Google::Type::LatLng
+  - title: 'Google::Type::LatLng'
     path: /ruby/docs/reference/google-cloud-vision-v1/latest/Google-Type-LatLng.html

--- a/third_party/docfx/templates/devsite/partials/li.tmpl.partial
+++ b/third_party/docfx/templates/devsite/partials/li.tmpl.partial
@@ -1,10 +1,10 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 {{#items}}
 {{#heading}}
-- heading: {{{heading}}}
+- heading: '{{{heading}}}'
 {{/heading}}
 {{^heading}}
-- title: {{{name}}}
+- title: '{{{name}}}'
   {{#status}}
   status: {{status}}
   {{/status}}


### PR DESCRIPTION
Otherwise, we can run into YAML parsing errors, like when a title
includes '[' or ']'.

See b/217584857.