### PR TITLE
chore(deps): update dependency click and black together

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
 appdirs~=1.4.4
 attrs~=21.4.0
-black~=21.10b0
+black~=22.3.0
 cachetools~=5.0.0
 certifi~=2021.10.8
 cffi~=1.15.0
 chardet~=4.0.0
-click~=8.0.0
+click~=8.1.0
 colorlog~=6.6.0
 flake8~=4.0.1
 gcp-docuploader~=0.6.0


### PR DESCRIPTION
For the newest `click` update, there had to be a `black` version update to 22.3.0 that followed together. Updating both versions, see https://github.com/psf/black/issues/2964 for context.

- [x] Tests pass
